### PR TITLE
Pixel segments, tracklets and track candidates

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -7,11 +7,12 @@ const unsigned int N_MAX_SEGMENTS_PER_MODULE = 600; //WHY!
 const unsigned int MAX_CONNECTED_MODULES = 40;
 const unsigned int N_MAX_TRACKLETS_PER_MODULE = 8000;//temporary
 const unsigned int N_MAX_TRIPLETS_PER_MODULE = 5000;
-const unsigned int N_MAX_TRACK_CANDIDATES_PER_MODULE = 5000;
+const unsigned int N_MAX_TRACK_CANDIDATES_PER_MODULE = 50000;
 const unsigned int N_MAX_PIXEL_MD_PER_MODULES = 100000;
 const unsigned int N_MAX_PIXEL_SEGMENTS_PER_MODULE = 50000;
-const unsigned int N_MAX_PIXEL_TRACKLETS_PER_MODULE = 2000000;
-const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES_PER_MODULE = 200000;
+const unsigned int N_MAX_PIXEL_TRACKLETS_PER_MODULE = 3000000;
+const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES_PER_MODULE = 2000000;
+
 
 struct SDL::modules* SDL::modulesInGPU = nullptr;
 struct SDL::modules* SDL::modulesInHost = nullptr;//explicit
@@ -115,7 +116,7 @@ void SDL::Event::addHitToEvent(float x, float y, float z, unsigned int detId, un
     {
         n_hits_by_layer_barrel_[moduleLayer-1]++;
     }
-    else
+    else if(subdet == Endcap)
     {
         n_hits_by_layer_endcap_[moduleLayer-1]++;
     }
@@ -1312,6 +1313,9 @@ unsigned int SDL::Event::getNumberOfTrackCandidates()
     {
         trackCandidates += it;
     }
+
+    //hack - add pixel track candidate multiplicity
+    trackCandidates += trackCandidatesInGPU->nTrackCandidates[*(modulesInGPU->nLowerModules)];
 
     return trackCandidates;
    

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -94,7 +94,7 @@ void SDL::Event::resetObjectsInModule()
     resetObjectRanges(*modulesInGPU,nModules);
 }
 
-void SDL::Event::addHitToEvent(float x, float y, float z, unsigned int detId)
+void SDL::Event::addHitToEvent(float x, float y, float z, unsigned int detId, unsigned int idx)
 {
     const int HIT_MAX = 1000000;
     const int HIT_2S_MAX = 100000;
@@ -106,7 +106,7 @@ void SDL::Event::addHitToEvent(float x, float y, float z, unsigned int detId)
     }
 
     //calls the addHitToMemory function
-    addHitToMemory(*hitsInGPU, *modulesInGPU, x, y, z, detId);
+    addHitToMemory(*hitsInGPU, *modulesInGPU, x, y, z, detId, idx);
 
     unsigned int moduleLayer = modulesInGPU->layers[(*detIdToIndex)[detId]];
     unsigned int subdet = modulesInGPU->subdets[(*detIdToIndex)[detId]];

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -4,6 +4,7 @@
 #include <vector>
 #include <list>
 #include <map>
+#include <cassert>
 #include <stdlib.h>
 #include <stdexcept>
 #include <iostream>
@@ -70,6 +71,7 @@ namespace SDL
         void createSegmentsWithModuleMap();
         void createTriplets();
         void createTrackletsWithModuleMap();
+        void createPixelTracklets();
         void createTrackletsWithAGapWithModuleMap();
         void createTrackCandidates();
 
@@ -133,7 +135,12 @@ __global__ void createTrackletsInGPU(struct SDL::modules& modulesInGPU, struct S
 
 __global__ void createTrackletsFromInnerInnerLowerModule(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::tracklets& trackletsInGPU, unsigned int innerInnerLowerModuleIndex, unsigned int nInnerSegments, unsigned int innerInnerLowerModuleArrayIndex);
 
+__global__ void createPixelTrackletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::tracklets& trackletsInGPU);
+
+__global__ void createPixelTrackletsFromOuterInnerLowerModule(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::tracklets& trackletsInGPU, unsigned int outerInnerLowerModuleIndex, unsigned int nInnerSegments, unsigned int nOuterSegments, unsigned int pixelModuleIndex, unsigned int pixelLowerModuleArrayIndex);
+
 __global__ void createTrackletsWithAGapInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::tracklets& trackletsInGPU);
+
 
 __global__ void createTrackletsWithAGapFromInnerInnerLowerModule(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::tracklets& trackletsInGPU, unsigned int innerInnerLowerModuleIndex, unsigned int nInnerSegments, unsigned int innerInnerLowerModuleArrayIndex);
 

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -53,7 +53,7 @@ namespace SDL
         Event();
         ~Event();
 
-        void addHitToEvent(float x, float y, float z, unsigned int detId); //call the appropriate hit function, then increment the counter here
+        void addHitToEvent(float x, float y, float z, unsigned int detId, unsigned int idx); //call the appropriate hit function, then increment the counter here
         void addPixelSegmentToEvent(std::vector<unsigned int> hitIndices, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr);
 
         /*functions that map the objects to the appropriate modules*/

--- a/SDL/Hit.cu
+++ b/SDL/Hit.cu
@@ -16,7 +16,7 @@ SDL::hits::hits()
     lowEdgeXs = nullptr;
     lowEdgeYs = nullptr;
 }
-
+//FIXME:New array!
 void SDL::createHitsInUnifiedMemory(struct hits& hitsInGPU,unsigned int nMaxHits,unsigned int nMax2SHits)
 {
     //nMaxHits and nMax2SHits are the maximum possible numbers
@@ -24,6 +24,9 @@ void SDL::createHitsInUnifiedMemory(struct hits& hitsInGPU,unsigned int nMaxHits
     cudaMallocManaged(&hitsInGPU.ys, nMaxHits * sizeof(float));
     cudaMallocManaged(&hitsInGPU.zs, nMaxHits * sizeof(float));
     cudaMallocManaged(&hitsInGPU.moduleIndices, nMaxHits * sizeof(unsigned int));
+    //TODO:This dude (idxs) is not used in the GPU at all. It is only used for simhit matching to make efficiency plots
+    //We can even skip this one later
+    cudaMallocManaged(&hitsInGPU.idxs, nMaxHits * sizeof(unsigned int));
 
     cudaMallocManaged(&hitsInGPU.rts, nMaxHits * sizeof(float));
     cudaMallocManaged(&hitsInGPU.phis, nMaxHits * sizeof(float));
@@ -40,8 +43,8 @@ void SDL::createHitsInUnifiedMemory(struct hits& hitsInGPU,unsigned int nMaxHits
     cudaMallocManaged(&hitsInGPU.n2SHits, sizeof(unsigned int));
     *hitsInGPU.n2SHits = 0;
 }
-
-void SDL::addHitToMemory(struct hits& hitsInGPU, struct modules& modulesInGPU, float x, float y, float z, unsigned int detId)
+//FIXME:New argument!
+void SDL::addHitToMemory(struct hits& hitsInGPU, struct modules& modulesInGPU, float x, float y, float z, unsigned int detId, unsigned int idxInNtuple)
 {
     unsigned int idx = *(hitsInGPU.nHits);
     unsigned int idxEdge2S = *(hitsInGPU.n2SHits);
@@ -51,6 +54,7 @@ void SDL::addHitToMemory(struct hits& hitsInGPU, struct modules& modulesInGPU, f
     hitsInGPU.zs[idx] = z;
     hitsInGPU.rts[idx] = sqrt(x*x + y*y);
     hitsInGPU.phis[idx] = phi(x,y,z);
+    hitsInGPU.idxs[idx] = idxInNtuple;
     unsigned int moduleIndex = (*detIdToIndex)[detId];
     hitsInGPU.moduleIndices[idx] = moduleIndex;
     if(modulesInGPU.subdets[moduleIndex] == Endcap and modulesInGPU.moduleType[moduleIndex] == TwoS)

--- a/SDL/Hit.cuh
+++ b/SDL/Hit.cuh
@@ -25,6 +25,7 @@ namespace SDL
         float *zs;
 
         unsigned int* moduleIndices;
+        unsigned int* idxs;
         
         float *rts;
         float* phis;
@@ -42,7 +43,7 @@ namespace SDL
     };
 
     void createHitsInUnifiedMemory(struct hits& hitsInGPU,unsigned int maxHits, unsigned int max2SHits);
-    void addHitToMemory(struct hits& hitsInGPU,struct modules& modulesInGPU,float x, float y, float z, unsigned int detId);
+    void addHitToMemory(struct hits& hitsInGPU,struct modules& modulesInGPU,float x, float y, float z, unsigned int detId, unsigned int idxInNtuple);
     CUDA_HOSTDEV inline float phi(float x, float y, float z);
     CUDA_HOSTDEV inline float ATan2(float y, float x);
     CUDA_HOSTDEV float phi_mpi_pi(float phi);

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -18,10 +18,10 @@ CXXFLAGS      =  -g --compiler-options -Wall --compiler-options -Wshadow --compi
 LD            = nvcc 
 #LDFLAGS       = -g -O2
 SOFLAGS       = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_52
-MEMFLAG       = -DExplicit_MD -DExplicit_Seg -DExplicit_Tracklet -DExplicit_Trips 
+#MEMFLAG       = -DExplicit_MD -DExplicit_Seg -DExplicit_Tracklet -DExplicit_Trips 
 #MEMFLAG       += -DFull_Explicit
 PRINTFLAG     = -DAddObjects
-CACHEFLAG     = -DCACHE_ALLOC
+#CACHEFLAG     = -DCACHE_ALLOC
 # how to make it 
 #
 

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -25,29 +25,31 @@ CUDA_CONST_VAR float SDL::deltaZLum = 15.0;
 CUDA_CONST_VAR float SDL::pixelPSZpitch = 0.15;
 CUDA_CONST_VAR float SDL::strip2SZpitch = 5.0;
 
-void SDL::createMDsInUnifiedMemory(struct miniDoublets& mdsInGPU, unsigned int maxMDsPerModule, unsigned int nModules)
+//FIXME:new memory locations for the pixel MDs
+void SDL::createMDsInUnifiedMemory(struct miniDoublets& mdsInGPU, unsigned int maxMDsPerModule, unsigned int nModules, unsigned int maxPixelMDs)
 {
+    unsigned int nMemoryLocations = maxMDsPerModule * (nModules - 1) + maxPixelMDs;
 #ifdef CACHE_ALLOC
     cudaStream_t stream=0;
-    mdsInGPU.hitIndices = (unsigned int*)cms::cuda::allocate_managed(maxMDsPerModule * nModules * 3 * sizeof(unsigned int), stream);
-    mdsInGPU.pixelModuleFlag = (short*)cms::cuda::allocate_managed(maxMDsPerModule*nModules*sizeof(short),stream);
-    mdsInGPU.nMDs = (unsigned int*)cms::cuda::allocate_managed(nModules*sizeof(unsigned int),stream);
-    mdsInGPU.dphichanges = (float*)cms::cuda::allocate_managed(maxMDsPerModule*nModules*9*sizeof(float),stream);
+    mdsInGPU.hitIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations * 3 * sizeof(unsigned int), stream);
+    mdsInGPU.pixelModuleFlag = (short*)cms::cuda::allocate_managed(nMemoryLocations*sizeof(short),stream);
+    mdsInGPU.nMDs = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations*sizeof(unsigned int),stream);
+    mdsInGPU.dphichanges = (float*)cms::cuda::allocate_managed(nMemoryLocations*9*sizeof(float),stream);
 #else
-    cudaMallocManaged(&mdsInGPU.hitIndices, maxMDsPerModule * nModules * 3 * sizeof(unsigned int));
-    cudaMallocManaged(&mdsInGPU.pixelModuleFlag, maxMDsPerModule * nModules * sizeof(short));
-    cudaMallocManaged(&mdsInGPU.dphichanges, maxMDsPerModule * nModules * 9 * sizeof(float));
+    cudaMallocManaged(&mdsInGPU.hitIndices, nMemoryLocations * 3 * sizeof(unsigned int));
+    cudaMallocManaged(&mdsInGPU.pixelModuleFlag, nMemoryLocations * sizeof(short));
+    cudaMallocManaged(&mdsInGPU.dphichanges, nMemoryLocations * 9 * sizeof(float));
     cudaMallocManaged(&mdsInGPU.nMDs, nModules * sizeof(unsigned int));
 #endif
-    mdsInGPU.moduleIndices = mdsInGPU.hitIndices + maxMDsPerModule * nModules * 2 ;
-    mdsInGPU.dzs  = mdsInGPU.dphichanges + maxMDsPerModule*nModules;
-    mdsInGPU.dphis  = mdsInGPU.dphichanges + 2*maxMDsPerModule*nModules;
-    mdsInGPU.shiftedXs  = mdsInGPU.dphichanges + 3*maxMDsPerModule*nModules;
-    mdsInGPU.shiftedYs  = mdsInGPU.dphichanges + 4*maxMDsPerModule*nModules;
-    mdsInGPU.shiftedZs  = mdsInGPU.dphichanges + 5*maxMDsPerModule*nModules;
-    mdsInGPU.noShiftedDzs  = mdsInGPU.dphichanges + 6*maxMDsPerModule*nModules;
-    mdsInGPU.noShiftedDphis  = mdsInGPU.dphichanges + 7*maxMDsPerModule*nModules;
-    mdsInGPU.noShiftedDphiChanges  = mdsInGPU.dphichanges + 8*maxMDsPerModule*nModules;
+    mdsInGPU.moduleIndices = mdsInGPU.hitIndices + nMemoryLocations * 2 ;
+    mdsInGPU.dzs  = mdsInGPU.dphichanges + nMemoryLocations;
+    mdsInGPU.dphis  = mdsInGPU.dphichanges + 2*nMemoryLocations;
+    mdsInGPU.shiftedXs  = mdsInGPU.dphichanges + 3*nMemoryLocations;
+    mdsInGPU.shiftedYs  = mdsInGPU.dphichanges + 4*nMemoryLocations;
+    mdsInGPU.shiftedZs  = mdsInGPU.dphichanges + 5*nMemoryLocations;
+    mdsInGPU.noShiftedDzs  = mdsInGPU.dphichanges + 6*nMemoryLocations;
+    mdsInGPU.noShiftedDphis  = mdsInGPU.dphichanges + 7*nMemoryLocations;
+    mdsInGPU.noShiftedDphiChanges  = mdsInGPU.dphichanges + 8*nMemoryLocations;
 #pragma omp parallel for default(shared)
     for(size_t i = 0; i< nModules; i++)
     {
@@ -55,6 +57,8 @@ void SDL::createMDsInUnifiedMemory(struct miniDoublets& mdsInGPU, unsigned int m
     }
 }
 
+
+//FIXME:Add memory locations for the pixel MDs here!
 void SDL::createMDsInExplicitMemory(struct miniDoublets& mdsInGPU, unsigned int maxMDsPerModule, unsigned int nModules)
 {
 
@@ -95,7 +99,7 @@ void SDL::createMDsInExplicitMemory(struct miniDoublets& mdsInGPU, unsigned int 
 
 }
 
-__device__ void SDL::addMDToMemory(struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int lowerHitIdx, unsigned int upperHitIdx, unsigned int lowerModuleIdx, float dz, float dPhi, float dPhiChange, float shiftedX, float shiftedY, float shiftedZ, float noShiftedDz, float noShiftedDphi, float noShiftedDPhiChange, unsigned int idx)
+__host__ __device__ void SDL::addMDToMemory(struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int lowerHitIdx, unsigned int upperHitIdx, unsigned int lowerModuleIdx, float dz, float dPhi, float dPhiChange, float shiftedX, float shiftedY, float shiftedZ, float noShiftedDz, float noShiftedDphi, float noShiftedDPhiChange, unsigned int idx)
 {
     //the index into which this MD needs to be written will be computed in the kernel
     //nMDs variable will be incremented in the kernel, no need to worry about that here

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -53,10 +53,10 @@ namespace SDL
 
 
 
-    void createMDsInUnifiedMemory(struct miniDoublets& mdsInGPU, unsigned int maxMDs,unsigned int nModules);
+    void createMDsInUnifiedMemory(struct miniDoublets& mdsInGPU, unsigned int maxMDs,unsigned int nModules, unsigned int maxPixelMDs);
     void createMDsInExplicitMemory(struct miniDoublets& mdsInGPU, unsigned int maxMDs,unsigned int nModules);
     //for successful MDs
-    CUDA_DEV void addMDToMemory(struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int lowerHitIdx, unsigned int upperHitIdx, unsigned int lowerModuleIdx, float dz, float dphi, float dphichange, float shfitedX, float shiftedY, float shiftedZ, float noShiftedDz, float noShiftedDphi, float noShiftedDPhiChange, unsigned int idx);
+    CUDA_HOSTDEV void addMDToMemory(struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int lowerHitIdx, unsigned int upperHitIdx, unsigned int lowerModuleIdx, float dz, float dphi, float dphichange, float shfitedX, float shiftedY, float shiftedZ, float noShiftedDz, float noShiftedDphi, float noShiftedDPhiChange, unsigned int idx);
 
     CUDA_DEV float dPhiThreshold(struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int hitIndex, unsigned int moduleIndex, float dPhi = 0, float dz = 0);
     CUDA_DEV extern inline float isTighterTiltedModules(struct modules& modulesInGPU, unsigned int moduleIndex);

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -65,7 +65,9 @@ void SDL::freeModulesInUnifiedMemory(struct modules& modulesInGPU)
 
 void SDL::createLowerModuleIndexMap(struct modules& modulesInGPU, unsigned int nLowerModules, unsigned int nModules)
 {
-    cudaMallocManaged(&modulesInGPU.lowerModuleIndices,nLowerModules * sizeof(unsigned int));
+    //FIXME:some hacks to get the pixel module in hte lower modules index without incrementing nLowerModules counter!
+    //Reproduce these hacks in the explicit memory for identical results (or come up with a better method)
+    cudaMallocManaged(&modulesInGPU.lowerModuleIndices,(nLowerModules + 1) * sizeof(unsigned int));
     cudaMallocManaged(&modulesInGPU.reverseLookupLowerModuleIndices,nModules * sizeof(int));
 
     unsigned int lowerModuleCounter = 0;
@@ -84,6 +86,10 @@ void SDL::createLowerModuleIndexMap(struct modules& modulesInGPU, unsigned int n
             modulesInGPU.reverseLookupLowerModuleIndices[index] = -1;
         }
     }
+    //hacky stuff "beyond the index" for the pixel module. nLowerModules will *NOT* cover the pixel module!
+    modulesInGPU.lowerModuleIndices[nLowerModules] = (*detIdToIndex)[1];
+    modulesInGPU.reverseLookupLowerModuleIndices[(*detIdToIndex)[1]] = nLowerModules;
+
 }
 
 void SDL::loadModulesFromFile(struct modules& modulesInGPU, unsigned int& nModules)
@@ -117,6 +123,9 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, unsigned int& nModul
             counter++;
         }
     }
+    //MANUAL INSERTION OF PIXEL MODULE!
+    (*detIdToIndex)[1] = counter; //pixel module is the last module in the module list
+    counter++;
     nModules = counter;
     std::cout<<"Number of modules = "<<nModules<<std::endl;
 
@@ -127,28 +136,46 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, unsigned int& nModul
         unsigned int detId = it->first;
         unsigned int index = it->second;
         modulesInGPU.detIds[index] = detId;
-        unsigned short layer,ring,rod,module,subdet,side;
-        setDerivedQuantities(detId,layer,ring,rod,module,subdet,side);
-        modulesInGPU.layers[index] = layer;
-        modulesInGPU.rings[index] = ring;
-        modulesInGPU.rods[index] = rod;
-        modulesInGPU.modules[index] = module;
-        modulesInGPU.subdets[index] = subdet;
-        modulesInGPU.sides[index] = side;
+        if(detId == 1)
+        {
+            modulesInGPU.layers[index] = 0;
+            modulesInGPU.rings[index] = 0;
+            modulesInGPU.rods[index] = 0;
+            modulesInGPU.modules[index] = 0;
+            modulesInGPU.subdets[index] = SDL::InnerPixel;
+            modulesInGPU.sides[index] = 0;
+            modulesInGPU.isInverted[index] = 0;
+            modulesInGPU.isLower[index] = false;
+            modulesInGPU.moduleType[index] = PixelModule;
+            modulesInGPU.moduleLayerType[index] = SDL::InnerPixelLayer;
+            modulesInGPU.slopes[index] = 0;
+            modulesInGPU.drdzs[index] = 0;
+        }
+        else
+        {
+            unsigned short layer,ring,rod,module,subdet,side;
+            setDerivedQuantities(detId,layer,ring,rod,module,subdet,side);
+            modulesInGPU.layers[index] = layer;
+            modulesInGPU.rings[index] = ring;
+            modulesInGPU.rods[index] = rod;
+            modulesInGPU.modules[index] = module;
+            modulesInGPU.subdets[index] = subdet;
+            modulesInGPU.sides[index] = side;
 
-        modulesInGPU.isInverted[index] = modulesInGPU.parseIsInverted(index);
-        modulesInGPU.isLower[index] = modulesInGPU.parseIsLower(index);
+            modulesInGPU.isInverted[index] = modulesInGPU.parseIsInverted(index);
+            modulesInGPU.isLower[index] = modulesInGPU.parseIsLower(index);
 
-        modulesInGPU.moduleType[index] = modulesInGPU.parseModuleType(index);
-        modulesInGPU.moduleLayerType[index] = modulesInGPU.parseModuleLayerType(index);
+            modulesInGPU.moduleType[index] = modulesInGPU.parseModuleType(index);
+            modulesInGPU.moduleLayerType[index] = modulesInGPU.parseModuleLayerType(index);
 
-        modulesInGPU.slopes[index] = (subdet == Endcap) ? endcapGeometry.getSlopeLower(detId) : tiltedGeometry.getSlope(detId);
-        modulesInGPU.drdzs[index] = (subdet == Barrel) ? tiltedGeometry.getDrDz(detId) : 0;
+            modulesInGPU.slopes[index] = (subdet == Endcap) ? endcapGeometry.getSlopeLower(detId) : tiltedGeometry.getSlope(detId);
+            modulesInGPU.drdzs[index] = (subdet == Barrel) ? tiltedGeometry.getDrDz(detId) : 0;
+        }
         if(modulesInGPU.isLower[index]) lowerModuleCounter++;
     }
 
     *modulesInGPU.nLowerModules = lowerModuleCounter;
-    std::cout<<"number of lower modules = "<<*modulesInGPU.nLowerModules<<std::endl;
+    std::cout<<"number of lower modules (without fake pixel module)= "<<*modulesInGPU.nLowerModules<<std::endl;
     createLowerModuleIndexMap(modulesInGPU,lowerModuleCounter, nModules);
     fillConnectedModuleArray(modulesInGPU,nModules);
     resetObjectRanges(modulesInGPU,nModules);

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -65,7 +65,7 @@ void SDL::freeModulesInUnifiedMemory(struct modules& modulesInGPU)
 
 void SDL::createLowerModuleIndexMap(struct modules& modulesInGPU, unsigned int nLowerModules, unsigned int nModules)
 {
-    //FIXME:some hacks to get the pixel module in hte lower modules index without incrementing nLowerModules counter!
+    //FIXME:some hacks to get the pixel module in the lower modules index without incrementing nLowerModules counter!
     //Reproduce these hacks in the explicit memory for identical results (or come up with a better method)
     cudaMallocManaged(&modulesInGPU.lowerModuleIndices,(nLowerModules + 1) * sizeof(unsigned int));
     cudaMallocManaged(&modulesInGPU.reverseLookupLowerModuleIndices,nModules * sizeof(int));
@@ -123,7 +123,7 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, unsigned int& nModul
             counter++;
         }
     }
-    //MANUAL INSERTION OF PIXEL MODULE!
+    //FIXME:MANUAL INSERTION OF PIXEL MODULE!
     (*detIdToIndex)[1] = counter; //pixel module is the last module in the module list
     counter++;
     nModules = counter;

--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -20,6 +20,7 @@ namespace SDL
 {
     enum SubDet
     {
+        InnerPixel = 0,
         Barrel = 5,
         Endcap = 4
     };
@@ -32,13 +33,15 @@ namespace SDL
     enum ModuleType
     {
         PS,
-        TwoS
+        TwoS,
+        PixelModule
     };
 
     enum ModuleLayerType
     {
         Pixel,
-        Strip
+        Strip,
+        InnerPixelLayer
     };
 
 

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -18,7 +18,7 @@ void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned
 #else
     cudaMallocManaged(&segmentsInGPU.mdIndices, nMemoryLocations * 6 * sizeof(unsigned int));
     cudaMallocManaged(&segmentsInGPU.nSegments, nModules * sizeof(unsigned int));
-    cudaMallocManaged(&segmentsInGPU.dPhis, nMemoryLocations * 13*sizeof(float));
+    cudaMallocManaged(&segmentsInGPU.dPhis, (nMemoryLocations * 13 + maxPixelSegments * 6)*sizeof(float));
 #endif
     segmentsInGPU.innerLowerModuleIndices = segmentsInGPU.mdIndices + nMemoryLocations * 2;
     segmentsInGPU.outerLowerModuleIndices = segmentsInGPU.mdIndices + nMemoryLocations * 3;

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -3,35 +3,49 @@
 #include "allocate.h"
 //#endif
 
-void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned int maxSegments, unsigned int nModules)
+///FIXME:NOTICE THE NEW maxPixelSegments!
+
+void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned int maxSegments, unsigned int nModules, unsigned int maxPixelSegments)
 {
+    //FIXME:Since the number of pixel segments is 10x the number of regular segments per module, we need to provide
+    //extra memory to the pixel segments
+    unsigned int nMemoryLocations = maxSegments * (nModules - 1) + maxPixelSegments;
 #ifdef CACHE_ALLOC
     cudaStream_t stream=0; 
-    segmentsInGPU.mdIndices = (unsigned int*)cms::cuda::allocate_managed(maxSegments*nModules*6 *sizeof(unsigned int),stream);
+    segmentsInGPU.mdIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations*6 *sizeof(unsigned int),stream);
     segmentsInGPU.nSegments = (unsigned int*)cms::cuda::allocate_managed(nModules *sizeof(unsigned int),stream);
-    segmentsInGPU.dPhis = (float*)cms::cuda::allocate_managed(maxSegments*nModules*13 *sizeof(float),stream);
+    segmentsInGPU.dPhis = (float*)cms::cuda::allocate_managed((nMemoryLocations*13 + maxPixelSegments * 6) *sizeof(float),stream);
 #else
-    cudaMallocManaged(&segmentsInGPU.mdIndices, maxSegments * nModules * 6 * sizeof(unsigned int));
+    cudaMallocManaged(&segmentsInGPU.mdIndices, nMemoryLocations * 6 * sizeof(unsigned int));
     cudaMallocManaged(&segmentsInGPU.nSegments, nModules * sizeof(unsigned int));
-    cudaMallocManaged(&segmentsInGPU.dPhis, maxSegments * nModules * 13*sizeof(float));
+    cudaMallocManaged(&segmentsInGPU.dPhis, nMemoryLocations * 13*sizeof(float));
 #endif
-    segmentsInGPU.innerLowerModuleIndices = segmentsInGPU.mdIndices + maxSegments *nModules * 2;
-    segmentsInGPU.outerLowerModuleIndices = segmentsInGPU.mdIndices + maxSegments *nModules * 3;
-    segmentsInGPU.innerMiniDoubletAnchorHitIndices = segmentsInGPU.mdIndices + maxSegments *nModules * 4;
-    segmentsInGPU.outerMiniDoubletAnchorHitIndices = segmentsInGPU.mdIndices + maxSegments *nModules * 5;
+    segmentsInGPU.innerLowerModuleIndices = segmentsInGPU.mdIndices + nMemoryLocations * 2;
+    segmentsInGPU.outerLowerModuleIndices = segmentsInGPU.mdIndices + nMemoryLocations * 3;
+    segmentsInGPU.innerMiniDoubletAnchorHitIndices = segmentsInGPU.mdIndices + nMemoryLocations * 4;
+    segmentsInGPU.outerMiniDoubletAnchorHitIndices = segmentsInGPU.mdIndices + nMemoryLocations * 5;
 
-    segmentsInGPU.dPhiMins = segmentsInGPU.dPhis + maxSegments *nModules;
-    segmentsInGPU.dPhiMaxs = segmentsInGPU.dPhis + maxSegments *nModules * 2;
-    segmentsInGPU.dPhiChanges = segmentsInGPU.dPhis + maxSegments *nModules * 3;
-    segmentsInGPU.dPhiChangeMins = segmentsInGPU.dPhis + maxSegments *nModules * 4;
-    segmentsInGPU.dPhiChangeMaxs = segmentsInGPU.dPhis + maxSegments *nModules * 5;
-    segmentsInGPU.zIns  = segmentsInGPU.dPhis + maxSegments *nModules * 6;
-    segmentsInGPU.zOuts = segmentsInGPU.dPhis + maxSegments *nModules * 7;
-    segmentsInGPU.rtIns = segmentsInGPU.dPhis + maxSegments *nModules * 8;
-    segmentsInGPU.rtOuts = segmentsInGPU.dPhis + maxSegments *nModules * 9;
-    segmentsInGPU.dAlphaInnerMDSegments = segmentsInGPU.dPhis + maxSegments *nModules * 10;
-    segmentsInGPU.dAlphaOuterMDSegments = segmentsInGPU.dPhis + maxSegments *nModules * 11;
-    segmentsInGPU.dAlphaInnerMDOuterMDs = segmentsInGPU.dPhis + maxSegments *nModules * 12;
+    segmentsInGPU.dPhiMins = segmentsInGPU.dPhis + nMemoryLocations;
+    segmentsInGPU.dPhiMaxs = segmentsInGPU.dPhis + nMemoryLocations * 2;
+    segmentsInGPU.dPhiChanges = segmentsInGPU.dPhis + nMemoryLocations * 3;
+    segmentsInGPU.dPhiChangeMins = segmentsInGPU.dPhis + nMemoryLocations * 4;
+    segmentsInGPU.dPhiChangeMaxs = segmentsInGPU.dPhis + nMemoryLocations * 5;
+    segmentsInGPU.zIns  = segmentsInGPU.dPhis + nMemoryLocations * 6;
+    segmentsInGPU.zOuts = segmentsInGPU.dPhis + nMemoryLocations * 7;
+    segmentsInGPU.rtIns = segmentsInGPU.dPhis + nMemoryLocations * 8;
+    segmentsInGPU.rtOuts = segmentsInGPU.dPhis + nMemoryLocations * 9;
+    segmentsInGPU.dAlphaInnerMDSegments = segmentsInGPU.dPhis + nMemoryLocations * 10;
+    segmentsInGPU.dAlphaOuterMDSegments = segmentsInGPU.dPhis + nMemoryLocations * 11;
+    segmentsInGPU.dAlphaInnerMDOuterMDs = segmentsInGPU.dPhis + nMemoryLocations * 12;
+
+    //FIXME:pixel dudes
+    segmentsInGPU.ptIn = segmentsInGPU.dPhis + nMemoryLocations * 13;
+    segmentsInGPU.ptErr = segmentsInGPU.dPhis + nMemoryLocations * 13 + maxPixelSegments;
+    segmentsInGPU.px = segmentsInGPU.dPhis + nMemoryLocations * 13 + maxPixelSegments * 2;
+    segmentsInGPU.py = segmentsInGPU.dPhis + nMemoryLocations * 13 + maxPixelSegments * 3;
+    segmentsInGPU.pz = segmentsInGPU.dPhis + nMemoryLocations * 13 + maxPixelSegments * 4;
+    segmentsInGPU.etaErr = segmentsInGPU.dPhis + nMemoryLocations * 13 + maxPixelSegments * 5;
+
 #pragma omp parallel for default(shared)
     for(size_t i = 0; i < nModules; i++)
     {
@@ -160,6 +174,24 @@ __device__ void SDL::addSegmentToMemory(struct segments& segmentsInGPU, unsigned
     segmentsInGPU.dAlphaInnerMDSegments[idx] = dAlphaInnerMDSegment;
     segmentsInGPU.dAlphaOuterMDSegments[idx] = dAlphaOuterMDSegment;
     segmentsInGPU.dAlphaInnerMDOuterMDs[idx] = dAlphaInnerMDOuterMD;
+}
+
+void SDL::addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, unsigned int pixelModuleIndex, unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, unsigned int idx)
+{
+    segmentsInGPU.mdIndices[idx * 2] = innerMDIndex;
+    segmentsInGPU.mdIndices[idx * 2 + 1] = outerMDIndex;
+    segmentsInGPU.innerLowerModuleIndices[idx] = pixelModuleIndex;
+    segmentsInGPU.outerLowerModuleIndices[idx] = pixelModuleIndex;
+    segmentsInGPU.innerMiniDoubletAnchorHitIndices[idx] = innerAnchorHitIndex;
+    segmentsInGPU.outerMiniDoubletAnchorHitIndices[idx] = outerAnchorHitIndex;
+    segmentsInGPU.dPhiChanges[idx] = dPhiChange;
+    unsigned int pixelSegmentArrayIndex = segmentsInGPU.nSegments[pixelModuleIndex]; //since the increment happens only after adding the segment to memory
+    segmentsInGPU.ptIn[pixelSegmentArrayIndex] = ptIn;
+    segmentsInGPU.ptErr[pixelSegmentArrayIndex] = ptErr;
+    segmentsInGPU.px[pixelSegmentArrayIndex] = px;
+    segmentsInGPU.py[pixelSegmentArrayIndex] = py;
+    segmentsInGPU.pz[pixelSegmentArrayIndex] = pz;
+    segmentsInGPU.etaErr[pixelSegmentArrayIndex] = etaErr;
 }
 
 __device__ void SDL::dAlphaThreshold(float* dAlphaThresholdValues, struct hits& hitsInGPU, struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, unsigned int& innerMiniDoubletAnchorHitIndex, unsigned int& outerMiniDoubletAnchorHitIndex, unsigned int& innerLowerModuleIndex, unsigned int& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex)

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -47,12 +47,20 @@ namespace SDL
         float* dAlphaOuterMDSegments;
         float* dAlphaInnerMDOuterMDs;
 
+        //not so optional pixel dudes
+        float* ptIn;
+        float* ptErr;
+        float* px;
+        float* py;
+        float* pz;
+        float* etaErr;
+
         segments();
 	      void freeMemory();
 	      void freeMemoryCache();
     };
 
-    void createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned int maxSegments, unsigned int nModules);
+    void createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned int maxSegments, unsigned int nModules, unsigned int maxPixelSegments);
     void createSegmentsInExplicitMemory(struct segments& segmentsInGPU, unsigned int maxSegments, unsigned int nModules);
 
     CUDA_DEV void dAlphaThreshold(float* dAlphaThresholdValues, struct hits& hitsInGPU, struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, unsigned int& innerMiniDoubletAnchorHitIndex, unsigned int& outerMiniDoubletAnchorHitIndex, unsigned int& innerLowerModuleIndex, unsigned int& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex);
@@ -60,6 +68,9 @@ namespace SDL
    
     CUDA_DEV void addSegmentToMemory(struct segments& segmentsInGPU, unsigned int lowerMDIndex, unsigned int upperMDIndex, unsigned int innerLowerModuleIndex, unsigned int outerLowerModuleIndex, unsigned int innerMDAnchorHitIndex, unsigned int outerMDAnchorHitIndex, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float&
             dAlphaInnerMDOuterMD, unsigned int idx);
+
+    void addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, unsigned int pixelModuleIndex, unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, unsigned int idx);
+
 
 
     CUDA_DEV bool runSegmentDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, unsigned int& innerLowerModuleIndex, unsigned int& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float&

--- a/SDL/Tracklet.cu
+++ b/SDL/Tracklet.cu
@@ -10,26 +10,28 @@
 CUDA_CONST_VAR float SDL::pt_betaMax = 7.0;
 
 
-void SDL::createTrackletsInUnifiedMemory(struct tracklets& trackletsInGPU, unsigned int maxTracklets, unsigned int nLowerModules)
+void SDL::createTrackletsInUnifiedMemory(struct tracklets& trackletsInGPU, unsigned int maxTracklets, unsigned int maxPixelTracklets, unsigned int nLowerModules)
 {
+
+    unsigned int nMemoryLocations = maxTracklets * nLowerModules + maxPixelTracklets;
 #ifdef CACHE_ALLOC
     cudaStream_t stream =0;
-    trackletsInGPU.segmentIndices = (unsigned int*)cms::cuda::allocate_managed(maxTracklets * nLowerModules * sizeof(unsigned int) * 2,stream);
-    trackletsInGPU.lowerModuleIndices = (unsigned int*)cms::cuda::allocate_managed(maxTracklets * nLowerModules * sizeof(unsigned int) * 4,stream);//split up to avoid runtime error of exceeding max byte allocation at a time
+    trackletsInGPU.segmentIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(unsigned int) * 2,stream);
+    trackletsInGPU.lowerModuleIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(unsigned int) * 4,stream);//split up to avoid runtime error of exceeding max byte allocation at a time
     trackletsInGPU.nTracklets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int),stream);
-    trackletsInGPU.zOut = (float*)cms::cuda::allocate_managed(maxTracklets * nLowerModules * sizeof(float) * 4,stream);
-    trackletsInGPU.betaIn = (float*)cms::cuda::allocate_managed(maxTracklets * nLowerModules * sizeof(float) * 2,stream);
+    trackletsInGPU.zOut = (float*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(float) * 4,stream);
+    trackletsInGPU.betaIn = (float*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(float) * 2,stream);
 #else
-    cudaMallocManaged(&trackletsInGPU.segmentIndices, 2 * maxTracklets * nLowerModules * sizeof(unsigned int));
-    cudaMallocManaged(&trackletsInGPU.lowerModuleIndices, 4 * maxTracklets * nLowerModules * sizeof(unsigned int));
+    cudaMallocManaged(&trackletsInGPU.segmentIndices, 2 * nMemoryLocations * sizeof(unsigned int));
+    cudaMallocManaged(&trackletsInGPU.lowerModuleIndices, 4 * nMemoryLocations * sizeof(unsigned int));
     cudaMallocManaged(&trackletsInGPU.nTracklets,nLowerModules * sizeof(unsigned int));
-    cudaMallocManaged(&trackletsInGPU.zOut, maxTracklets * nLowerModules *4* sizeof(float));
-    cudaMallocManaged(&trackletsInGPU.betaIn, maxTracklets * nLowerModules *2* sizeof(float));
+    cudaMallocManaged(&trackletsInGPU.zOut, nMemoryLocations *4* sizeof(float));
+    cudaMallocManaged(&trackletsInGPU.betaIn, nMemoryLocations *2* sizeof(float));
 #endif
     trackletsInGPU.rtOut = trackletsInGPU.zOut + maxTracklets * nLowerModules;
-    trackletsInGPU.deltaPhiPos = trackletsInGPU.zOut + maxTracklets * nLowerModules * 2;
-    trackletsInGPU.deltaPhi = trackletsInGPU.zOut + maxTracklets * nLowerModules * 3;
-    trackletsInGPU.betaOut = trackletsInGPU.betaIn + maxTracklets * nLowerModules;
+    trackletsInGPU.deltaPhiPos = trackletsInGPU.zOut + nMemoryLocations * 2;
+    trackletsInGPU.deltaPhi = trackletsInGPU.zOut + nMemoryLocations * 3;
+    trackletsInGPU.betaOut = trackletsInGPU.betaIn + nMemoryLocations;
 #pragma omp parallel for
     for(size_t i = 0; i<nLowerModules;i++)
     {
@@ -140,7 +142,8 @@ void SDL::tracklets::freeMemory()
     cudaFree(betaIn);
 }
 
-__device__ bool SDL::runTrackletDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, unsigned int innerInnerLowerModuleIndex, unsigned int innerOuterLowerModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float& betaOut)
+__device__ bool SDL::runTrackletDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, unsigned int innerInnerLowerModuleIndex, unsigned int innerOuterLowerModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float&
+        betaOut, unsigned int N_MAX_SEGMENTS_PER_MODULE)
 {
 
     bool pass = false;
@@ -150,8 +153,23 @@ __device__ bool SDL::runTrackletDefaultAlgo(struct modules& modulesInGPU, struct
     short outerInnerLowerModuleSubdet = modulesInGPU.subdets[outerInnerLowerModuleIndex];
     short outerOuterLowerModuleSubdet = modulesInGPU.subdets[outerOuterLowerModuleIndex];
 
+    if(innerInnerLowerModuleSubdet == SDL::InnerPixel) 
+    {
+        if(outerInnerLowerModuleSubdet == SDL::Barrel and outerOuterLowerModuleSubdet == SDL::Barrel)
+        {
+            pass = runTrackletDefaultAlgoPPBB(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, innerInnerLowerModuleIndex, outerInnerLowerModuleIndex, outerOuterLowerModuleIndex, innerSegmentIndex, outerSegmentIndex,zOut,rtOut,deltaPhiPos,deltaPhi,betaIn,betaOut,N_MAX_SEGMENTS_PER_MODULE);     
+        }
+        else if(outerInnerLowerModuleSubdet == SDL::Barrel and outerOuterLowerModuleSubdet == SDL::Endcap)
+        {
+            pass = runTrackletDefaultAlgoPPBB(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, innerInnerLowerModuleIndex, outerInnerLowerModuleIndex, outerOuterLowerModuleIndex, innerSegmentIndex, outerSegmentIndex,zOut,rtOut,deltaPhiPos,deltaPhi,betaIn,betaOut,N_MAX_SEGMENTS_PER_MODULE);     
+        }
+        else if(outerInnerLowerModuleSubdet == SDL::Endcap and outerOuterLowerModuleSubdet == SDL::Endcap)
+        {
+	    pass = runTrackletDefaultAlgoPPEE(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, innerInnerLowerModuleIndex, outerInnerLowerModuleIndex, outerOuterLowerModuleIndex, innerSegmentIndex, outerSegmentIndex,zOut,rtOut,deltaPhiPos,deltaPhi,betaIn,betaOut,N_MAX_SEGMENTS_PER_MODULE);
+        }
+    }
 
-    if(innerInnerLowerModuleSubdet == SDL::Barrel
+    else if(innerInnerLowerModuleSubdet == SDL::Barrel
             and innerOuterLowerModuleSubdet == SDL::Barrel
             and outerInnerLowerModuleSubdet == SDL::Barrel
             and outerOuterLowerModuleSubdet == SDL::Barrel)
@@ -932,8 +950,496 @@ __device__ bool SDL::runTrackletDefaultAlgoEEEE(struct modules& modulesInGPU, st
 }
 
 
+__device__ bool SDL::runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU ,struct segments& segmentsInGPU, unsigned int pixelModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& dPhiPos, float& dPhi, float& betaIn, float& betaOut, unsigned int
+        N_MAX_SEGMENTS_PER_MODULE) // pixel to BB and BE segments
+{
+    bool pass = true;
+
+    bool isPS_OutLo = (modulesInGPU.moduleType[outerInnerLowerModuleIndex] == SDL::PS);
+    unsigned int innerInnerAnchorHitIndex = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerSegmentIndex];
+
+    unsigned int outerInnerAnchorHitIndex = segmentsInGPU.innerMiniDoubletAnchorHitIndices[outerSegmentIndex];
+
+    unsigned int innerOuterAnchorHitIndex = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerSegmentIndex];
+    unsigned int outerOuterAnchorHitIndex= segmentsInGPU.outerMiniDoubletAnchorHitIndices[outerSegmentIndex];
+    if(fabsf(deltaPhi(hitsInGPU.xs[innerOuterAnchorHitIndex], hitsInGPU.ys[innerOuterAnchorHitIndex], hitsInGPU.zs[innerOuterAnchorHitIndex], hitsInGPU.xs[outerInnerAnchorHitIndex], hitsInGPU.ys[outerInnerAnchorHitIndex], hitsInGPU.zs[outerInnerAnchorHitIndex])) > M_PI/2.)
+    {
+        pass = false;
+    }
+
+    unsigned int pixelSegmentArrayIndex = innerSegmentIndex - (pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE);
+    float ptIn = segmentsInGPU.ptIn[pixelSegmentArrayIndex];
+    float ptSLo = ptIn;
+    float px = segmentsInGPU.px[pixelSegmentArrayIndex];   
+    float py = segmentsInGPU.py[pixelSegmentArrayIndex];
+    float pz = segmentsInGPU.pz[pixelSegmentArrayIndex];
+    float ptErr = segmentsInGPU.ptErr[pixelSegmentArrayIndex];
+    float etaErr = segmentsInGPU.etaErr[pixelSegmentArrayIndex];
+    ptSLo = fmaxf(PTCUT, ptSLo - 10.0f*fmaxf(ptErr, 0.005f*ptSLo));
+    ptSLo = fminf(10.0f, ptSLo);
+
+    float rt_InLo = hitsInGPU.rts[innerInnerAnchorHitIndex];
+    float rt_InUp = hitsInGPU.rts[innerOuterAnchorHitIndex];
+    float rt_OutLo = hitsInGPU.rts[outerInnerAnchorHitIndex];
+    float z_InLo = hitsInGPU.zs[innerInnerAnchorHitIndex];
+    float z_InUp = hitsInGPU.zs[innerOuterAnchorHitIndex];
+    float z_OutLo = hitsInGPU.zs[outerInnerAnchorHitIndex];
+
+    float rt_InOut = hitsInGPU.rts[innerOuterAnchorHitIndex];
+    float z_InOut = hitsInGPU.zs[innerOuterAnchorHitIndex];
+
+    float alpha1GeV_OutLo = asinf(fminf(rt_OutLo * k2Rinv1GeVf / ptCut, sinAlphaMax));
+    float rtRatio_OutLoInLo = rt_OutLo / rt_InLo; // Outer segment beginning rt divided by inner segment beginning rt;
+    const float rtRatio_OutLoInOut = rt_OutLo / rt_InOut; // Outer segment beginning rt divided by inner segment beginning rt;
+
+    float dzDrtScale = tanf(alpha1GeV_OutLo) / alpha1GeV_OutLo; // The track can bend in r-z plane slightly
+    const float zpitch_InLo = 0.05f;
+    const float zpitch_InOut = 0.05f;
+    float zpitch_OutLo = (isPS_OutLo ? pixelPSZpitch : strip2SZpitch);
+    float zGeom = zpitch_InLo + zpitch_OutLo;
+    float zHi = z_InOut + (z_InOut + deltaZLum) * (rtRatio_OutLoInOut - 1.f) * (z_InOut < 0.f ? 1.f : dzDrtScale) + (zpitch_InOut + zpitch_OutLo);
+    float zLo = z_InOut + (z_InOut - deltaZLum) * (rtRatio_OutLoInOut - 1.f) * (z_InOut > 0.f ? 1.f : dzDrtScale) - (zpitch_InOut + zpitch_OutLo); //slope-correction only on outer end
+
+    if (not (z_OutLo >= zLo and z_OutLo <= zHi))
+    {
+        pass = false;
+    }
+    const float coshEta = sqrtf(ptIn * ptIn + pz * pz) / ptIn;
+    // const float drt_OutLo_InLo = (rt_OutLo - rt_InLo);
+    const float drt_OutLo_InUp = (rt_OutLo - rt_InUp);
+    const float invRt_InLo = 1. / rt_InLo;
+    const float r3_InLo = sqrtf(z_InLo * z_InLo + rt_InLo * rt_InLo);    
+    const float r3_InUp = sqrtf(z_InUp * z_InUp + rt_InUp * rt_InUp);    
+    float drt_InSeg = hitsInGPU.rts[innerOuterAnchorHitIndex] - hitsInGPU.rts[innerInnerAnchorHitIndex];
+    float dz_InSeg = hitsInGPU.zs[innerOuterAnchorHitIndex] - hitsInGPU.zs[innerInnerAnchorHitIndex];
+
+    float dr3_InSeg = sqrtf(hitsInGPU.rts[innerOuterAnchorHitIndex] * hitsInGPU.rts[innerOuterAnchorHitIndex] + hitsInGPU.zs[innerOuterAnchorHitIndex] * hitsInGPU.zs[innerOuterAnchorHitIndex]) - sqrtf(hitsInGPU.rts[innerInnerAnchorHitIndex] * hitsInGPU.rts[innerInnerAnchorHitIndex] + hitsInGPU.zs[innerInnerAnchorHitIndex] * hitsInGPU.zs[innerInnerAnchorHitIndex]);
+    const float sdlThetaMulsF = 0.015f * sqrt(0.1f + 0.2 * (rt_OutLo - rt_InUp) / 50.f) * sqrt(r3_InUp / rt_InUp);
+    const float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; // will need a better guess than x4?
+
+    float dzErr = drt_OutLo_InUp*etaErr*coshEta; //FIXME: check with the calc in the endcap
+    dzErr *= dzErr;
+    dzErr += 0.03f*0.03f; // pixel size x2. ... random for now
+    dzErr *= 9.f; //3 sigma
+    dzErr += sdlMuls*sdlMuls*drt_OutLo_InUp*drt_OutLo_InUp/3.f*coshEta*coshEta;//sloppy
+    dzErr += zGeom*zGeom;
+    dzErr = sqrtf(dzErr);
+
+    const float dzDrIn = pz / ptIn;
+    const float zWindow = dzErr / drt_InSeg * drt_OutLo_InUp + zGeom;
+    const float dzMean = dzDrIn * drt_OutLo_InUp *
+        (1.f + drt_OutLo_InUp * drt_OutLo_InUp * 4 * k2Rinv1GeVf * k2Rinv1GeVf / ptIn /
+         ptIn / 24.f); // with curved path correction
+    // Constructing upper and lower bound
+    float zLoPointed = z_InUp + dzMean - zWindow;
+    float zHiPointed = z_InUp + dzMean + zWindow;
+
+    if (not (z_OutLo >= zLoPointed and z_OutLo <= zHiPointed))
+    {
+        pass = false;
+    }
+    const float sdlPVoff = 0.1f / rt_OutLo;
+    float sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
+
+    dPhiPos = deltaPhi(hitsInGPU.xs[innerOuterAnchorHitIndex], hitsInGPU.ys[innerOuterAnchorHitIndex], hitsInGPU.zs[innerOuterAnchorHitIndex], hitsInGPU.xs[outerOuterAnchorHitIndex], hitsInGPU.ys[outerOuterAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex]);
+    //no dphipos cut
+    float midPointX = (hitsInGPU.xs[innerInnerAnchorHitIndex] + hitsInGPU.xs[outerInnerAnchorHitIndex])/2;
+    float midPointY = (hitsInGPU.ys[innerInnerAnchorHitIndex] + hitsInGPU.ys[outerInnerAnchorHitIndex])/2;
+    float midPointZ = (hitsInGPU.zs[innerInnerAnchorHitIndex] + hitsInGPU.zs[outerInnerAnchorHitIndex])/2;
+
+    float diffX = hitsInGPU.xs[outerInnerAnchorHitIndex] - hitsInGPU.xs[innerInnerAnchorHitIndex];
+    float diffY = hitsInGPU.ys[outerInnerAnchorHitIndex] - hitsInGPU.ys[innerInnerAnchorHitIndex] ;
+    float diffZ = hitsInGPU.zs[outerInnerAnchorHitIndex] - hitsInGPU.zs[innerInnerAnchorHitIndex]; 
+
+    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    if (not (fabsf(dPhi) <= sdlCut))
+    {
+        pass = false;
+    }
+
+    float alpha_InLo = segmentsInGPU.dPhiChanges[innerSegmentIndex];
+    float alpha_OutLo = segmentsInGPU.dPhiChanges[outerSegmentIndex];
+
+    bool isEC_lastLayer = modulesInGPU.subdets[outerOuterLowerModuleIndex] == SDL::Endcap and modulesInGPU.moduleType[outerOuterLowerModuleIndex] == SDL::TwoS;
+
+    unsigned int outerOuterEdgeIndex = hitsInGPU.edge2SMap[outerOuterAnchorHitIndex]; //POTENTIAL NUCLEAR GANDHI
+    float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
+    
+    alpha_OutUp = deltaPhi(hitsInGPU.xs[outerOuterAnchorHitIndex],hitsInGPU.ys[outerOuterAnchorHitIndex],hitsInGPU.zs[outerOuterAnchorHitIndex],hitsInGPU.xs[outerOuterAnchorHitIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex], hitsInGPU.ys[outerOuterAnchorHitIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[outerInnerAnchorHitIndex]);
+
+    alpha_OutUp_highEdge = alpha_OutUp;
+    alpha_OutUp_lowEdge = alpha_OutUp;
+
+    float tl_axis_x = hitsInGPU.xs[outerOuterAnchorHitIndex] - hitsInGPU.xs[innerOuterAnchorHitIndex];
+    float tl_axis_y = hitsInGPU.ys[outerOuterAnchorHitIndex] - hitsInGPU.ys[innerOuterAnchorHitIndex];
+    float tl_axis_z = hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[innerOuterAnchorHitIndex];
+
+    float tl_axis_highEdge_x = tl_axis_x;
+    float tl_axis_highEdge_y = tl_axis_y;
+    float tl_axis_highEdge_z = tl_axis_z;
+
+    float tl_axis_lowEdge_x = tl_axis_x;
+    float tl_axis_lowEdge_y = tl_axis_y;
+    float tl_axis_lowEdge_z = tl_axis_z;
+
+    betaIn = -deltaPhi(px, py, pz, tl_axis_x, tl_axis_y, tl_axis_z);
+    float betaInRHmin = betaIn;
+    float betaInRHmax = betaIn;
+    betaOut = -alpha_OutUp + deltaPhi(hitsInGPU.xs[outerOuterAnchorHitIndex], hitsInGPU.ys[outerOuterAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+
+    float betaOutRHmin = betaOut;
+    float betaOutRHmax = betaOut;
+
+    if(isEC_lastLayer)
+    {
+        alpha_OutUp_highEdge = deltaPhi(hitsInGPU.highEdgeXs[outerOuterEdgeIndex],hitsInGPU.highEdgeYs[outerOuterEdgeIndex],hitsInGPU.zs[outerOuterAnchorHitIndex],hitsInGPU.highEdgeXs[outerOuterEdgeIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex], hitsInGPU.highEdgeYs[outerOuterEdgeIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[outerInnerAnchorHitIndex]);
+
+        alpha_OutUp_lowEdge = deltaPhi(hitsInGPU.lowEdgeXs[outerOuterEdgeIndex],hitsInGPU.lowEdgeYs[outerOuterEdgeIndex],hitsInGPU.zs[outerOuterAnchorHitIndex],hitsInGPU.lowEdgeXs[outerOuterEdgeIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex], hitsInGPU.lowEdgeYs[outerOuterEdgeIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[outerInnerAnchorHitIndex]);
+
+        tl_axis_highEdge_x = hitsInGPU.highEdgeXs[outerOuterEdgeIndex] - hitsInGPU.xs[innerOuterAnchorHitIndex];
+        tl_axis_highEdge_y = hitsInGPU.highEdgeYs[outerOuterEdgeIndex] - hitsInGPU.ys[innerOuterAnchorHitIndex];
+        tl_axis_highEdge_z = hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[innerOuterAnchorHitIndex];
+
+        tl_axis_lowEdge_x = hitsInGPU.lowEdgeXs[outerOuterEdgeIndex] - hitsInGPU.xs[innerOuterAnchorHitIndex];
+        tl_axis_lowEdge_y = hitsInGPU.lowEdgeYs[outerOuterEdgeIndex] - hitsInGPU.ys[innerOuterAnchorHitIndex];
+        tl_axis_lowEdge_z = hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[innerOuterAnchorHitIndex];
+
+        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(hitsInGPU.highEdgeXs[outerOuterEdgeIndex], hitsInGPU.highEdgeYs[outerOuterEdgeIndex], hitsInGPU.zs[outerOuterAnchorHitIndex], tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_highEdge_z);
+
+        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(hitsInGPU.lowEdgeXs[outerOuterEdgeIndex], hitsInGPU.lowEdgeYs[outerOuterEdgeIndex], hitsInGPU.zs[outerOuterAnchorHitIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_lowEdge_z);
+    }
+
+    //beta computation
+    float drt_tl_axis = sqrtf(tl_axis_x * tl_axis_x + tl_axis_y * tl_axis_y);
+    float drt_tl_lowEdge = sqrtf(tl_axis_lowEdge_x * tl_axis_lowEdge_x + tl_axis_lowEdge_y * tl_axis_lowEdge_y);
+    float drt_tl_highEdge = sqrtf(tl_axis_highEdge_x * tl_axis_highEdge_x + tl_axis_highEdge_y * tl_axis_highEdge_y);
+
+    //innerOuterAnchor - innerInnerAnchor
+    const float rt_InSeg = sqrtf((hitsInGPU.xs[innerOuterAnchorHitIndex] - hitsInGPU.xs[innerInnerAnchorHitIndex]) * (hitsInGPU.xs[innerOuterAnchorHitIndex] - hitsInGPU.xs[innerInnerAnchorHitIndex]) + (hitsInGPU.ys[innerOuterAnchorHitIndex] - hitsInGPU.ys[innerInnerAnchorHitIndex]) * (hitsInGPU.ys[innerOuterAnchorHitIndex] - hitsInGPU.ys[innerInnerAnchorHitIndex]));
+
+    //no betaIn cut for the pixels
+    float betaAv = 0.5f * (betaIn + betaOut);
+    float pt_beta = ptIn;
+
+    const float pt_betaMax = 7.0f;
+
+    int lIn = 0;
+    int lOut = isEC_lastLayer ? 11 : 5;
+    float sdOut_dr = sqrtf((hitsInGPU.xs[outerOuterAnchorHitIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex]) * (hitsInGPU.xs[outerOuterAnchorHitIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex]) + (hitsInGPU.ys[outerOuterAnchorHitIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex]) * (hitsInGPU.ys[outerOuterAnchorHitIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex]));
+    float sdOut_d = hitsInGPU.rts[outerOuterAnchorHitIndex] - hitsInGPU.rts[outerInnerAnchorHitIndex];
+
+    const float diffDr = fabsf(rt_InSeg - sdOut_dr) / fabsf(rt_InSeg + sdOut_dr);
+
+    runDeltaBetaIterations(betaIn, betaOut, betaAv, pt_beta, rt_InSeg, sdOut_dr, drt_tl_axis, lIn);
+
+     const float betaInMMSF = (fabsf(betaInRHmin + betaInRHmax) > 0) ? (2.f * betaIn / fabsf(betaInRHmin + betaInRHmax)) : 0.; //mean value of min,max is the old betaIn
+    const float betaOutMMSF = (fabsf(betaOutRHmin + betaOutRHmax) > 0) ? (2.f * betaOut / fabsf(betaOutRHmin + betaOutRHmax)) : 0.;
+    betaInRHmin *= betaInMMSF;
+    betaInRHmax *= betaInMMSF;
+    betaOutRHmin *= betaOutMMSF;
+    betaOutRHmax *= betaOutMMSF;
+
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+
+    float sdIn_rt = hitsInGPU.rts[innerOuterAnchorHitIndex];
+    float sdOut_rt = hitsInGPU.rts[outerInnerAnchorHitIndex];
+    float sdIn_z = hitsInGPU.zs[innerOuterAnchorHitIndex];
+    float sdOut_z = hitsInGPU.zs[outerInnerAnchorHitIndex];
+    const float alphaInAbsReg =  fmaxf(fabsf(alpha_InLo), asinf(fminf(sdIn_rt * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
+    const float alphaOutAbsReg = fmaxf(fabsf(alpha_OutLo), asinf(fminf(sdOut_rt * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
+    const float dBetaInLum = lIn < 11 ? 0.0f : fabsf(alphaInAbsReg*deltaZLum / sdIn_z);
+    const float dBetaOutLum = lOut < 11 ? 0.0f : fabsf(alphaOutAbsReg*deltaZLum / sdOut_z);
+    const float dBetaLum2 = (dBetaInLum + dBetaOutLum) * (dBetaInLum + dBetaOutLum);
+
+    const float sinDPhi = sinf(dPhi);
+    const float dBetaRIn2 = 0; // TODO-RH
+
+    float dBetaROut = 0;
+    if(isEC_lastLayer)
+    {
+        dBetaROut = (sqrtf(hitsInGPU.highEdgeXs[outerOuterEdgeIndex] * hitsInGPU.highEdgeXs[outerOuterEdgeIndex] + hitsInGPU.highEdgeYs[outerOuterEdgeIndex] * hitsInGPU.highEdgeYs[outerOuterEdgeIndex]) - sqrtf(hitsInGPU.lowEdgeXs[outerOuterEdgeIndex] * hitsInGPU.lowEdgeXs[outerOuterEdgeIndex] + hitsInGPU.lowEdgeYs[outerOuterEdgeIndex] * hitsInGPU.lowEdgeYs[outerOuterEdgeIndex])) * sinDPhi / drt_tl_axis;
+    }
+
+    const float dBetaROut2 =  dBetaROut * dBetaROut;
+
+    float betaOutCut = asinf(fminf(drt_tl_axis*k2Rinv1GeVf / ptCut, sinAlphaMax)) //FIXME: need faster version
+        + (0.02f / sdOut_d) + sqrtf(dBetaLum2 + dBetaMuls*dBetaMuls);
+
+    //Cut #6: The real beta cut
+    if (not (fabsf(betaOut) < betaOutCut))
+    {
+        pass = false;
+    }
+
+    const float pt_betaOut = drt_tl_axis * k2Rinv1GeVf / sin(betaOut);
+    const float dBetaRes = 0.02f / fminf(sdOut_d, drt_InSeg);
+    const float dBetaCut2 = (dBetaRes*dBetaRes * 2.0f + dBetaMuls * dBetaMuls + dBetaLum2 + dBetaRIn2 + dBetaROut2
+            + 0.25 * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
+    float dBeta = betaIn - betaOut;
+    float deltaBetaCut = sqrtf(dBetaCut2);
+    if (not (dBeta * dBeta <= dBetaCut2))
+    {
+        //printf("dBeta2 = %f, dBetaCut2 = %f\n",dBeta * dBeta, dBetaCut2);
+        pass = false;
+    }
+
+    return pass;
+}
+
+__device__ bool SDL::runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU ,struct segments& segmentsInGPU, unsigned int pixelModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& dPhi, float& betaIn, float& betaOut, unsigned int
+        N_MAX_SEGMENTS_PER_MODULE) // pixel to EE segments
+{
+    bool pass = true;
+    bool isPS_OutLo = (modulesInGPU.moduleType[outerInnerLowerModuleIndex] == SDL::PS);
+    unsigned int innerInnerAnchorHitIndex = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerSegmentIndex];
+
+    unsigned int outerInnerAnchorHitIndex = segmentsInGPU.innerMiniDoubletAnchorHitIndices[outerSegmentIndex];
+
+    unsigned int innerOuterAnchorHitIndex = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerSegmentIndex];
+    unsigned int outerOuterAnchorHitIndex= segmentsInGPU.outerMiniDoubletAnchorHitIndices[outerSegmentIndex];
+    unsigned int pixelSegmentArrayIndex = innerSegmentIndex - (pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE);
+    float ptIn = segmentsInGPU.ptIn[pixelSegmentArrayIndex];
+    float ptSLo = ptIn;
+    float px = segmentsInGPU.px[pixelSegmentArrayIndex];   
+    float py = segmentsInGPU.py[pixelSegmentArrayIndex];
+    float pz = segmentsInGPU.pz[pixelSegmentArrayIndex];
+    float ptErr = segmentsInGPU.ptErr[pixelSegmentArrayIndex];
+    float etaErr = segmentsInGPU.etaErr[pixelSegmentArrayIndex];
+
+    ptSLo = fmaxf(PTCUT, ptSLo - 10.0f*fmaxf(ptErr, 0.005f*ptSLo));
+    ptSLo = fminf(10.0f, ptSLo);
+    float rtIn = hitsInGPU.rts[innerOuterAnchorHitIndex];
+    rtOut = hitsInGPU.rts[outerInnerAnchorHitIndex];
+    float zIn = hitsInGPU.zs[innerOuterAnchorHitIndex];
+    zOut = hitsInGPU.zs[outerInnerAnchorHitIndex];
+    float rtOut_o_rtIn = rtOut/rtIn;
+    const float zpitch_InLo = 0.05f;
+    float zpitch_OutLo = (isPS_OutLo ? pixelPSZpitch : strip2SZpitch);
+    float zGeom = zpitch_InLo + zpitch_OutLo;
+
+    const float sdlSlope = asinf(fminf(rtOut * k2Rinv1GeVf / ptCut, sinAlphaMax));
+    const float dzDrtScale = tanf(sdlSlope) / sdlSlope;//FIXME: need approximate value
+    float zLo = zIn + (zIn - deltaZLum) * (rtOut_o_rtIn - 1.f) * (zIn > 0.f ? 1.f : dzDrtScale) - zGeom; //slope-correction only on outer end
+
+    if (not (zIn * zOut > 0))
+    {
+        pass = false;
+    }
+
+    const float dLum = copysignf(deltaZLum, zIn);
+    bool isOutSgInnerMDPS = modulesInGPU.moduleType[outerInnerLowerModuleIndex] == SDL::PS;
+
+    const float rtGeom1 = isOutSgInnerMDPS ? pixelPSZpitch : strip2SZpitch;//FIXME: make this chosen by configuration for lay11,12 full PS
+    const float zGeom1 = copysignf(zGeom, zIn); //used in B-E region
+    float rtLo = rtIn * (1.f + (zOut - zIn - zGeom1) / (zIn + zGeom1 + dLum) / dzDrtScale) - rtGeom1; //slope correction only on the lower end
+
+    if (not (rtOut >= rtLo))
+    {
+        pass = false;
+    }
+
+    float zInForHi = zIn - zGeom1 - dLum;
+    if (zInForHi * zIn < 0)
+        zInForHi = copysignf(0.1f, zIn);
+    float rtHi = rtIn * (1.f + (zOut - zIn + zGeom1) / zInForHi) + rtGeom1;
+
+    // Cut #2: rt condition
+    if (not (rtOut >= rtLo and rtOut <= rtHi))
+    {
+        pass = false;
+    }
+
+    const float rt_InUp = hitsInGPU.rts[innerOuterAnchorHitIndex];
+    const float rt_OutLo = hitsInGPU.rts[outerInnerAnchorHitIndex];
+    const float z_InUp = hitsInGPU.zs[innerOuterAnchorHitIndex];    
+    const float dzOutInAbs = fabsf(zOut - zIn);
+    const float coshEta = hypotf(ptIn, pz) / ptIn;
+    const float multDzDr = dzOutInAbs*coshEta/(coshEta*coshEta - 1.f);
+    const float r3_InUp = sqrtf(z_InUp * z_InUp + rt_InUp * rt_InUp);
+    const float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2 * (rt_OutLo - rtIn) / 50.f) * sqrtf(r3_InUp / rtIn);
+    const float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; // will need a better guess than x4?
+
+    float drtErr = etaErr*multDzDr;
+    drtErr *= drtErr;
+    drtErr += 0.03f*0.03f; // pixel size x2. ... random for now
+    drtErr *= 9.f; //3 sigma
+    drtErr += sdlMuls*sdlMuls*multDzDr*multDzDr/3.f*coshEta*coshEta;//sloppy: relative muls is 1/3 of total muls
+    drtErr = sqrtf(drtErr);
+    const float drtDzIn = fabsf(ptIn / pz);//all tracks are out-going in endcaps?
+
+    const float drt_OutLo_InUp = (rt_OutLo - rt_InUp); // drOutIn
+
+    const float rtWindow = drtErr + rtGeom1;
+    const float drtMean = drtDzIn * dzOutInAbs *
+        (1.f - drt_OutLo_InUp * drt_OutLo_InUp * 4 * k2Rinv1GeVf * k2Rinv1GeVf / ptIn /
+         ptIn / 24.f); // with curved path correction
+    const float rtLo_point = rtIn + drtMean - rtWindow;
+    const float rtHi_point = rtIn + drtMean + rtWindow;
+
+    // Cut #3: rt-z pointed
+    if (not (rtOut >= rtLo_point and rtOut <= rtHi_point))
+    {
+        pass = false;
+    }
+
+    const float alpha1GeV_OutLo = asinf(fminf(rt_OutLo * k2Rinv1GeVf / ptCut, sinAlphaMax));
+    const float sdlPVoff = 0.1f / rt_OutLo;
+    float sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
+
+    deltaPhiPos = deltaPhi(hitsInGPU.xs[innerOuterAnchorHitIndex], hitsInGPU.ys[innerOuterAnchorHitIndex], hitsInGPU.zs[innerOuterAnchorHitIndex], hitsInGPU.xs[outerOuterAnchorHitIndex], hitsInGPU.ys[outerOuterAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex]);
+    //no deltaphipos cut
+    float midPointX = (hitsInGPU.xs[innerInnerAnchorHitIndex] + hitsInGPU.xs[outerInnerAnchorHitIndex])/2;
+    float midPointY = (hitsInGPU.ys[innerInnerAnchorHitIndex] + hitsInGPU.ys[outerInnerAnchorHitIndex])/2;
+    float midPointZ = (hitsInGPU.zs[innerInnerAnchorHitIndex] + hitsInGPU.zs[outerInnerAnchorHitIndex])/2;
+
+    float diffX = (-hitsInGPU.xs[innerInnerAnchorHitIndex] + hitsInGPU.xs[outerInnerAnchorHitIndex]);
+    float diffY = (-hitsInGPU.ys[innerInnerAnchorHitIndex] + hitsInGPU.ys[outerInnerAnchorHitIndex]);
+    float diffZ = (-hitsInGPU.zs[innerInnerAnchorHitIndex] + hitsInGPU.zs[outerInnerAnchorHitIndex]);
+
+    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+
+    // Cut #5: deltaPhiChange
+    if (not (fabsf(dPhi) <= sdlCut))
+    {
+        pass = false;
+    }
+    float alpha_InLo = segmentsInGPU.dPhiChanges[innerSegmentIndex];
+    float alpha_OutLo = segmentsInGPU.dPhiChanges[outerSegmentIndex];
+
+    bool isEC_lastLayer = modulesInGPU.subdets[outerOuterLowerModuleIndex] == SDL::Endcap and modulesInGPU.moduleType[outerOuterLowerModuleIndex] == SDL::TwoS;
+
+    unsigned int outerOuterEdgeIndex = hitsInGPU.edge2SMap[outerOuterAnchorHitIndex]; //POTENTIAL NUCLEAR GANDHI
+    float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
+    
+    alpha_OutUp = deltaPhi(hitsInGPU.xs[outerOuterAnchorHitIndex],hitsInGPU.ys[outerOuterAnchorHitIndex],hitsInGPU.zs[outerOuterAnchorHitIndex],hitsInGPU.xs[outerOuterAnchorHitIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex], hitsInGPU.ys[outerOuterAnchorHitIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[outerInnerAnchorHitIndex]);
+
+    alpha_OutUp_highEdge = alpha_OutUp;
+    alpha_OutUp_lowEdge = alpha_OutUp;
+
+    float tl_axis_x = hitsInGPU.xs[outerOuterAnchorHitIndex] - hitsInGPU.xs[innerOuterAnchorHitIndex];
+    float tl_axis_y = hitsInGPU.ys[outerOuterAnchorHitIndex] - hitsInGPU.ys[innerOuterAnchorHitIndex];
+    float tl_axis_z = hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[innerOuterAnchorHitIndex];
+
+    float tl_axis_highEdge_x = tl_axis_x;
+    float tl_axis_highEdge_y = tl_axis_y;
+    float tl_axis_highEdge_z = tl_axis_z;
+
+    float tl_axis_lowEdge_x = tl_axis_x;
+    float tl_axis_lowEdge_y = tl_axis_y;
+    float tl_axis_lowEdge_z = tl_axis_z;
+
+    betaIn = -deltaPhi(px, py, pz, tl_axis_x, tl_axis_y, tl_axis_z);
+    float betaInRHmin = betaIn;
+    float betaInRHmax = betaIn;
+
+    betaOut = -alpha_OutUp + deltaPhi(hitsInGPU.xs[outerOuterAnchorHitIndex], hitsInGPU.ys[outerOuterAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+
+    float betaOutRHmin = betaOut;
+    float betaOutRHmax = betaOut;
+
+    if(isEC_lastLayer)
+    {
+        alpha_OutUp_highEdge = deltaPhi(hitsInGPU.highEdgeXs[outerOuterEdgeIndex],hitsInGPU.highEdgeYs[outerOuterEdgeIndex],hitsInGPU.zs[outerOuterAnchorHitIndex],hitsInGPU.highEdgeXs[outerOuterEdgeIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex], hitsInGPU.highEdgeYs[outerOuterEdgeIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[outerInnerAnchorHitIndex]);
+
+        alpha_OutUp_lowEdge = deltaPhi(hitsInGPU.lowEdgeXs[outerOuterEdgeIndex],hitsInGPU.lowEdgeYs[outerOuterEdgeIndex],hitsInGPU.zs[outerOuterAnchorHitIndex],hitsInGPU.lowEdgeXs[outerOuterEdgeIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex], hitsInGPU.lowEdgeYs[outerOuterEdgeIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex], hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[outerInnerAnchorHitIndex]);
+
+        tl_axis_highEdge_x = hitsInGPU.highEdgeXs[outerOuterEdgeIndex] - hitsInGPU.xs[innerOuterAnchorHitIndex];
+        tl_axis_highEdge_y = hitsInGPU.highEdgeYs[outerOuterEdgeIndex] - hitsInGPU.ys[innerOuterAnchorHitIndex];
+        tl_axis_highEdge_z = hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[innerOuterAnchorHitIndex];
+
+        tl_axis_lowEdge_x = hitsInGPU.lowEdgeXs[outerOuterEdgeIndex] - hitsInGPU.xs[innerOuterAnchorHitIndex];
+        tl_axis_lowEdge_y = hitsInGPU.lowEdgeYs[outerOuterEdgeIndex] - hitsInGPU.ys[innerOuterAnchorHitIndex];
+        tl_axis_lowEdge_z = hitsInGPU.zs[outerOuterAnchorHitIndex] - hitsInGPU.zs[innerOuterAnchorHitIndex];
+
+        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(hitsInGPU.highEdgeXs[outerOuterEdgeIndex], hitsInGPU.highEdgeYs[outerOuterEdgeIndex], hitsInGPU.zs[outerOuterAnchorHitIndex], tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_highEdge_z);
+
+        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(hitsInGPU.lowEdgeXs[outerOuterEdgeIndex], hitsInGPU.lowEdgeYs[outerOuterEdgeIndex], hitsInGPU.zs[outerOuterAnchorHitIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_lowEdge_z);
+    }
+
+    //beta computation
+    float drt_tl_axis = sqrtf(tl_axis_x * tl_axis_x + tl_axis_y * tl_axis_y);
+    float drt_tl_lowEdge = sqrtf(tl_axis_lowEdge_x * tl_axis_lowEdge_x + tl_axis_lowEdge_y * tl_axis_lowEdge_y);
+    float drt_tl_highEdge = sqrtf(tl_axis_highEdge_x * tl_axis_highEdge_x + tl_axis_highEdge_y * tl_axis_highEdge_y);
+//no betaIn cut for the pixels
+    const float rt_InSeg = sqrtf((hitsInGPU.xs[innerOuterAnchorHitIndex] - hitsInGPU.xs[innerInnerAnchorHitIndex]) * (hitsInGPU.xs[innerOuterAnchorHitIndex] - hitsInGPU.xs[innerInnerAnchorHitIndex]) + (hitsInGPU.ys[innerOuterAnchorHitIndex] - hitsInGPU.ys[innerInnerAnchorHitIndex]) * (hitsInGPU.ys[innerOuterAnchorHitIndex] - hitsInGPU.ys[innerInnerAnchorHitIndex]));
+
+    float betaAv = 0.5f * (betaIn + betaOut);
+    float pt_beta = ptIn;
+
+    const float pt_betaMax = 7.0f;
+
+    int lIn = 0;
+    int lOut = isEC_lastLayer ? 11 : 5;
+    float sdOut_dr = sqrtf((hitsInGPU.xs[outerOuterAnchorHitIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex]) * (hitsInGPU.xs[outerOuterAnchorHitIndex] - hitsInGPU.xs[outerInnerAnchorHitIndex]) + (hitsInGPU.ys[outerOuterAnchorHitIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex]) * (hitsInGPU.ys[outerOuterAnchorHitIndex] - hitsInGPU.ys[outerInnerAnchorHitIndex]));
+    float sdOut_d = hitsInGPU.rts[outerOuterAnchorHitIndex] - hitsInGPU.rts[outerInnerAnchorHitIndex];
+
+    const float diffDr = fabsf(rt_InSeg - sdOut_dr) / fabsf(rt_InSeg + sdOut_dr);
+
+    runDeltaBetaIterations(betaIn, betaOut, betaAv, pt_beta, rt_InSeg, sdOut_dr, drt_tl_axis, lIn);
+
+     const float betaInMMSF = (fabsf(betaInRHmin + betaInRHmax) > 0) ? (2.f * betaIn / fabsf(betaInRHmin + betaInRHmax)) : 0.; //mean value of min,max is the old betaIn
+    const float betaOutMMSF = (fabsf(betaOutRHmin + betaOutRHmax) > 0) ? (2.f * betaOut / fabsf(betaOutRHmin + betaOutRHmax)) : 0.;
+    betaInRHmin *= betaInMMSF;
+    betaInRHmax *= betaInMMSF;
+    betaOutRHmin *= betaOutMMSF;
+    betaOutRHmax *= betaOutMMSF;
+
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+
+    float sdIn_rt = hitsInGPU.rts[innerOuterAnchorHitIndex];
+    float sdOut_rt = hitsInGPU.rts[outerInnerAnchorHitIndex];
+    float sdIn_z = hitsInGPU.zs[innerOuterAnchorHitIndex];
+    float sdOut_z = hitsInGPU.zs[outerInnerAnchorHitIndex];
+    const float alphaInAbsReg =  fmaxf(fabsf(alpha_InLo), asinf(fminf(sdIn_rt * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
+    const float alphaOutAbsReg = fmaxf(fabsf(alpha_OutLo), asinf(fminf(sdOut_rt * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
+    const float dBetaInLum = lIn < 11 ? 0.0f : fabsf(alphaInAbsReg*deltaZLum / sdIn_z);
+    const float dBetaOutLum = lOut < 11 ? 0.0f : fabsf(alphaOutAbsReg*deltaZLum / sdOut_z);
+    const float dBetaLum2 = (dBetaInLum + dBetaOutLum) * (dBetaInLum + dBetaOutLum);
+
+    const float sinDPhi = sinf(dPhi);
+    const float dBetaRIn2 = 0; // TODO-RH
+
+    float dBetaROut = 0;
+    if(isEC_lastLayer)
+    {
+        dBetaROut = (sqrtf(hitsInGPU.highEdgeXs[outerOuterEdgeIndex] * hitsInGPU.highEdgeXs[outerOuterEdgeIndex] + hitsInGPU.highEdgeYs[outerOuterEdgeIndex] * hitsInGPU.highEdgeYs[outerOuterEdgeIndex]) - sqrtf(hitsInGPU.lowEdgeXs[outerOuterEdgeIndex] * hitsInGPU.lowEdgeXs[outerOuterEdgeIndex] + hitsInGPU.lowEdgeYs[outerOuterEdgeIndex] * hitsInGPU.lowEdgeYs[outerOuterEdgeIndex])) * sinDPhi / drt_tl_axis;
+    }
+
+    const float dBetaROut2 =  dBetaROut * dBetaROut;
+
+    float betaOutCut = asinf(fminf(drt_tl_axis*k2Rinv1GeVf / ptCut, sinAlphaMax)) //FIXME: need faster version
+        + (0.02f / sdOut_d) + sqrtf(dBetaLum2 + dBetaMuls*dBetaMuls);
+
+    //Cut #6: The real beta cut
+    if (not (fabsf(betaOut) < betaOutCut))
+    {
+        pass = false;
+    }
+
+    const float pt_betaOut = drt_tl_axis * k2Rinv1GeVf / sin(betaOut);
+    float drt_InSeg = hitsInGPU.rts[innerOuterAnchorHitIndex] - hitsInGPU.rts[innerInnerAnchorHitIndex];
+
+    const float dBetaRes = 0.02f / fminf(sdOut_d, drt_InSeg);
+    const float dBetaCut2 = (dBetaRes*dBetaRes * 2.0f + dBetaMuls * dBetaMuls + dBetaLum2 + dBetaRIn2 + dBetaROut2
+            + 0.25 * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
+    float dBeta = betaIn - betaOut;
+    float deltaBetaCut = sqrtf(dBetaCut2);
+    if (not (dBeta * dBeta <= dBetaCut2))
+    {
+        pass = false;
+    }
+
+    return pass;
+}
+
 __device__ void SDL::runDeltaBetaIterations(float& betaIn, float& betaOut, float& betaAv, float & pt_beta, float sdIn_dr, float sdOut_dr, float dr, float lIn)
 {
+    if (lIn == 0)
+    {
+        betaOut += copysign(asinf(fminf(sdOut_dr * k2Rinv1GeVf / fabsf(pt_beta), sinAlphaMax)), betaOut);
+        return;
+    }
+
     if (true //do it for all//diffDr > 0.05 //only if segment length is different significantly
             and betaIn * betaOut > 0.f
             and (fabsf(pt_beta) < 4.f * pt_betaMax

--- a/SDL/Tracklet.cuh
+++ b/SDL/Tracklet.cuh
@@ -43,12 +43,18 @@ namespace SDL
         void freeMemoryCache();
     };
 
-    void createTrackletsInUnifiedMemory(struct tracklets& trackletsInGPU, unsigned int maxTracklets, unsigned int nLowerModules);
+    void createTrackletsInUnifiedMemory(struct tracklets& trackletsInGPU, unsigned int maxTracklets, unsigned int maxPixelTracklets, unsigned int nLowerModules);
     void createTrackletsInExplicitMemory(struct tracklets& trackletsInGPU, unsigned int maxTracklets, unsigned int nLowerModules);
 
     CUDA_DEV void addTrackletToMemory(struct tracklets& trackletsInGPU, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, unsigned int innerInnerLowerModuleIndex, unsigned int innerOuterLowerModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float& betaOut, unsigned int trackletIndex);
 
     CUDA_DEV void runDeltaBetaIterations(float& betaIn, float& betaOut, float& betaAv, float & pt_beta, float sdIn_dr, float sdOut_dr, float dr, float lIn);
+
+    CUDA_DEV bool runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU ,struct segments& segmentsInGPU, unsigned int pixelModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& dPhiPos, float& dPhi, float& betaIn, float& betaOut, unsigned int
+        N_MAX_SEGMENTS_PER_MODULE); // pixel to BB and BE segments
+
+    CUDA_DEV bool runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU ,struct segments& segmentsInGPU, unsigned int pixelModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& dPhi, float& betaIn, float& betaOut, unsigned int
+        N_MAX_SEGMENTS_PER_MODULE); // pixel to EE segments
 
     CUDA_DEV bool runTrackletDefaultAlgoBBBB(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, unsigned int innerInnerLowerModuleIndex, unsigned int innerOuterLowerModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float& betaOut);
 
@@ -56,7 +62,8 @@ namespace SDL
 
     CUDA_DEV bool runTrackletDefaultAlgoEEEE(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, unsigned int innerInnerLowerModuleIndex, unsigned int innerOuterLowerModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float& betaOut);
 
-    CUDA_DEV bool runTrackletDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, unsigned int innerInnerLowerModuleIndex, unsigned int innerOuterLowerModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float& betaOut);
+    CUDA_DEV bool runTrackletDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, unsigned int innerInnerLowerModuleIndex, unsigned int innerOuterLowerModuleIndex, unsigned int outerInnerLowerModuleIndex, unsigned int outerOuterLowerModuleIndex, unsigned int innerSegmentIndex, unsigned int outerSegmentIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float&
+            betaOut, unsigned int N_MAX_SEGMENTS_PER_MODULE = 600);
 
     extern CUDA_CONST_VAR float pt_betaMax;
 

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -628,7 +628,7 @@ int main(int argc, char** argv)
 
                 // Takes two arguments, SDL::Hit, and detId
                 // SDL::Event internally will structure whether we already have the module instance or we need to create a new one.
-                event.addHitToEvent(trk.ph2_x()[ihit], trk.ph2_y()[ihit], trk.ph2_z()[ihit],trk.ph2_detId()[ihit]);
+                event.addHitToEvent(trk.ph2_x()[ihit], trk.ph2_y()[ihit], trk.ph2_z()[ihit],trk.ph2_detId()[ihit], ihit);
 
             }
 

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -806,10 +806,15 @@ int main(int argc, char** argv)
             // ----------------
 
             // ----------------
-            if(ana.verbose != 0) std::cout<<"Adding pixel segments!"<<std::endl;
+            if(ana.verbose != 0) std::cout<<"Adding Pixel Segments!"<<std::endl;
             addPixelSegments(event,-1);
    
-
+            if(ana.verbose != 0) std::cout<<" Reco Pixel Tracklet start"<<std::endl;
+            my_timer.Start(kFALSE);
+            event.createPixelTracklets();
+            float ptl_elapsed = my_timer.RealTime();
+            if (ana.verbose != 0) std::cout << "Reco Pixel Tracklet processing time: " << ptl_elapsed - tp_elapsed << " secs" << std::endl;
+ 
             if (ana.verbose != 0) std::cout << "Reco Tracklet start" << std::endl;
             my_timer.Start(kFALSE);
             // event.createTracklets();
@@ -819,7 +824,7 @@ int main(int argc, char** argv)
             //event.createTrackletsViaNavigation();
             float tl_elapsed = my_timer.RealTime();
             event_times[ana.looper.getCurrentEventIndex()][3] = tl_elapsed - tp_elapsed;
-            if (ana.verbose != 0) std::cout << "Reco Tracklet processing time: " << tl_elapsed - tp_elapsed << " secs" << std::endl;
+            if (ana.verbose != 0) std::cout << "Reco Tracklet processing time: " << tl_elapsed - ptl_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of Tracklets produced: " << event.getNumberOfTracklets() << std::endl;
             if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
             if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerBarrel(1) << std::endl;

--- a/src/trkCore.cc
+++ b/src/trkCore.cc
@@ -456,7 +456,7 @@ void addOuterTrackerHits(SDL::Event& event)
         // Takes two arguments, SDL::Hit, and detId
         // SDL::Event internally will structure whether we already have the module instance or we need to create a new one.
         //
-        event.addHitToEvent(x,y,z,detId);
+        event.addHitToEvent(x,y,z,detId, ihit);
 
     }
 }


### PR DESCRIPTION
I have marked places where new variables/functions/arrays have been introduced with a FIXME. There are a bunch of hacks to ensure those that do not involve pixels don't have issues. For example, I would've augmented the lowerModuleIndices array by one without increasing the number of lower modules. This is to ensure the regular functions that don't rely on pixels don't get affected (think of pixels as a "secret location" that can only be accessed by "saying the magic index numbers"). The code that reads pixels from the tracking Ntuple is in doAnalysis.cc