### PR TITLE
delete module objects properly 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 # Simple makefile
 
 EXES=bin/doAnalysis bin/sdl #bin/mtv bin/tracklet bin/sdl
@@ -16,11 +17,12 @@ CXXFLAGS    = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual
 LDFLAGS     = -g -O2 
 ROOTLIBS    = $(shell root-config --libs)
 #ROOTCFLAGS  = $(shell `root-config --cflags)
-ROOTCFLAGS   = --compiler-options -pthread --compiler-options -std=c++17 -m64 -I/cvmfs/cms.cern.ch/slc7_amd64_gcc700/cms/cmssw/CMSSW_11_0_0_pre6/external/slc7_amd64_gcc700/bin/../../../../../../../slc7_amd64_gcc700/lcg/root/6.14.09-nmpfii5/include
+#ROOTCFLAGS   = --compiler-options -pthread --compiler-options -std=c++17 -m64 -I/cvmfs/cms.cern.ch/slc7_amd64_gcc700/cms/cmssw/CMSSW_11_0_0_pre6/external/slc7_amd64_gcc700/bin/../../../../../../../slc7_amd64_gcc700/lcg/root/6.14.09-nmpfii5/include
+ROOTCFLAGS = --compiler-options -pthread --compiler-options -std=c++17 -m64 -I/cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0_pre5/external/slc7_amd64_gcc900/bin/../../../../../../../slc7_amd64_gcc900/lcg/root/6.20.06-ghbfee3/include
 CXXFLAGS    = $(ROOTCFLAGS) -ISDL -I$(shell pwd) -Isrc -Isrc/AnalysisInterface
-CFLAGS      = $(ROOTCFLAGS) --compiler-options -Wall --compiler-options -Wno-unused-function --compiler-options -g --compiler-options -O2 --compiler-options -fPIC --compiler-options -fno-var-tracking -ISDL -I$(shell pwd) -Isrc -Isrc/AnalysisInterface -I/cvmfs/cms.cern.ch/slc7_amd64_gcc700/external/cuda/10.1.105-pafccj2/include --compiler-options -fopenmp
+CFLAGS      = $(ROOTCFLAGS) --compiler-options -Wall --compiler-options -Wno-unused-function --compiler-options -g --compiler-options -O2 --compiler-options -fPIC --compiler-options -fno-var-tracking -ISDL -I$(shell pwd) -Isrc -Isrc/AnalysisInterface -I/cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/cuda/11.0.3/include --compiler-options -fopenmp
 EXTRACFLAGS = $(shell rooutil-config)
-EXTRAFLAGS  = -fPIC -ITMultiDrawTreePlayer -Wunused-variable -lTMVA -lEG -lGenVector -lXMLIO -lMLP -lTreePlayer -L/cvmfs/cms.cern.ch/slc7_amd64_gcc700/external/cuda/10.1.105-pafccj2/lib64 -lcudart -fopenmp
+EXTRAFLAGS  = -fPIC -ITMultiDrawTreePlayer -Wunused-variable -lTMVA -lEG -lGenVector -lXMLIO -lMLP -lTreePlayer -L/cvmfs/cms.cern.ch/slc7_amd64_gcc900/external/cuda/11.0.3/lib64 -lcudart -fopenmp
 
 all: $(EXES)
 

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -18,10 +18,10 @@ SDL::Event::Event()
     mdsInTemp = nullptr; //explicit
     segmentsInGPU = nullptr;
     segmentsInTemp = nullptr;
-    trackletsInGPU = nullptr; 
-    trackletsInTemp = nullptr; 
-    tripletsInGPU = nullptr; 
-    tripletsInTemp = nullptr; 
+    trackletsInGPU = nullptr;
+    trackletsInTemp = nullptr;
+    tripletsInGPU = nullptr;
+    tripletsInTemp = nullptr;
     //reset the arrays
     for(int i = 0; i<6; i++)
     {
@@ -53,19 +53,19 @@ SDL::Event::~Event()
     mdsInGPU->freeMemory();
 #endif
 #ifdef Explicit_Seg
-    segmentsInTemp->freeMemory(); 
+    segmentsInTemp->freeMemory();
     cudaFreeHost(segmentsInTemp);
 #else
-    segmentsInGPU->freeMemory(); 
+    segmentsInGPU->freeMemory();
 #endif
-#ifdef Explicit_Tracklet 
-    trackletsInTemp->freeMemory(); 
+#ifdef Explicit_Tracklet
+    trackletsInTemp->freeMemory();
     cudaFreeHost(trackletsInTemp);
 #else
     trackletsInGPU->freeMemory();
 #endif
 #ifdef Explicit_Trips
-    tripletsInTemp->freeMemory(); 
+    tripletsInTemp->freeMemory();
     cudaFreeHost(tripletsInTemp);
 #else
     tripletsInGPU->freeMemory();
@@ -86,6 +86,12 @@ void SDL::initModules()
         loadModulesFromFile(*modulesInGPU,nModules); //nModules gets filled here
     }
     resetObjectRanges(*modulesInGPU,nModules);
+}
+
+void SDL::cleanModules()
+{
+  freeModulesInUnifiedMemory(*modulesInGPU);
+  cudaFree(modulesInGPU);
 }
 
 void SDL::Event::resetObjectsInModule()
@@ -117,7 +123,7 @@ void SDL::Event::addHitToEvent(float x, float y, float z, unsigned int detId)
     else
     {
         n_hits_by_layer_endcap_[moduleLayer-1]++;
-    } 
+    }
 
 }
 
@@ -136,7 +142,7 @@ void SDL::Event::addMiniDoubletsToEvent()
         {
             modulesInGPU->mdRanges[idx * 2] = idx * N_MAX_MD_PER_MODULES;
             modulesInGPU->mdRanges[idx * 2 + 1] = (idx * N_MAX_MD_PER_MODULES) + mdsInGPU->nMDs[idx] - 1;
-    
+
             if(modulesInGPU->subdets[idx] == Barrel)
             {
                 n_minidoublets_by_layer_barrel_[modulesInGPU->layers[idx] -1] += mdsInGPU->nMDs[idx];
@@ -171,7 +177,7 @@ void SDL::Event::addSegmentsToEvent()
 
             if(modulesInGPU->subdets[idx] == Barrel)
             {
-  
+
                 n_segments_by_layer_barrel_[modulesInGPU->layers[idx] - 1] += segmentsInGPU->nSegments[idx];
             }
             else
@@ -229,9 +235,9 @@ void SDL::Event::createMiniDoublets()
 
     if(cudaerr != cudaSuccess)
     {
-        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;    
+        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
     }
-    
+
 #if defined(AddObjects) && !defined(Full_Explicit)
     addMiniDoubletsToEvent();
 #endif
@@ -265,7 +271,7 @@ void SDL::Event::createSegmentsWithModuleMap()
 //    dim3 nThreads(1,16,16);
 //    dim3 nBlocks(((nLowerModules * MAX_CONNECTED_MODULES)  % nThreads.x == 0 ? (nLowerModules * MAX_CONNECTED_MODULES)/nThreads.x : (nLowerModules * MAX_CONNECTED_MODULES)/nThreads.x + 1),(N_MAX_MD_PER_MODULES % nThreads.y == 0 ? N_MAX_MD_PER_MODULES/nThreads.y : N_MAX_MD_PER_MODULES/nThreads.y + 1), (N_MAX_MD_PER_MODULES % nThreads.z == 0 ? N_MAX_MD_PER_MODULES/nThreads.z : N_MAX_MD_PER_MODULES/nThreads.z + 1));
 
-    unsigned int nThreads = 1;   
+    unsigned int nThreads = 1;
     unsigned int nBlocks = nLowerModules % nThreads == 0 ? nLowerModules/nThreads : nLowerModules/nThreads + 1;
 
     createSegmentsInGPU<<<nBlocks,nThreads>>>(*modulesInGPU, *hitsInGPU, *mdsInGPU, *segmentsInGPU);
@@ -273,7 +279,7 @@ void SDL::Event::createSegmentsWithModuleMap()
     cudaError_t cudaerr = cudaDeviceSynchronize();
     if(cudaerr != cudaSuccess)
     {
-        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;    
+        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
     }
 #if defined(AddObjects) && !defined(Full_Explicit)
     addSegmentsToEvent();
@@ -352,7 +358,7 @@ void SDL::Event::createTrackletsWithModuleMap()
     cudaError_t cudaerr = cudaDeviceSynchronize();
     if(cudaerr != cudaSuccess)
     {
-        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;    
+        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
 
     }
     /*addTrackletsToEvent will be called in the createTrackletsWithAGapWithModuleMap function*/
@@ -396,7 +402,7 @@ void SDL::Event::createTrackletsWithAGapWithModuleMap()
     cudaError_t cudaerr = cudaDeviceSynchronize();
     if(cudaerr != cudaSuccess)
     {
-        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;    
+        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
 
     }
 
@@ -424,8 +430,8 @@ void SDL::Event::addTrackletsToEvent()
             //{
             //    printTracklet(*trackletsInGPU, *segmentsInGPU, *mdsInGPU, *hitsInGPU, *modulesInGPU, i * N_MAX_TRACKLETS_PER_MODULE + jdx);
             //}
-            
- 
+
+
             if(modulesInGPU->subdets[idx] == Barrel)
             {
                 n_tracklets_by_layer_barrel_[modulesInGPU->layers[idx] - 1] += trackletsInGPU->nTracklets[i];
@@ -461,7 +467,7 @@ void SDL::Event::addTripletsToEvent()
         {
             modulesInGPU->tripletRanges[idx * 2] = idx * N_MAX_TRIPLETS_PER_MODULE;
             modulesInGPU->tripletRanges[idx * 2 + 1] = idx * N_MAX_TRIPLETS_PER_MODULE + tripletsInGPU->nTriplets[i] - 1;
- 
+
             if(modulesInGPU->subdets[idx] == Barrel)
             {
                 n_triplets_by_layer_barrel_[modulesInGPU->layers[idx] - 1] += tripletsInGPU->nTriplets[i];
@@ -497,7 +503,7 @@ __global__ void createMiniDoubletsInGPU(struct SDL::modules& modulesInGPU, struc
 
     float dz, dphi, dphichange, shiftedX, shiftedY, shiftedZ, noShiftedDz, noShiftedDphi, noShiftedDphiChange;
     bool success = runMiniDoubletDefaultAlgo(modulesInGPU, hitsInGPU, lowerModuleIndex, lowerHitArrayIndex, upperHitArrayIndex, dz, dphi, dphichange, shiftedX, shiftedY, shiftedZ, noShiftedDz, noShiftedDphi, noShiftedDphiChange);
-    
+
     if(success)
     {
         unsigned int mdModuleIndex = atomicAdd(&mdsInGPU.nMDs[lowerModuleIndex],1);
@@ -552,7 +558,7 @@ __global__ void createMiniDoubletsInGPU(struct SDL::modules& modulesInGPU, struc
 
     createMiniDoubletsFromLowerModule<<<nBlocks,nThreads>>>(modulesInGPU, hitsInGPU, mdsInGPU, lowerModuleIndex, upperModuleIndex, nLowerHits, nUpperHits);
 
-  
+
 }*/
 
 /*__global__ void createSegmentsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU)
@@ -563,7 +569,7 @@ __global__ void createMiniDoubletsInGPU(struct SDL::modules& modulesInGPU, struc
 
     int innerLowerModuleArrayIdx = xAxisIdx/MAX_CONNECTED_MODULES;
     int outerLowerModuleArrayIdx = xAxisIdx % MAX_CONNECTED_MODULES; //need this index from the connected module array
-    
+
     unsigned int innerLowerModuleIndex = modulesInGPU.lowerModuleIndices[innerLowerModuleArrayIdx];
 
     unsigned int nConnectedModules = modulesInGPU.nConnectedModules[innerLowerModuleIndex];
@@ -654,7 +660,7 @@ __global__ void createSegmentsInGPU(struct SDL::modules& modulesInGPU, struct SD
     dim3 nThreads(1,16,16);
     dim3 nBlocks((nConnectedModules % nThreads.x == 0 ? nConnectedModules/nThreads.x : nConnectedModules/nThreads.x + 1), (nInnerMDs % nThreads.y == 0 ? nInnerMDs/nThreads.y : nInnerMDs/nThreads.y + 1), (N_MAX_MD_PER_MODULES % nThreads.z == 0 ? N_MAX_MD_PER_MODULES/nThreads.z : N_MAX_MD_PER_MODULES/nThreads.z + 1));
     createSegmentsFromInnerLowerModule<<<nBlocks,nThreads>>>(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, innerLowerModuleIndex,nInnerMDs);
-   
+
 }
 
 
@@ -686,7 +692,7 @@ __global__ void createTrackletsFromInnerInnerLowerModule(struct SDL::modules& mo
     unsigned int outerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[outerSegmentIndex];
 
     //with both segment indices obtained, run the tracklet algorithm
-    
+
    float zOut,rtOut,deltaPhiPos,deltaPhi,betaIn,betaOut;
 
    bool success = runTrackletDefaultAlgo(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, innerInnerLowerModuleIndex, innerOuterLowerModuleIndex, outerInnerLowerModuleIndex, outerOuterLowerModuleIndex, innerSegmentIndex, outerSegmentIndex, zOut, rtOut, deltaPhiPos, deltaPhi, betaIn, betaOut); //might want to send the other two module indices and the anchor hits also to save memory accesses
@@ -721,15 +727,15 @@ __global__ void createTrackletsWithAGapFromInnerInnerLowerModule(struct SDL::mod
     int xAxisIndex = blockIdx.x * blockDim.x + threadIdx.x;
     int innerSegmentArrayIndex =  blockIdx.y * blockDim.y + threadIdx.y;
     int outerSegmentArrayIndex = blockIdx.z * blockDim.z + threadIdx.z;
-    
+
     if(innerSegmentArrayIndex >= nInnerSegments) return;
 
     int middleLowerModuleArrayIndex = xAxisIndex / MAX_CONNECTED_MODULES;
     int outerInnerLowerModuleArrayIndex = xAxisIndex % MAX_CONNECTED_MODULES;
 
     unsigned int innerSegmentIndex = innerInnerLowerModuleIndex * N_MAX_SEGMENTS_PER_MODULE + innerSegmentArrayIndex;
-    unsigned int innerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[innerSegmentIndex]; 
-   
+    unsigned int innerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[innerSegmentIndex];
+
     //first check for middle modules
     unsigned int nMiddleLowerModules = modulesInGPU.nConnectedModules[innerOuterLowerModuleIndex];
     if(middleLowerModuleArrayIndex >= nMiddleLowerModules) return;
@@ -751,7 +757,7 @@ __global__ void createTrackletsWithAGapFromInnerInnerLowerModule(struct SDL::mod
     unsigned int outerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[outerSegmentIndex];
 
     //with both segment indices obtained, run the tracklet algorithm
-    
+
    float zOut,rtOut,deltaPhiPos,deltaPhi,betaIn,betaOut;
 
    bool success = runTrackletDefaultAlgo(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, innerInnerLowerModuleIndex, innerOuterLowerModuleIndex, outerInnerLowerModuleIndex, outerOuterLowerModuleIndex, innerSegmentIndex, outerSegmentIndex, zOut, rtOut, deltaPhiPos, deltaPhi, betaIn, betaOut); //might want to send the other two module indices and the anchor hits also to save memory accesses
@@ -785,7 +791,7 @@ __global__ void createTrackletsWithAGapInGPU(struct SDL::modules& modulesInGPU, 
     //Inner kernel of Proposal 2 : Inner kernel does middle->outer modoule mapping
     int outerInnerLowerModuleArrayIndex = blockIdx.x * blockDim.x + threadIdx.x;
     int outerSegmentArrayIndex = blockIdx.y * blockDim.y + threadIdx.y;
-    
+
     //check for outerInnerLowerModules
     if(outerInnerLowerModuleArrayIndex >= nOuterInnerLowerModules) return;
 
@@ -801,7 +807,7 @@ __global__ void createTrackletsWithAGapInGPU(struct SDL::modules& modulesInGPU, 
     unsigned int outerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[outerSegmentIndex];
 
     //with both segment indices obtained, run the tracklet algorithm
-    
+
    float zOut,rtOut,deltaPhiPos,deltaPhi,betaIn,betaOut;
 
    bool success = runTrackletDefaultAlgo(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, innerInnerLowerModuleIndex, innerOuterLowerModuleIndex, outerInnerLowerModuleIndex, outerOuterLowerModuleIndex, innerSegmentIndex, outerSegmentIndex, zOut, rtOut, deltaPhiPos, deltaPhi, betaIn, betaOut); //might want to send the other two module indices and the anchor hits also to save memory accesses
@@ -827,9 +833,9 @@ __global__ void createTrackletsWithAGapFromInnerInnerLowerModule(struct SDL::mod
     //middle lower module - modules that are connected to outer lower module of inner segment
     unsigned int innerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[innerSegmentIndex];
     unsigned int nMiddleLowerModules = modulesInGPU.nConnectedModules[innerOuterLowerModuleIndex];
- 
+
     if(middleLowerModuleArrayIndex >= nMiddleLowerModules) return;
- 
+
     unsigned int middleLowerModuleIndex = modulesInGPU.moduleMap[innerOuterLowerModuleIndex * MAX_CONNECTED_MODULES + middleLowerModuleArrayIndex];
 
     unsigned int nOuterInnerLowerModules = modulesInGPU.nConnectedModules[middleLowerModuleIndex];
@@ -854,7 +860,7 @@ __global__ void createTrackletsWithAGapInGPU(struct SDL::modules& modulesInGPU, 
 
     dim3 nThreads(1,1,1);
     dim3 nBlocks(MAX_CONNECTED_MODULES % nThreads.x  == 0 ? MAX_CONNECTED_MODULES / nThreads.x : MAX_CONNECTED_MODULES / nThreads.x + 1 , nInnerSegments % nThreads.y == 0 ? nInnerSegments/nThreads.y : nInnerSegments/nThreads.y + 1,1);
-    
+
     createTrackletsWithAGapFromInnerInnerLowerModule<<<nBlocks,nThreads>>>(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, trackletsInGPU, innerInnerLowerModuleIndex, nInnerSegments, innerInnerLowerModuleArrayIndex);
 
 }*/
@@ -885,7 +891,7 @@ __global__ void createTripletsFromInnerInnerLowerModule(struct SDL::modules& mod
         unsigned int tripletIndex = innerInnerLowerModuleArrayIndex * N_MAX_TRIPLETS_PER_MODULE + tripletModuleIndex;
 
         addTripletToMemory(tripletsInGPU, innerSegmentIndex, outerSegmentIndex, innerInnerLowerModuleIndex, middleLowerModuleIndex, outerOuterLowerModuleIndex, zOut, rtOut, deltaPhiPos, deltaPhi, betaIn, betaOut, tripletIndex);
-    }   
+    }
 }
 
 __global__ void createTripletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU)
@@ -950,7 +956,7 @@ unsigned int SDL::Event::getNumberOfMiniDoublets()
     }
 
     return miniDoublets;
-   
+
 }
 
 unsigned int SDL::Event::getNumberOfMiniDoubletsByLayer(unsigned int layer)
@@ -958,7 +964,7 @@ unsigned int SDL::Event::getNumberOfMiniDoubletsByLayer(unsigned int layer)
      if(layer == 6)
         return n_minidoublets_by_layer_barrel_[layer];
     else
-        return n_minidoublets_by_layer_barrel_[layer] + n_minidoublets_by_layer_endcap_[layer];   
+        return n_minidoublets_by_layer_barrel_[layer] + n_minidoublets_by_layer_endcap_[layer];
 }
 
 unsigned int SDL::Event::getNumberOfMiniDoubletsByLayerBarrel(unsigned int layer)
@@ -984,7 +990,7 @@ unsigned int SDL::Event::getNumberOfSegments()
     }
 
     return segments;
-   
+
 }
 
 unsigned int SDL::Event::getNumberOfSegmentsByLayer(unsigned int layer)
@@ -992,7 +998,7 @@ unsigned int SDL::Event::getNumberOfSegmentsByLayer(unsigned int layer)
      if(layer == 6)
         return n_segments_by_layer_barrel_[layer];
     else
-        return n_segments_by_layer_barrel_[layer] + n_segments_by_layer_endcap_[layer];   
+        return n_segments_by_layer_barrel_[layer] + n_segments_by_layer_endcap_[layer];
 }
 
 unsigned int SDL::Event::getNumberOfSegmentsByLayerBarrel(unsigned int layer)
@@ -1018,7 +1024,7 @@ unsigned int SDL::Event::getNumberOfTracklets()
     }
 
     return tracklets;
-   
+
 }
 
 unsigned int SDL::Event::getNumberOfTrackletsByLayer(unsigned int layer)
@@ -1052,7 +1058,7 @@ unsigned int SDL::Event::getNumberOfTriplets()
     }
 
     return triplets;
-   
+
 }
 
 

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -108,6 +108,7 @@ namespace SDL
     extern struct modules* modulesInHost;
     extern unsigned int nModules;
     void initModules(); //read from file and init
+    void cleanModules();
     void initModulesHost(); //read from file and init
 
 }

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -33,6 +33,33 @@ void SDL::createModulesInUnifiedMemory(struct modules& modulesInGPU,unsigned int
 
 }
 
+void SDL::freeModulesInUnifiedMemory(struct modules& modulesInGPU)
+{
+  cudaFree(modulesInGPU.detIds);
+  cudaFree(modulesInGPU.moduleMap);
+  cudaFree(modulesInGPU.nConnectedModules);
+  cudaFree(modulesInGPU.drdzs);
+  cudaFree(modulesInGPU.slopes);
+  cudaFree(modulesInGPU.nModules);
+  cudaFree(modulesInGPU.nLowerModules);
+  cudaFree(modulesInGPU.layers);
+  cudaFree(modulesInGPU.rings);
+  cudaFree(modulesInGPU.modules);
+  cudaFree(modulesInGPU.rods);
+  cudaFree(modulesInGPU.subdets);
+  cudaFree(modulesInGPU.sides);
+  cudaFree(modulesInGPU.isInverted);
+  cudaFree(modulesInGPU.isLower);
+  cudaFree(modulesInGPU.hitRanges);
+  cudaFree(modulesInGPU.mdRanges);
+  cudaFree(modulesInGPU.segmentRanges);
+  cudaFree(modulesInGPU.trackletRanges);
+  cudaFree(modulesInGPU.tripletRanges);
+  cudaFree(modulesInGPU.moduleType);
+  cudaFree(modulesInGPU.moduleLayerType);
+  cudaFree(modulesInGPU.lowerModuleIndices);
+}
+
 void SDL::createLowerModuleIndexMap(struct modules& modulesInGPU, unsigned int nLowerModules)
 {
     cudaMallocManaged(&modulesInGPU.lowerModuleIndices,nLowerModules * sizeof(unsigned int));
@@ -71,7 +98,7 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, unsigned int& nModul
         std::stringstream ss(line);
         std::string token;
         bool flag = 0;
-        
+
         while(std::getline(ss,token,','))
         {
             if(flag == 1) break;
@@ -88,10 +115,10 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, unsigned int& nModul
     for(auto it = (*detIdToIndex).begin(); it != (*detIdToIndex).end(); it++)
     {
         unsigned int detId = it->first;
-        unsigned int index = it->second; 
+        unsigned int index = it->second;
         modulesInGPU.detIds[index] = detId;
         unsigned short layer,ring,rod,module,subdet,side;
-        setDerivedQuantities(detId,layer,ring,rod,module,subdet,side); 
+        setDerivedQuantities(detId,layer,ring,rod,module,subdet,side);
         modulesInGPU.layers[index] = layer;
         modulesInGPU.rings[index] = ring;
         modulesInGPU.rods[index] = rod;
@@ -115,7 +142,7 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, unsigned int& nModul
     createLowerModuleIndexMap(modulesInGPU,lowerModuleCounter);
     fillConnectedModuleArray(modulesInGPU,nModules);
     resetObjectRanges(modulesInGPU,nModules);
-} 
+}
 
 void SDL::fillConnectedModuleArray(struct modules& modulesInGPU, unsigned int nModules)
 {
@@ -306,4 +333,3 @@ void SDL::resetObjectRanges(struct modules& modulesInGPU, unsigned int nModules)
     }
 
 }
-

--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -90,6 +90,7 @@ namespace SDL
 
     void createLowerModuleIndexMap(struct modules& modulesInGPU, unsigned int nLowerModules);
     void createModulesInUnifiedMemory(struct modules& modulesInGPU,unsigned int nModules);
+    void freeModulesInUnifiedMemory(struct modules& modulesInGPU);
     void fillConnectedModuleArray(struct modules& modulesInGPU, unsigned int nModules);
     void setDerivedQuantities(unsigned int detId, unsigned short& layer, unsigned short& ring, unsigned short& rod, unsigned short& module, unsigned short& subdet, unsigned short& side);
     void resetObjectRanges(struct modules& modulesInGPU, unsigned int nModules);

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -492,7 +492,7 @@ int main(int argc, char** argv)
         TStopwatch my_timer;
 
         // run_eff_study == 0 then run all the reconstruction
-      // 
+      //
         //if ((ana.run_eff_study == 0 and ana.run_ineff_study == 0) or ana.run_mtv_study)
         {
 
@@ -542,7 +542,7 @@ int main(int argc, char** argv)
             event.createMiniDoublets();
             // event.createPseudoMiniDoubletsFromAnchorModule(); // Useless.....
             float md_elapsed = my_timer.RealTime();
-            
+
             if (ana.verbose != 0) std::cout << "Reco Mini-doublet processing time: " << md_elapsed << " secs" << std::endl;
 
             if (ana.verbose != 0) std::cout << "# of Mini-doublets produced: " << event.getNumberOfMiniDoublets() << std::endl;
@@ -578,7 +578,7 @@ int main(int argc, char** argv)
             // ----------------
 
             // ----------------
-            // 
+            //
 
             if (ana.verbose != 0) std::cout << "Reco Segment start" << std::endl;
             my_timer.Start(kFALSE);
@@ -846,13 +846,13 @@ int main(int argc, char** argv)
                         {
 
                             int ihit = trk.simhit_hitIdx()[simhitidx][irecohit];
-                            
+
                             trackevent->addHitToEvent(
                                     // a hit
                                     trk.ph2_x()[ihit], trk.ph2_y()[ihit], trk.ph2_z()[ihit],
                                     // add to module with "detId"
                                     trk.ph2_detId()[ihit]);
-                                    
+
 
                         }
 
@@ -950,6 +950,8 @@ int main(int argc, char** argv)
 //        // <--------------------------
 //        // <--------------------------
     }
+
+    SDL::cleanModules();
 
     // Writing output file
     ana.cutflow.saveOutput();
@@ -1074,4 +1076,3 @@ int layer(int lay, int det)
 //     return has_good_pair_all_layer;
 
 // }
-

--- a/setup.sh
+++ b/setup.sh
@@ -11,8 +11,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # export SCRAM_ARCH=slc6_amd64_gcc630   # or whatever scram_arch you need for your desired CMSSW release
 # export CMSSW_VERSION=CMSSW_10_1_0
 #export SCRAM_ARCH=slc7_amd64_gcc900   # or whatever scram_arch you need for your desired CMSSW release
-export SCRAM_ARCH=slc7_amd64_gcc700
-export CMSSW_VERSION=CMSSW_11_0_0_pre6
+#export SCRAM_ARCH=slc7_amd64_gcc700
+#export CMSSW_VERSION=CMSSW_11_0_0_pre6
+export SCRAM_ARCH=slc7_amd64_gcc900
+export CMSSW_VERSION=CMSSW_11_2_0_pre5
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 cd /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/$CMSSW_VERSION/src
 eval `scramv1 runtime -sh`


### PR DESCRIPTION
create cleanModules() function to delete the created module object properly. not really affect the correctness of the code at this point, but it is a good programming practice to provide initModules() and cleanModules() functions as a pair.