### PR TITLE
Pixel loading

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -240,14 +240,14 @@ void SDL::Event::addHitToEventOMP(std::vector<float> x, std::vector<float> y, st
     unsigned int subdet = modulesInGPU->subdets[(*detIdToIndex)[host_detId[ihit]]];
     host_moduleIndex[ihit] = (*detIdToIndex)[host_detId[ihit]];
 
-    if(subdet == Barrel)
-    {
-        n_hits_by_layer_barrel_[moduleLayer-1]++;
-    }
-    else
-    {
-        n_hits_by_layer_endcap_[moduleLayer-1]++;
-    }
+//    if(subdet == Barrel) // this doesn't seem useful anymore
+//    {
+//        n_hits_by_layer_barrel_[moduleLayer-1]++;
+//    }
+//    else
+//    {
+//        n_hits_by_layer_endcap_[moduleLayer-1]++;
+//    }
   
 
       host_rts[ihit] = sqrt(host_x[ihit]*host_x[ihit] + host_y[ihit]*host_y[ihit]);
@@ -404,6 +404,221 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices, fl
   cudaDeviceSynchronize();
   cudaFree(hitIndices_dev); // added by tres
 }
+__global__ void /*SDL::Event::*/addPixelSegmentToEventKernelV2(unsigned int* hitIndices0,unsigned int* hitIndices1,unsigned int* hitIndices2,unsigned int* hitIndices3, float* dPhiChange, float* ptIn, float* ptErr, float* px, float* py, float* pz, float* etaErr,unsigned int pixelModuleIndex, struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU,const int size)
+{
+
+    
+    const int init_nMD = mdsInGPU.nMDs[pixelModuleIndex];
+    const int init_nSeg = segmentsInGPU.nSegments[pixelModuleIndex];
+    for( int tid = blockIdx.x * blockDim.x + threadIdx.x; tid < size; tid += blockDim.x*gridDim.x)
+    {
+
+      if(tid==0){
+
+      mdsInGPU.nMDs[pixelModuleIndex] += 2*size;
+      segmentsInGPU.nSegments[pixelModuleIndex] += size;
+      }
+      //step 1 : Add pixel MDs
+      unsigned int innerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES + init_nMD + 2*(tid); //mdsInGPU.nMDs[pixelModuleIndex];
+      //FIXME:Fake Pixel MDs are being added to MD unified memory!
+      addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices0[tid], hitIndices1[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,innerMDIndex);
+      //mdsInGPU.nMDs[pixelModuleIndex]++;
+      unsigned int outerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES + init_nMD + 2*(tid) +1;//mdsInGPU.nMDs[pixelModuleIndex];
+      addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices2[tid], hitIndices3[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,outerMDIndex);
+      //mdsInGPU.nMDs[pixelModuleIndex]++;
+
+      //step 2 : Add pixel segment
+      unsigned int pixelSegmentIndex = pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE + init_nSeg + tid;//segmentsInGPU.nSegments[pixelModuleIndex];
+      //FIXME:Fake Pixel Segment gets added to Segment unified memory in a convoluted fashion!
+      addPixelSegmentToMemory(segmentsInGPU, mdsInGPU, hitsInGPU, modulesInGPU, innerMDIndex, outerMDIndex, pixelModuleIndex, hitIndices0[tid], hitIndices2[tid], dPhiChange[tid], ptIn[tid], ptErr[tid], px[tid], py[tid], pz[tid], etaErr[tid], pixelSegmentIndex);
+      //segmentsInGPU.nSegments[pixelModuleIndex]++;
+    }
+}
+void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> etaErr)
+{
+//    assert(hitIndices.size() == 4);
+    if(mdsInGPU == nullptr)
+    {
+        cudaMallocHost(&mdsInGPU, sizeof(SDL::miniDoublets));
+#ifdef Explicit_MD
+        //FIXME: Add memory locations for pixel MDs
+    	createMDsInExplicitMemory(*mdsInGPU, N_MAX_MD_PER_MODULES, nModules, N_MAX_PIXEL_MD_PER_MODULES);
+#else
+    	createMDsInUnifiedMemory(*mdsInGPU, N_MAX_MD_PER_MODULES, nModules, N_MAX_PIXEL_MD_PER_MODULES);
+#endif
+    }
+    if(segmentsInGPU == nullptr)
+    {
+        cudaMallocHost(&segmentsInGPU, sizeof(SDL::segments));
+#ifdef Explicit_Seg
+        //FIXME:Add memory locations for pixel segments
+        //createSegmentsInExplicitMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nModules);
+        createSegmentsInExplicitMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE);
+#else
+        createSegmentsInUnifiedMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE);
+#endif
+    }
+    const int size = ptIn.size();
+    unsigned int pixelModuleIndex = (*detIdToIndex)[1] -1; //double check the -1?
+    unsigned int* hitIndices0_host = &hitIndices0[0];
+    unsigned int* hitIndices1_host = &hitIndices1[0];
+    unsigned int* hitIndices2_host = &hitIndices2[0];
+    unsigned int* hitIndices3_host = &hitIndices3[0];
+    float* dPhiChange_host = &dPhiChange[0];
+    float* ptIn_host = &ptIn[0];
+    float* ptErr_host = &ptErr[0];
+    float* px_host = &px[0];
+    float* py_host = &py[0];
+    float* pz_host = &pz[0];
+    float* etaErr_host = &etaErr[0];
+
+    unsigned int* hitIndices0_dev;
+    unsigned int* hitIndices1_dev;
+    unsigned int* hitIndices2_dev;
+    unsigned int* hitIndices3_dev;
+    float* dPhiChange_dev;
+    float* ptIn_dev;
+    float* ptErr_dev;
+    float* px_dev;
+    float* py_dev;
+    float* pz_dev;
+    float* etaErr_dev;
+
+    cudaMalloc(&hitIndices0_dev,size*sizeof(unsigned int));
+    cudaMalloc(&hitIndices1_dev,size*sizeof(unsigned int));
+    cudaMalloc(&hitIndices2_dev,size*sizeof(unsigned int));
+    cudaMalloc(&hitIndices3_dev,size*sizeof(unsigned int));
+    cudaMalloc(&dPhiChange_dev,size*sizeof(unsigned int));
+    cudaMalloc(&ptIn_dev,size*sizeof(unsigned int));
+    cudaMalloc(&ptErr_dev,size*sizeof(unsigned int));
+    cudaMalloc(&px_dev,size*sizeof(unsigned int));
+    cudaMalloc(&py_dev,size*sizeof(unsigned int));
+    cudaMalloc(&pz_dev,size*sizeof(unsigned int));
+    cudaMalloc(&etaErr_dev,size*sizeof(unsigned int));
+
+    cudaMemcpy(hitIndices0_dev,hitIndices0_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(hitIndices1_dev,hitIndices1_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(hitIndices2_dev,hitIndices2_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(hitIndices3_dev,hitIndices3_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(dPhiChange_dev,dPhiChange_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(ptIn_dev,ptIn_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(ptErr_dev,ptErr_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(px_dev,px_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(py_dev,py_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(pz_dev,pz_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+    cudaMemcpy(etaErr_dev,etaErr_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice);
+
+  addPixelSegmentToEventKernelV2<<<1,1>>>(hitIndices0_dev,hitIndices1_dev,hitIndices2_dev,hitIndices3_dev,dPhiChange_dev,ptIn_dev,ptErr_dev,px_dev,py_dev,pz_dev,etaErr_dev,pixelModuleIndex, *modulesInGPU,*hitsInGPU,*mdsInGPU,*segmentsInGPU,size);
+  cudaDeviceSynchronize();
+  cudaFree(hitIndices0_dev);
+  cudaFree(hitIndices1_dev);
+  cudaFree(hitIndices2_dev);
+  cudaFree(hitIndices3_dev);
+  cudaFree(dPhiChange_dev);
+  cudaFree(ptIn_dev);
+  cudaFree(ptErr_dev);
+  cudaFree(px_dev);
+  cudaFree(py_dev);
+  cudaFree(pz_dev);
+  cudaFree(etaErr_dev);
+}
+
+//void SDL::Event::addPixelSegmentToEventV2(std::vector<std::vector<float>> r3PCA, std::vector<std::vector<float>> r3LH, std::vector<std::vector<int>> hitIdxInNtuple,std::vector<std::vector<unsigned int>> hitIndicies, std::vector<std::vector<float>> pt){
+//
+//    const int loopsize = r3PCA.at(0).size() + r3LH.at(0).size();
+//
+//    float* r3PCA_X = &r3PCA.at(0);
+//    float* r3PCA_Y = &r3PCA.at(1);
+//    float* r3PCA_Z = &r3PCA.at(2);
+//    float* r3LH_X = &r3LH.at(0);
+//    float* r3LH_Y = &r3LH.at(1);
+//    float* r3LH_Z = &r3LH.at(2);
+//    int* hitIdxInNtuple0 = &hitIdxInNtuple.at(0);
+//    int* hitIdxInNtuple1 = &hitIdxInNtuple.at(1);
+//    int* hitIdxInNtuple2 = &hitIdxInNtuple.at(2);
+//    int* hitIdxInNtuple3 = &hitIdxInNtuple.at(3);
+//    unsigned int* hitIndices0 = &hitIndices.at(0);
+//    unsigned int* hitIndices1 = &hitIndices.at(1);
+//    unsigned int* hitIndices2 = &hitIndices.at(2);
+//    unsigned int* hitIndices3 = &hitIndices.at(3);
+//    float* ptIn = &pt.at(0);
+//    float* ptErr = &pt.at(1);
+//    float* etaErr = &pt.at(2);
+//    float* deltaPhi = &pt.at(3);
+//
+//    
+////#pragma omp parallel for  // this part can be run in parallel.
+//  for (int ihit=0; ihit<loopsize;ihit++){
+//    unsigned int moduleLayer = modulesInGPU->layers[(*detIdToIndex)[host_detId[ihit]]];
+//    unsigned int subdet = modulesInGPU->subdets[(*detIdToIndex)[host_detId[ihit]]];
+//    host_moduleIndex[ihit] = (*detIdToIndex)[host_detId[ihit]];
+//
+//    if(subdet == Barrel)
+//    {
+//        n_hits_by_layer_barrel_[moduleLayer-1]++;
+//    }
+//    else
+//    {
+//        n_hits_by_layer_endcap_[moduleLayer-1]++;
+//    }
+//  
+//
+//      host_rts[ihit] = sqrt(host_x[ihit]*host_x[ihit] + host_y[ihit]*host_y[ihit]);
+//      host_phis[ihit] = phi(host_x[ihit],host_y[ihit],host_z[ihit]);
+//      host_idxs[ihit] = ihit;
+////  }
+////// This part i think has a race condition. so this is not run in parallel. 
+//////#pragma omp parallel for
+////  for (int ihit=0; ihit<loopsize;ihit++){
+//      unsigned int this_index = host_moduleIndex[ihit];
+//      if(modulesInGPU->subdets[this_index] == Endcap && modulesInGPU->moduleType[this_index] == TwoS)
+//      {
+//          float xhigh, yhigh, xlow, ylow;
+//          getEdgeHits(host_detId[ihit],host_x[ihit],host_y[ihit],xhigh,yhigh,xlow,ylow);
+//          host_highEdgeXs[ihit] = xhigh;
+//          host_highEdgeYs[ihit] = yhigh;
+//          host_lowEdgeXs[ihit] = xlow;
+//          host_lowEdgeYs[ihit] = ylow;
+//
+//      }
+//
+//      //set the hit ranges appropriately in the modules struct
+//
+//      //start the index rolling if the module is encountered for the first time
+//      if(modulesInGPU->hitRanges[this_index * 2] == -1)
+//      {
+//          modulesInGPU->hitRanges[this_index * 2] = ihit;
+//      }
+//      //always update the end index
+//      modulesInGPU->hitRanges[this_index * 2 + 1] = ihit;
+//
+//  }
+////simply copy the host arrays to the hitsInGPU struct
+//    cudaMemcpy(hitsInGPU->xs,host_x,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->ys,host_y,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->zs,host_z,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->rts,host_rts,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->idxs,host_idxs,loopsize*sizeof(unsigned int),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->moduleIndices,host_moduleIndex,loopsize*sizeof(unsigned int),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->highEdgeXs,host_highEdgeXs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->highEdgeYs,host_highEdgeYs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->lowEdgeXs,host_lowEdgeXs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->lowEdgeYs,host_lowEdgeYs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
+//    cudaMemcpy(hitsInGPU->nHits,&loopsize,sizeof(unsigned int),cudaMemcpyHostToDevice);// value can't correctly be set in hit allocation 
+//    cudaDeviceSynchronize(); //doesn't seem to make a difference
+//
+//    cudaFreeHost(host_rts);
+//    cudaFreeHost(host_idxs);
+//    cudaFreeHost(host_phis);
+//    cudaFreeHost(host_moduleIndex);
+//    cudaFreeHost(host_highEdgeXs);
+//    cudaFreeHost(host_highEdgeYs);
+//    cudaFreeHost(host_lowEdgeXs);
+//    cudaFreeHost(host_lowEdgeYs);
+//
+//
+//
+//}
 
 void SDL::Event::addMiniDoubletsToEvent()
 {
@@ -1490,7 +1705,7 @@ __global__ void createTrackCandidatesInGPU(struct SDL::modules& modulesInGPU, st
     //inner tracklet/triplet inner segment inner MD lower module
     int innerInnerInnerLowerModuleArrayIndex = blockIdx.x * blockDim.x + threadIdx.x;
     //hack to include pixel detector
-    if(innerInnerInnerLowerModuleArrayIndex >= *modulesInGPU.nLowerModules + 1) return; 
+    if(innerInnerInnerLowerModuleArrayIndex >= *modulesInGPU.nLowerModules /*+ 1*/) return; 
 
     unsigned int nTracklets = trackletsInGPU.nTracklets[innerInnerInnerLowerModuleArrayIndex];
     unsigned int nTriplets = tripletsInGPU.nTriplets[innerInnerInnerLowerModuleArrayIndex]; // should be zero for the pixels

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -407,30 +407,24 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices, fl
 __global__ void addPixelSegmentToEventKernelV2(unsigned int* hitIndices0,unsigned int* hitIndices1,unsigned int* hitIndices2,unsigned int* hitIndices3, float* dPhiChange, float* ptIn, float* ptErr, float* px, float* py, float* pz, float* etaErr,unsigned int pixelModuleIndex, struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU,const int size)
 {
 
-    
-    //const int init_nMD = mdsInGPU.nMDs[pixelModuleIndex];
-    //const int init_nSeg = segmentsInGPU.nSegments[pixelModuleIndex];
-    //printf("Init test: %d %d\n",init_nMD,init_nSeg);
     for( int tid = blockIdx.x * blockDim.x + threadIdx.x; tid < size; tid += blockDim.x*gridDim.x)
     {
 
-      unsigned int innerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES + /*init_nMD +*/ 2*(tid); //mdsInGPU.nMDs[pixelModuleIndex];
+      unsigned int innerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES + 2*(tid); 
       addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices0[tid], hitIndices1[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,innerMDIndex);
-      unsigned int outerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES /*+ init_nMD*/ + 2*(tid) +1;//mdsInGPU.nMDs[pixelModuleIndex];
+      unsigned int outerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES + 2*(tid) +1;
       addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices2[tid], hitIndices3[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,outerMDIndex);
 
-      unsigned int pixelSegmentIndex = pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE /*+ init_nSeg*/ + tid;//segmentsInGPU.nSegments[pixelModuleIndex];
+      unsigned int pixelSegmentIndex = pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE + tid;
       addPixelSegmentToMemory(segmentsInGPU, mdsInGPU, hitsInGPU, modulesInGPU, innerMDIndex, outerMDIndex, pixelModuleIndex, hitIndices0[tid], hitIndices2[tid], dPhiChange[tid], ptIn[tid], ptErr[tid], px[tid], py[tid], pz[tid], etaErr[tid], pixelSegmentIndex);
     }
 }
 void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> etaErr)
 {
-//    assert(hitIndices.size() == 4);
     if(mdsInGPU == nullptr)
     {
         cudaMallocHost(&mdsInGPU, sizeof(SDL::miniDoublets));
 #ifdef Explicit_MD
-        //FIXME: Add memory locations for pixel MDs
     	createMDsInExplicitMemory(*mdsInGPU, N_MAX_MD_PER_MODULES, nModules, N_MAX_PIXEL_MD_PER_MODULES);
 #else
     	createMDsInUnifiedMemory(*mdsInGPU, N_MAX_MD_PER_MODULES, nModules, N_MAX_PIXEL_MD_PER_MODULES);
@@ -440,8 +434,6 @@ void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,
     {
         cudaMallocHost(&segmentsInGPU, sizeof(SDL::segments));
 #ifdef Explicit_Seg
-        //FIXME:Add memory locations for pixel segments
-        //createSegmentsInExplicitMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nModules);
         createSegmentsInExplicitMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE);
 #else
         createSegmentsInUnifiedMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE);
@@ -499,7 +491,7 @@ void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,
 
     unsigned int nThreads = 256;
     unsigned int nBlocks =  size % nThreads == 0 ? size/nThreads : size/nThreads + 1;
-  addPixelSegmentToEventKernelV2<<<1,1>>>(hitIndices0_dev,hitIndices1_dev,hitIndices2_dev,hitIndices3_dev,dPhiChange_dev,ptIn_dev,ptErr_dev,px_dev,py_dev,pz_dev,etaErr_dev,pixelModuleIndex, *modulesInGPU,*hitsInGPU,*mdsInGPU,*segmentsInGPU,size);
+  addPixelSegmentToEventKernelV2<<<nBlocks,nThreads>>>(hitIndices0_dev,hitIndices1_dev,hitIndices2_dev,hitIndices3_dev,dPhiChange_dev,ptIn_dev,ptErr_dev,px_dev,py_dev,pz_dev,etaErr_dev,pixelModuleIndex, *modulesInGPU,*hitsInGPU,*mdsInGPU,*segmentsInGPU,size);
   cudaDeviceSynchronize();
   cudaFree(hitIndices0_dev);
   cudaFree(hitIndices1_dev);
@@ -514,102 +506,6 @@ void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,
   cudaFree(etaErr_dev);
 }
 
-//void SDL::Event::addPixelSegmentToEventV2(std::vector<std::vector<float>> r3PCA, std::vector<std::vector<float>> r3LH, std::vector<std::vector<int>> hitIdxInNtuple,std::vector<std::vector<unsigned int>> hitIndicies, std::vector<std::vector<float>> pt){
-//
-//    const int loopsize = r3PCA.at(0).size() + r3LH.at(0).size();
-//
-//    float* r3PCA_X = &r3PCA.at(0);
-//    float* r3PCA_Y = &r3PCA.at(1);
-//    float* r3PCA_Z = &r3PCA.at(2);
-//    float* r3LH_X = &r3LH.at(0);
-//    float* r3LH_Y = &r3LH.at(1);
-//    float* r3LH_Z = &r3LH.at(2);
-//    int* hitIdxInNtuple0 = &hitIdxInNtuple.at(0);
-//    int* hitIdxInNtuple1 = &hitIdxInNtuple.at(1);
-//    int* hitIdxInNtuple2 = &hitIdxInNtuple.at(2);
-//    int* hitIdxInNtuple3 = &hitIdxInNtuple.at(3);
-//    unsigned int* hitIndices0 = &hitIndices.at(0);
-//    unsigned int* hitIndices1 = &hitIndices.at(1);
-//    unsigned int* hitIndices2 = &hitIndices.at(2);
-//    unsigned int* hitIndices3 = &hitIndices.at(3);
-//    float* ptIn = &pt.at(0);
-//    float* ptErr = &pt.at(1);
-//    float* etaErr = &pt.at(2);
-//    float* deltaPhi = &pt.at(3);
-//
-//    
-////#pragma omp parallel for  // this part can be run in parallel.
-//  for (int ihit=0; ihit<loopsize;ihit++){
-//    unsigned int moduleLayer = modulesInGPU->layers[(*detIdToIndex)[host_detId[ihit]]];
-//    unsigned int subdet = modulesInGPU->subdets[(*detIdToIndex)[host_detId[ihit]]];
-//    host_moduleIndex[ihit] = (*detIdToIndex)[host_detId[ihit]];
-//
-//    if(subdet == Barrel)
-//    {
-//        n_hits_by_layer_barrel_[moduleLayer-1]++;
-//    }
-//    else
-//    {
-//        n_hits_by_layer_endcap_[moduleLayer-1]++;
-//    }
-//  
-//
-//      host_rts[ihit] = sqrt(host_x[ihit]*host_x[ihit] + host_y[ihit]*host_y[ihit]);
-//      host_phis[ihit] = phi(host_x[ihit],host_y[ihit],host_z[ihit]);
-//      host_idxs[ihit] = ihit;
-////  }
-////// This part i think has a race condition. so this is not run in parallel. 
-//////#pragma omp parallel for
-////  for (int ihit=0; ihit<loopsize;ihit++){
-//      unsigned int this_index = host_moduleIndex[ihit];
-//      if(modulesInGPU->subdets[this_index] == Endcap && modulesInGPU->moduleType[this_index] == TwoS)
-//      {
-//          float xhigh, yhigh, xlow, ylow;
-//          getEdgeHits(host_detId[ihit],host_x[ihit],host_y[ihit],xhigh,yhigh,xlow,ylow);
-//          host_highEdgeXs[ihit] = xhigh;
-//          host_highEdgeYs[ihit] = yhigh;
-//          host_lowEdgeXs[ihit] = xlow;
-//          host_lowEdgeYs[ihit] = ylow;
-//
-//      }
-//
-//      //set the hit ranges appropriately in the modules struct
-//
-//      //start the index rolling if the module is encountered for the first time
-//      if(modulesInGPU->hitRanges[this_index * 2] == -1)
-//      {
-//          modulesInGPU->hitRanges[this_index * 2] = ihit;
-//      }
-//      //always update the end index
-//      modulesInGPU->hitRanges[this_index * 2 + 1] = ihit;
-//
-//  }
-////simply copy the host arrays to the hitsInGPU struct
-//    cudaMemcpy(hitsInGPU->xs,host_x,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->ys,host_y,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->zs,host_z,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->rts,host_rts,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->idxs,host_idxs,loopsize*sizeof(unsigned int),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->moduleIndices,host_moduleIndex,loopsize*sizeof(unsigned int),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->highEdgeXs,host_highEdgeXs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->highEdgeYs,host_highEdgeYs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->lowEdgeXs,host_lowEdgeXs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->lowEdgeYs,host_lowEdgeYs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->nHits,&loopsize,sizeof(unsigned int),cudaMemcpyHostToDevice);// value can't correctly be set in hit allocation 
-//    cudaDeviceSynchronize(); //doesn't seem to make a difference
-//
-//    cudaFreeHost(host_rts);
-//    cudaFreeHost(host_idxs);
-//    cudaFreeHost(host_phis);
-//    cudaFreeHost(host_moduleIndex);
-//    cudaFreeHost(host_highEdgeXs);
-//    cudaFreeHost(host_highEdgeYs);
-//    cudaFreeHost(host_lowEdgeXs);
-//    cudaFreeHost(host_lowEdgeYs);
-//
-//
-//
-//}
 
 void SDL::Event::addMiniDoubletsToEvent()
 {

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -62,6 +62,7 @@ namespace SDL
         void addHitToEvent(float x, float y, float z, unsigned int detId, unsigned int idx); //call the appropriate hit function, then increment the counter here
         void /*unsigned int*/ addPixToEvent(float x, float y, float z, unsigned int detId, unsigned int idx); //call the appropriate hit function, then increment the counter here
         void addPixelSegmentToEvent(std::vector<unsigned int> hitIndices, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr);
+        void addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> etaErr);
 
         /*functions that map the objects to the appropriate modules*/
         void addMiniDoubletsToEvent();

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -12,9 +12,27 @@ TVector3 r3FromPCA(const TVector3& p3, const float dxy, const float dz){
   return TVector3(vx, vy, vz);
 }
 
-void addPixelSegments(SDL::Event& event, int isimtrk, const int hit_size)
+void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, std::vector<float> trkY, std::vector<float> trkZ, std::vector<unsigned int> hitId)
 {
     unsigned int count = 0;
+    std::vector<float> px_vec;
+    std::vector<float> py_vec;
+    std::vector<float> pz_vec;
+    std::vector<float> vecX;
+    std::vector<float> vecY;
+    std::vector<float> vecZ;
+    std::vector<int> hitIdxInNtuple_vec0;
+    std::vector<int> hitIdxInNtuple_vec1;
+    std::vector<int> hitIdxInNtuple_vec2;
+    std::vector<int> hitIdxInNtuple_vec3;
+    std::vector<unsigned int> hitIndices_vec0;
+    std::vector<unsigned int> hitIndices_vec1;
+    std::vector<unsigned int> hitIndices_vec2;
+    std::vector<unsigned int> hitIndices_vec3;
+    std::vector<float> ptIn_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
+    std::vector<float> ptErr_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
+    std::vector<float> etaErr_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
+    std::vector<float> deltaPhi_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
     for (auto&& [iSeed, _] : iter::enumerate(trk.see_stateTrajGlbPx()))
     {
 
@@ -91,7 +109,7 @@ void addPixelSegments(SDL::Event& event, int isimtrk, const int hit_size)
         float px = p3LH.X();
         float py = p3LH.Y();
         float pz = p3LH.Z();
-
+        const int hit_size = trkX.size();
         if ((ptIn > 0.7) and (fabs(p3LH.Eta()) < 3))
         {
       // old unified hits version
@@ -126,18 +144,18 @@ void addPixelSegments(SDL::Event& event, int isimtrk, const int hit_size)
 //            event.addPixelSegmentToEvent(hitIndices, pixelSegmentDeltaPhiChange, ptIn, ptErr, px, py, pz, etaErr);
       // new explicit hits version. Works for both explicit and unified hits. 
 	          int hitIdx0InNtuple = trk.see_hitIdx()[iSeed][0];
-            event.addPixToEvent(r3PCA.X(), r3PCA.Y(), r3PCA.Z(), 1, hitIdx0InNtuple);
+//            event.addPixToEvent(r3PCA.X(), r3PCA.Y(), r3PCA.Z(), 1, hitIdx0InNtuple);
             unsigned int hitIdx0 = hit_size + count;
             count++; // incrementing the counter after the hitIdx should take care for the -1 right?
      
             int hitIdx1InNtuple = trk.see_hitIdx()[iSeed][1];
-            event.addPixToEvent(r3PCA.X(), r3PCA.Y(), r3PCA.Z(), 1, hitIdx1InNtuple);
+//            event.addPixToEvent(r3PCA.X(), r3PCA.Y(), r3PCA.Z(), 1, hitIdx1InNtuple);
             unsigned int hitIdx1 = hit_size + count;
             count++;
 
             int hitIdx2InNtuple = trk.see_hitIdx()[iSeed][2];
 
-            event.addPixToEvent(r3LH.X(), r3LH.Y(), r3LH.Z(),1,hitIdx2InNtuple);
+//            event.addPixToEvent(r3LH.X(), r3LH.Y(), r3LH.Z(),1,hitIdx2InNtuple);
             unsigned int hitIdx2 = hit_size + count;
             count++;
 
@@ -149,17 +167,73 @@ void addPixelSegments(SDL::Event& event, int isimtrk, const int hit_size)
             }
             else
             {
-                event.addPixToEvent(r3LH.X(), r3LH.Y(), r3LH.Z(),1,hitIdx3InNtuple);
+//                event.addPixToEvent(r3LH.X(), r3LH.Y(), r3LH.Z(),1,hitIdx3InNtuple);
                 hitIdx3 = hit_size + count;
                 count++;
             }
 
             std::vector<unsigned int> hitIndices = {hitIdx0, hitIdx1, hitIdx2, hitIdx3}; 
 
-            event.addPixelSegmentToEvent(hitIndices, pixelSegmentDeltaPhiChange, ptIn, ptErr, px, py, pz, etaErr);
+//            event.addPixelSegmentToEvent(hitIndices, pixelSegmentDeltaPhiChange, ptIn, ptErr, px, py, pz, etaErr);
 //          printf("test: %u (%u,%u,%u,%u)\n",iSeed,hitIdx0,hitIdx1,hitIdx2,hitIdx3);
+//          NEWEST VERSION
+            trkX.push_back(r3PCA.X());
+            trkY.push_back(r3PCA.Y());
+            trkZ.push_back(r3PCA.Z());
+            trkX.push_back(r3PCA.X());
+            trkY.push_back(r3PCA.Y());
+            trkZ.push_back(r3PCA.Z());
+            trkX.push_back(r3LH.X());
+            trkY.push_back(r3LH.Y());
+            trkZ.push_back(r3LH.Z());
+            trkX.push_back(r3LH.X());
+            trkY.push_back(r3LH.Y());
+            trkZ.push_back(r3LH.Z());
+            hitId.push_back(1);
+            hitId.push_back(1);
+            hitId.push_back(1);
+            hitId.push_back(1);
+            px_vec.push_back(px);
+            py_vec.push_back(py);
+            pz_vec.push_back(pz);
+
+            //vecX.push_back(r3PCA.X());
+            //vecY.push_back(r3PCA.Y());
+            //vecZ.push_back(r3PCA.Z());
+            //vecX.push_back(r3PCA.X());
+            //vecY.push_back(r3PCA.Y());
+            //vecZ.push_back(r3PCA.Z());
+            //vecX.push_back(r3LH.X());
+            //vecY.push_back(r3LH.Y());
+            //vecZ.push_back(r3LH.Z());
+            //vecX.push_back(r3LH.X());
+            //vecY.push_back(r3LH.Y());
+            //vecZ.push_back(r3LH.Z());
+            //hitIndices_vec.push_back(1);
+            //hitIndices_vec.push_back(1);
+            //hitIndices_vec.push_back(1);
+            //hitIndices_vec.push_back(1);
+            hitIndices_vec0.push_back(hitIdx0);
+            hitIndices_vec1.push_back(hitIdx1);
+            hitIndices_vec2.push_back(hitIdx2);
+            hitIndices_vec3.push_back(hitIdx3);
+
+            hitIdxInNtuple_vec0.push_back(hitIdx0InNtuple);
+            hitIdxInNtuple_vec1.push_back(hitIdx1InNtuple);
+            hitIdxInNtuple_vec2.push_back(hitIdx2InNtuple);
+            hitIdxInNtuple_vec3.push_back(hitIdx3InNtuple);
+            ptIn_vec.push_back(ptIn);
+            ptErr_vec.push_back(ptErr);
+            etaErr_vec.push_back(etaErr);
+            deltaPhi_vec.push_back(pixelSegmentDeltaPhiChange);
        } 
     }
+//    trkX.insert(trkX.end(),vecX.begin(),vecX.end());
+//    trkY.insert(trkY.end(),vecY.begin(),vecY.end());
+//    trkZ.insert(trkZ.end(),vecZ.begin(),vecZ.end());
+//    hitId.insert(hitId.end(),hitIndices_vec.begin(),hitIndices_vec.end());
+    event.addHitToEventOMP(trkX,trkY,trkZ,hitId);
+//    event.addPixelSegmentToEventV2(hitIndices_vec0,hitIndices_vec1,hitIndices_vec2,hitIndices_vec3, deltaPhi_vec, ptIn_vec, ptErr_vec, px_vec, py_vec, pz_vec, etaErr_vec);
 }
 
 int main(int argc, char** argv)
@@ -663,7 +737,8 @@ int main(int argc, char** argv)
             my_timer.Start();
             // Adding hits to modules
 //            event.addHitToEventGPU(trk.ph2_x(),trk.ph2_y(),trk.ph2_z(),trk.ph2_detId()); // adds explicit hits using a kernel approach. Slower than serial...
-            event.addHitToEventOMP(trk.ph2_x(),trk.ph2_y(),trk.ph2_z(),trk.ph2_detId()); //adds explicit hits using omp or serial approach.  check if this runs with omp or serially before you start!
+//            event.addHitToEventOMP(trk.ph2_x(),trk.ph2_y(),trk.ph2_z(),trk.ph2_detId(),0); //adds explicit hits using omp or serial approach.  check if this runs with omp or serially before you start!
+            addPixelSegments(event,-1,trk.ph2_x(),trk.ph2_y(),trk.ph2_z(),trk.ph2_detId()); //loads both pixels and hits at same time
             //old load hits method for unified memory
 //            for (unsigned int ihit = 0; ihit < trk.ph2_x().size(); ++ihit)
 //            {
@@ -744,13 +819,14 @@ int main(int argc, char** argv)
             // ----------------
             if(ana.verbose != 0) std::cout<<"Adding Pixel Segments!"<<std::endl;
             my_timer.Start(kFALSE);
-            addPixelSegments(event,-1,trk.ph2_x().size());
+//            addPixelSegments(event,-1,trk.ph2_x().size());
+//            addPixelSegments(event,-1,trk.ph2_x(),trk.ph2_y(),trk.ph2_z(),trk.ph2_detId()); //loads both pixels and hits at same time
             float pix_elapsed = my_timer.RealTime();
             event_times[ana.looper.getCurrentEventIndex()][4] = pix_elapsed - tp_elapsed;
    
             if(ana.verbose != 0) std::cout<<" Reco Pixel Tracklet start"<<std::endl;
             my_timer.Start(kFALSE);
-            event.createPixelTracklets();
+//            event.createPixelTracklets();
             float ptl_elapsed = my_timer.RealTime();
             event_times[ana.looper.getCurrentEventIndex()][5] = ptl_elapsed - pix_elapsed;
             if (ana.verbose != 0) std::cout << "Reco Pixel Tracklet processing time: " << ptl_elapsed - pix_elapsed << " secs" << std::endl;

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -18,21 +18,21 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
     std::vector<float> px_vec;
     std::vector<float> py_vec;
     std::vector<float> pz_vec;
-    std::vector<float> vecX;
-    std::vector<float> vecY;
-    std::vector<float> vecZ;
-    std::vector<int> hitIdxInNtuple_vec0;
-    std::vector<int> hitIdxInNtuple_vec1;
-    std::vector<int> hitIdxInNtuple_vec2;
-    std::vector<int> hitIdxInNtuple_vec3;
+//    std::vector<float> vecX;
+//    std::vector<float> vecY;
+//    std::vector<float> vecZ;
+//    std::vector<int> hitIdxInNtuple_vec0;
+//    std::vector<int> hitIdxInNtuple_vec1;
+//    std::vector<int> hitIdxInNtuple_vec2;
+//    std::vector<int> hitIdxInNtuple_vec3;
     std::vector<unsigned int> hitIndices_vec0;
     std::vector<unsigned int> hitIndices_vec1;
     std::vector<unsigned int> hitIndices_vec2;
     std::vector<unsigned int> hitIndices_vec3;
-    std::vector<float> ptIn_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
-    std::vector<float> ptErr_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
-    std::vector<float> etaErr_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
-    std::vector<float> deltaPhi_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
+    std::vector<float> ptIn_vec;
+    std::vector<float> ptErr_vec;
+    std::vector<float> etaErr_vec;
+    std::vector<float> deltaPhi_vec;
     for (auto&& [iSeed, _] : iter::enumerate(trk.see_stateTrajGlbPx()))
     {
 
@@ -143,23 +143,23 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
 //
 //            event.addPixelSegmentToEvent(hitIndices, pixelSegmentDeltaPhiChange, ptIn, ptErr, px, py, pz, etaErr);
       // new explicit hits version. Works for both explicit and unified hits. 
-	          int hitIdx0InNtuple = trk.see_hitIdx()[iSeed][0];
+//	          int hitIdx0InNtuple = trk.see_hitIdx()[iSeed][0];
 //            event.addPixToEvent(r3PCA.X(), r3PCA.Y(), r3PCA.Z(), 1, hitIdx0InNtuple);
             unsigned int hitIdx0 = hit_size + count;
             count++; // incrementing the counter after the hitIdx should take care for the -1 right?
      
-            int hitIdx1InNtuple = trk.see_hitIdx()[iSeed][1];
+//            int hitIdx1InNtuple = trk.see_hitIdx()[iSeed][1];
 //            event.addPixToEvent(r3PCA.X(), r3PCA.Y(), r3PCA.Z(), 1, hitIdx1InNtuple);
             unsigned int hitIdx1 = hit_size + count;
             count++;
 
-            int hitIdx2InNtuple = trk.see_hitIdx()[iSeed][2];
+//            int hitIdx2InNtuple = trk.see_hitIdx()[iSeed][2];
 
 //            event.addPixToEvent(r3LH.X(), r3LH.Y(), r3LH.Z(),1,hitIdx2InNtuple);
             unsigned int hitIdx2 = hit_size + count;
             count++;
 
-            int hitIdx3InNtuple = trk.see_hitIdx()[iSeed].size() > 3 ? trk.see_hitIdx()[iSeed][3] : trk.see_hitIdx()[iSeed][2]; // repeat last one if triplet
+//            int hitIdx3InNtuple = trk.see_hitIdx()[iSeed].size() > 3 ? trk.see_hitIdx()[iSeed][3] : trk.see_hitIdx()[iSeed][2]; // repeat last one if triplet
             unsigned int hitIdx3;
             if(trk.see_hitIdx()[iSeed].size() <= 3)
             {   
@@ -172,10 +172,10 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
                 count++;
             }
 
-            std::vector<unsigned int> hitIndices = {hitIdx0, hitIdx1, hitIdx2, hitIdx3}; 
+//            std::vector<unsigned int> hitIndices = {hitIdx0, hitIdx1, hitIdx2, hitIdx3}; 
 
 //            event.addPixelSegmentToEvent(hitIndices, pixelSegmentDeltaPhiChange, ptIn, ptErr, px, py, pz, etaErr);
-//          printf("test: %u (%u,%u,%u,%u)\n",iSeed,hitIdx0,hitIdx1,hitIdx2,hitIdx3);
+
 //          NEWEST VERSION
             trkX.push_back(r3PCA.X());
             trkY.push_back(r3PCA.Y());
@@ -197,31 +197,10 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
             py_vec.push_back(py);
             pz_vec.push_back(pz);
 
-            //vecX.push_back(r3PCA.X());
-            //vecY.push_back(r3PCA.Y());
-            //vecZ.push_back(r3PCA.Z());
-            //vecX.push_back(r3PCA.X());
-            //vecY.push_back(r3PCA.Y());
-            //vecZ.push_back(r3PCA.Z());
-            //vecX.push_back(r3LH.X());
-            //vecY.push_back(r3LH.Y());
-            //vecZ.push_back(r3LH.Z());
-            //vecX.push_back(r3LH.X());
-            //vecY.push_back(r3LH.Y());
-            //vecZ.push_back(r3LH.Z());
-            //hitIndices_vec.push_back(1);
-            //hitIndices_vec.push_back(1);
-            //hitIndices_vec.push_back(1);
-            //hitIndices_vec.push_back(1);
             hitIndices_vec0.push_back(hitIdx0);
             hitIndices_vec1.push_back(hitIdx1);
             hitIndices_vec2.push_back(hitIdx2);
             hitIndices_vec3.push_back(hitIdx3);
-
-            hitIdxInNtuple_vec0.push_back(hitIdx0InNtuple);
-            hitIdxInNtuple_vec1.push_back(hitIdx1InNtuple);
-            hitIdxInNtuple_vec2.push_back(hitIdx2InNtuple);
-            hitIdxInNtuple_vec3.push_back(hitIdx3InNtuple);
             ptIn_vec.push_back(ptIn);
             ptErr_vec.push_back(ptErr);
             etaErr_vec.push_back(etaErr);

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -233,7 +233,7 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
 //    trkZ.insert(trkZ.end(),vecZ.begin(),vecZ.end());
 //    hitId.insert(hitId.end(),hitIndices_vec.begin(),hitIndices_vec.end());
     event.addHitToEventOMP(trkX,trkY,trkZ,hitId);
-//    event.addPixelSegmentToEventV2(hitIndices_vec0,hitIndices_vec1,hitIndices_vec2,hitIndices_vec3, deltaPhi_vec, ptIn_vec, ptErr_vec, px_vec, py_vec, pz_vec, etaErr_vec);
+    event.addPixelSegmentToEventV2(hitIndices_vec0,hitIndices_vec1,hitIndices_vec2,hitIndices_vec3, deltaPhi_vec, ptIn_vec, ptErr_vec, px_vec, py_vec, pz_vec, etaErr_vec);
 }
 
 int main(int argc, char** argv)
@@ -817,19 +817,19 @@ int main(int argc, char** argv)
             // ----------------
 
             // ----------------
-            if(ana.verbose != 0) std::cout<<"Adding Pixel Segments!"<<std::endl;
-            my_timer.Start(kFALSE);
+//            if(ana.verbose != 0) std::cout<<"Adding Pixel Segments!"<<std::endl;
+//            my_timer.Start(kFALSE);
 //            addPixelSegments(event,-1,trk.ph2_x().size());
 //            addPixelSegments(event,-1,trk.ph2_x(),trk.ph2_y(),trk.ph2_z(),trk.ph2_detId()); //loads both pixels and hits at same time
-            float pix_elapsed = my_timer.RealTime();
-            event_times[ana.looper.getCurrentEventIndex()][4] = pix_elapsed - tp_elapsed;
+//            float pix_elapsed = my_timer.RealTime();
+//            event_times[ana.looper.getCurrentEventIndex()][4] = pix_elapsed - tp_elapsed;
    
             if(ana.verbose != 0) std::cout<<" Reco Pixel Tracklet start"<<std::endl;
             my_timer.Start(kFALSE);
-//            event.createPixelTracklets();
+            event.createPixelTracklets();
             float ptl_elapsed = my_timer.RealTime();
-            event_times[ana.looper.getCurrentEventIndex()][5] = ptl_elapsed - pix_elapsed;
-            if (ana.verbose != 0) std::cout << "Reco Pixel Tracklet processing time: " << ptl_elapsed - pix_elapsed << " secs" << std::endl;
+            event_times[ana.looper.getCurrentEventIndex()][4] = ptl_elapsed - tp_elapsed;
+            if (ana.verbose != 0) std::cout << "Reco Pixel Tracklet processing time: " << ptl_elapsed - tp_elapsed << " secs" << std::endl;
  
             if (ana.verbose != 0) std::cout << "Reco Tracklet start" << std::endl;
             my_timer.Start(kFALSE);
@@ -838,7 +838,7 @@ int main(int argc, char** argv)
 //             event.createTrackletsWithAGapWithModuleMap();
             //event.createTrackletsViaNavigation();
             float tl_elapsed = my_timer.RealTime();
-            event_times[ana.looper.getCurrentEventIndex()][6] = tl_elapsed - ptl_elapsed;
+            event_times[ana.looper.getCurrentEventIndex()][5] = tl_elapsed - ptl_elapsed;
             if (ana.verbose != 0) std::cout << "Reco Tracklet processing time: " << tl_elapsed - ptl_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of Tracklets produced: " << event.getNumberOfTracklets() << std::endl;
             if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
@@ -855,7 +855,7 @@ int main(int argc, char** argv)
             event.createTrackCandidates();
             //event.createTrackCandidatesFromTracklets();
             float tc_elapsed = my_timer.RealTime();
-            event_times[ana.looper.getCurrentEventIndex()][7] = tc_elapsed - tl_elapsed;
+            event_times[ana.looper.getCurrentEventIndex()][6] = tc_elapsed - tl_elapsed;
             if (ana.verbose != 0) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed - tl_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
             if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
@@ -900,33 +900,33 @@ int main(int argc, char** argv)
     std::cout<<setprecision(2);
     std::cout<<right;
     std::cout<< "Timing summary"<<std::endl;
-    std::cout<< "Evt     Hits       MD   Segments Triplets  Pixels  pTracklet  Tracklet  Tracks    Total  Total(no load)"<<std::endl;
+    std::cout<< "Evt     Hits       MD   Segments Triplets  pTracklet  Tracklet  Tracks    Total  Total(no load)"<<std::endl;
     float avg_hit = 0.;
     float avg_md = 0.;
     float avg_seg = 0.;
     float avg_trip = 0.;
-    float avg_pix = 0.;
+    //float avg_pix = 0.;
     float avg_plet = 0.;
     float avg_tlet = 0.;
     float avg_track = 0.;
     float avg_tot = 0.;
     float avg_noload = 0.;
     for(int ev=0;ev<ana.n_events;ev++){
-        float total =event_times[ev][0]+event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+event_times[ev][4]+ event_times[ev][5]+event_times[ev][6]+event_times[ev][7];
-        float no_load =event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+ event_times[ev][5]+event_times[ev][6]+event_times[ev][7];
+        float total =event_times[ev][0]+event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+event_times[ev][4]+ event_times[ev][5]+event_times[ev][6];//+event_times[ev][7];
+        float no_load =event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+ event_times[ev][5]+event_times[ev][6];//+event_times[ev][7];
         avg_hit += event_times[ev][0]; 
         avg_md += event_times[ev][1]; 
         avg_seg += event_times[ev][2]; 
         avg_trip += event_times[ev][3]; 
-        avg_pix += event_times[ev][4]; 
-        avg_plet += event_times[ev][5]; 
-        avg_tlet += event_times[ev][6]; 
-        avg_track += event_times[ev][7]; 
+       // avg_pix += event_times[ev][4]; 
+        avg_plet += event_times[ev][4]; 
+        avg_tlet += event_times[ev][5]; 
+        avg_track += event_times[ev][6]; 
         avg_tot += total;
         avg_noload += no_load;
-        std::cout<<ev<<"      "<<setw(6)<<event_times[ev][0]*1000 <<"   "<<setw(6)<<event_times[ev][1]*1000 <<"   "<<setw(6)<<event_times[ev][2]*1000 <<"   "<<setw(6)<<event_times[ev][3]*1000 <<"   "<<setw(7)<<event_times[ev][4]*1000 <<"   "<<setw(6)<<event_times[ev][5]*1000<<"   "<<setw(6)<<event_times[ev][6]*1000<<"   "<<setw(6)<<event_times[ev][7]*1000<<"   "<<setw(7)<<total*1000<<"   "<<setw(7)<<no_load*1000<<std::endl;
+        std::cout<<ev<<"      "<<setw(6)<<event_times[ev][0]*1000 <<"   "<<setw(6)<<event_times[ev][1]*1000 <<"   "<<setw(6)<<event_times[ev][2]*1000 <<"   "<<setw(6)<<event_times[ev][3]*1000 <<"   "<<setw(7)<<event_times[ev][4]*1000 <<"   "<<setw(6)<<event_times[ev][5]*1000<<"   "<<setw(6)<<event_times[ev][6]*1000<<"   "/*<<setw(6)<<event_times[ev][7]*1000<<"   "*/<<setw(7)<<total*1000<<"   "<<setw(7)<<no_load*1000<<std::endl;
     }
-        std::cout<<"avg:   "<<setw(6)<<avg_hit*1000/ana.n_events <<"   "<<setw(6)<<avg_md*1000/ana.n_events <<"   "<<setw(6)<<avg_seg*1000/ana.n_events <<"   "<<setw(6)<<avg_trip*1000/ana.n_events <<"   "<<setw(7)<<avg_pix*1000/ana.n_events<<"   "<<setw(6)<<avg_plet*1000/ana.n_events<<"   "<<setw(6)<<avg_tlet*1000/ana.n_events<<"   "<<setw(6)<<avg_track*1000/ana.n_events<<"   "<<setw(7)<<avg_tot*1000/ana.n_events<<"   "<<setw(7)<<avg_noload*1000/ana.n_events<<std::endl;
+        std::cout<<"avg:   "<<setw(6)<<avg_hit*1000/ana.n_events <<"   "<<setw(6)<<avg_md*1000/ana.n_events <<"   "<<setw(6)<<avg_seg*1000/ana.n_events <<"   "<<setw(6)<<avg_trip*1000/ana.n_events <<"   "/*<<setw(7)<<avg_pix*1000/ana.n_events<<"   "*/<<setw(6)<<avg_plet*1000/ana.n_events<<"   "<<setw(6)<<avg_tlet*1000/ana.n_events<<"   "<<setw(6)<<avg_track*1000/ana.n_events<<"   "<<setw(7)<<avg_tot*1000/ana.n_events<<"   "<<setw(7)<<avg_noload*1000/ana.n_events<<std::endl;
 
     SDL::cleanModules();
 


### PR DESCRIPTION
Now loads the hits and pixels to explicit memory at the same time with fewer kernels launched and memory allocations. To load the pixels in the MD and segment objects, those objects now have to be allocated in the load hits call. This also gives back cuda-memcheck functionality when loading hits (no hanging).
The print out statements are the same as before (excluding known instabilities) but i find these results questionable as they don't seem to change whether or not pixels are loaded. @bsathian , can you please verify that the pixels are working correctly here and that the output is the same as the CPU versions?
The Hit output was also removed (reports 0) as it doesn't seem meaningful anymore. 

Average Times  Hits       MD   Segments Triplets  pTracklet  Tracklet  Tracks    Total  Total(no load)
explicit    avg:   531.28    11.38   155.28    68.41     9.18   322.84   117.31   1215.67    675.21
explicit C avg:   533.79    11.77   162.99    69.57     2.69   333.46   121.38   1235.65    699.16
Unified    avg:   513.76    22.50   183.10   156.30    13.52   222.03   102.05   1213.24    685.97
unified C avg:   531.53    13.62   168.53    92.23    18.48   290.56   104.68   1219.63    669.61

