### PR TITLE
full explicit remove memset

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -48,25 +48,25 @@ SDL::Event::~Event()
 
 #ifdef Explicit_MD
     mdsInTemp->freeMemory();
-//    cudaFree(mdsInTemp);
+    cudaFreeHost(mdsInTemp);
 #else
     mdsInGPU->freeMemory();
 #endif
 #ifdef Explicit_Seg
     segmentsInTemp->freeMemory(); 
-//    cudaFree(segmentsInTemp);
+    cudaFreeHost(segmentsInTemp);
 #else
     segmentsInGPU->freeMemory(); 
 #endif
 #ifdef Explicit_Tracklet 
     trackletsInTemp->freeMemory(); 
-//    cudaFree(trackletsInTemp);
+    cudaFreeHost(trackletsInTemp);
 #else
     trackletsInGPU->freeMemory();
 #endif
 #ifdef Explicit_Trips
     tripletsInTemp->freeMemory(); 
-//    cudaFree(tripletsInTemp);
+    cudaFreeHost(tripletsInTemp);
 #else
     tripletsInGPU->freeMemory();
 #endif

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -48,25 +48,25 @@ SDL::Event::~Event()
 
 #ifdef Explicit_MD
     mdsInTemp->freeMemory();
-    cudaFree(mdsInTemp);
+//    cudaFree(mdsInTemp);
 #else
     mdsInGPU->freeMemory();
 #endif
 #ifdef Explicit_Seg
     segmentsInTemp->freeMemory(); 
-    cudaFree(segmentsInTemp);
+//    cudaFree(segmentsInTemp);
 #else
     segmentsInGPU->freeMemory(); 
 #endif
 #ifdef Explicit_Tracklet 
     trackletsInTemp->freeMemory(); 
-    cudaFree(trackletsInTemp);
+//    cudaFree(trackletsInTemp);
 #else
     trackletsInGPU->freeMemory();
 #endif
 #ifdef Explicit_Trips
     tripletsInTemp->freeMemory(); 
-    cudaFree(tripletsInTemp);
+//    cudaFree(tripletsInTemp);
 #else
     tripletsInGPU->freeMemory();
 #endif

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -19,7 +19,7 @@ LD            = nvcc
 #LDFLAGS       = -g -O2
 SOFLAGS       = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_52
 #MEMFLAG       = -DExplicit_MD -DExplicit_Tracklet -DExplicit_Trips 
-MEMFLAG       = -DExplicit_MD -DExplicit_Seg -DExplicit_Tracklet -DExplicit_Trips 
+#MEMFLAG       = -DExplicit_MD -DExplicit_Seg -DExplicit_Tracklet -DExplicit_Trips 
 #MEMFLAG       += -DFull_Explicit
 PRINTFLAG     = -DAddObjects
 # how to make it 

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -18,6 +18,7 @@ CXXFLAGS      =  -g --compiler-options -Wall --compiler-options -Wshadow --compi
 LD            = nvcc 
 #LDFLAGS       = -g -O2
 SOFLAGS       = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_52
+#MEMFLAG       = -DExplicit_MD -DExplicit_Tracklet -DExplicit_Trips 
 MEMFLAG       = -DExplicit_MD -DExplicit_Seg -DExplicit_Tracklet -DExplicit_Trips 
 #MEMFLAG       += -DFull_Explicit
 PRINTFLAG     = -DAddObjects

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -55,7 +55,7 @@ void SDL::createMDsInExplicitMemory(struct miniDoublets& mdsInGPU, struct miniDo
     cudaMalloc(&mdsInTemp.dphichanges, maxMDsPerModule * nModules * sizeof(float));
 #ifdef Full_Explicit
     cudaMalloc(&mdsInTemp.nMDs, nModules * sizeof(unsigned int)); //for full explicit
-//    cudaMemset(&mdsInTemp.nMDs,0,nModules *sizeof(unsigned int));
+    cudaMemset(mdsInTemp.nMDs,0,nModules *sizeof(unsigned int));
 #else
     cudaMallocManaged(&mdsInTemp.nMDs, nModules * sizeof(unsigned int)); // allows for transfer back
 #endif

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -55,7 +55,7 @@ void SDL::createMDsInExplicitMemory(struct miniDoublets& mdsInGPU, struct miniDo
     cudaMalloc(&mdsInTemp.dphichanges, maxMDsPerModule * nModules * sizeof(float));
 #ifdef Full_Explicit
     cudaMalloc(&mdsInTemp.nMDs, nModules * sizeof(unsigned int)); //for full explicit
-    cudaMemset(&mdsInTemp.nMDs,0,nModules *sizeof(unsigned int));
+//    cudaMemset(&mdsInTemp.nMDs,0,nModules *sizeof(unsigned int));
 #else
     cudaMallocManaged(&mdsInTemp.nMDs, nModules * sizeof(unsigned int)); // allows for transfer back
 #endif

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -39,7 +39,7 @@ void SDL::createSegmentsInExplicitMemory(struct segments& segmentsInGPU, struct 
     cudaMalloc(&segmentsInTemp.outerMiniDoubletAnchorHitIndices, maxSegments * nModules * sizeof(unsigned int));
 #ifdef Full_Explicit
     cudaMalloc(&segmentsInTemp.nSegments, nModules * sizeof(unsigned int));
-//    cudaMemset(&(segmentsInTemp.nSegments),0,nModules * sizeof(unsigned int));
+    cudaMemset(segmentsInTemp.nSegments,0,nModules * sizeof(unsigned int));
 #else
     cudaMallocManaged(&segmentsInTemp.nSegments, nModules * sizeof(unsigned int));
 #endif

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -39,7 +39,7 @@ void SDL::createSegmentsInExplicitMemory(struct segments& segmentsInGPU, struct 
     cudaMalloc(&segmentsInTemp.outerMiniDoubletAnchorHitIndices, maxSegments * nModules * sizeof(unsigned int));
 #ifdef Full_Explicit
     cudaMalloc(&segmentsInTemp.nSegments, nModules * sizeof(unsigned int));
-    cudaMemset(&(segmentsInTemp.nSegments),0,nModules * sizeof(unsigned int));
+//    cudaMemset(&(segmentsInTemp.nSegments),0,nModules * sizeof(unsigned int));
 #else
     cudaMallocManaged(&segmentsInTemp.nSegments, nModules * sizeof(unsigned int));
 #endif

--- a/SDL/Tracklet.cu
+++ b/SDL/Tracklet.cu
@@ -36,7 +36,7 @@ void SDL::createTrackletsInExplicitMemory(struct tracklets& trackletsInGPU, stru
 
 #ifdef Full_Explicit
     cudaMalloc(&trackletsInTemp.nTracklets,nLowerModules * sizeof(unsigned int));
-    cudaMemset(&(trackletsInTemp.nTracklets),0,nLowerModules*sizeof(unsigned int));
+//    cudaMemset(&(trackletsInTemp.nTracklets),0,nLowerModules*sizeof(unsigned int));
 #else
     cudaMallocManaged(&trackletsInTemp.nTracklets,nLowerModules * sizeof(unsigned int));
 #endif

--- a/SDL/Tracklet.cu
+++ b/SDL/Tracklet.cu
@@ -36,7 +36,7 @@ void SDL::createTrackletsInExplicitMemory(struct tracklets& trackletsInGPU, stru
 
 #ifdef Full_Explicit
     cudaMalloc(&trackletsInTemp.nTracklets,nLowerModules * sizeof(unsigned int));
-//    cudaMemset(&(trackletsInTemp.nTracklets),0,nLowerModules*sizeof(unsigned int));
+    cudaMemset(trackletsInTemp.nTracklets,0,nLowerModules*sizeof(unsigned int));
 #else
     cudaMallocManaged(&trackletsInTemp.nTracklets,nLowerModules * sizeof(unsigned int));
 #endif

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -29,7 +29,7 @@ void SDL::createTripletsInExplicitMemory(struct triplets& tripletsInGPU,struct t
     cudaMalloc(&tripletsInTemp.lowerModuleIndices, 3 * maxTriplets * nLowerModules * sizeof(unsigned int));
 #ifdef Full_Explicit
     cudaMalloc(&tripletsInTemp.nTriplets, nLowerModules * sizeof(unsigned int));
-    cudaMemset(&(tripletsInTemp.nTriplets),0,nLowerModules * sizeof(unsigned int));
+//    cudaMemset(&(tripletsInTemp.nTriplets),0,nLowerModules * sizeof(unsigned int));
 #else
     cudaMallocManaged(&tripletsInTemp.nTriplets, nLowerModules * sizeof(unsigned int));
 #endif

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -29,7 +29,7 @@ void SDL::createTripletsInExplicitMemory(struct triplets& tripletsInGPU,struct t
     cudaMalloc(&tripletsInTemp.lowerModuleIndices, 3 * maxTriplets * nLowerModules * sizeof(unsigned int));
 #ifdef Full_Explicit
     cudaMalloc(&tripletsInTemp.nTriplets, nLowerModules * sizeof(unsigned int));
-//    cudaMemset(&(tripletsInTemp.nTriplets),0,nLowerModules * sizeof(unsigned int));
+    cudaMemset(tripletsInTemp.nTriplets,0,nLowerModules * sizeof(unsigned int));
 #else
     cudaMallocManaged(&tripletsInTemp.nTriplets, nLowerModules * sizeof(unsigned int));
 #endif


### PR DESCRIPTION
removed the memset for the full explicit case. Doesn't seem to affect objects further down the line. tested by running minidoublets with full explicit and segments with unified. same output as when running minidoublets in unified memory. 
Also removed cudaFree for temp objects. 
Fixes all issues raised by cuda-memcheck