### PR TITLE
Fixing bugs from previous pull request

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1962,5 +1962,6 @@ std::shared_ptr<SDL::trackCandidates> SDL::Event::getTrackCandidates()
     unsigned int nMemoryLocations = (N_MAX_TRACK_CANDIDATES_PER_MODULE) * (nLowerModules) + (N_MAX_PIXEL_TRACK_CANDIDATES_PER_MODULE);
     cudaMemcpy(trackCandidatesInCPU->objectIndices, trackCandidatesInGPU->objectIndices, 2 * nMemoryLocations * sizeof(unsigned int), cudaMemcpyDeviceToHost);
     cudaMemcpy(trackCandidatesInCPU->trackCandidateType, trackCandidatesInGPU->trackCandidateType, nMemoryLocations * sizeof(short), cudaMemcpyDeviceToHost);
+    cudaMemcpy(trackCandidatesInCPU->nTrackCandidates, trackCandidatesInGPU->nTrackCandidates, (nLowerModules + 1) * sizeof(unsigned int), cudaMemcpyDeviceToHost);
     return trackCandidatesInCPU;
 }

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1879,23 +1879,26 @@ unsigned int SDL::Event::getNumberOfTrackCandidates()
     {
         trackCandidates += it;
     }
-
+    
     //hack - add pixel track candidate multiplicity
-#ifdef Explicit_Track
-    unsigned int nLowerModules = *(SDL::modulesInGPU->nLowerModules);
-    unsigned int nTrackCandidatesInPixelModule;
-    cudaMemcpy(&nTrackCandidatesInPixelModule,&trackCandidatesInGPU->nTrackCandidates[nLowerModules],sizeof(unsigned int),cudaMemcpyDeviceToHost);
-//    std::cout<<"number of pixel track candidates = "<<nTrackCandidatesInPixelModule<<std::endl;
-    trackCandidates += nTrackCandidatesInPixelModule;
-#else
-    trackCandidates += trackCandidatesInGPU->nTrackCandidates[*(modulesInGPU->nLowerModules)];
-#endif
+    trackCandidates += getNumberOfTrackCandidates();
 
     return trackCandidates;
    
 }
 
+unsigned int SDL::Event::getNumberOfPixelTrackCandidates()
+{
+#ifdef Explicit_Track
+    unsigned int nLowerModules = *(SDL::modulesInGPU->nLowerModules);
+    unsigned int nTrackCandidatesInPixelModule;
+    cudaMemcpy(&nTrackCandidatesInPixelModule,&trackCandidatesInGPU->nTrackCandidates[nLowerModules],sizeof(unsigned int),cudaMemcpyDeviceToHost);
+    return nTrackCandidatesInPixelModule;
+#else
+    return trackCandidatesInGPU->nTrackCandidates[*(modulesInGPU->nLowerModules)];
+#endif
 
+}
 unsigned int SDL::Event::getNumberOfTrackCandidatesByLayer(unsigned int layer)
 {
     if(layer == 6)

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1881,7 +1881,7 @@ unsigned int SDL::Event::getNumberOfTrackCandidates()
     }
     
     //hack - add pixel track candidate multiplicity
-    trackCandidates += getNumberOfTrackCandidates();
+    trackCandidates += getNumberOfPixelTrackCandidates();
 
     return trackCandidates;
    

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -12,7 +12,7 @@ const unsigned int N_MAX_TRACK_CANDIDATES_PER_MODULE = 50000;
 const unsigned int N_MAX_PIXEL_MD_PER_MODULES = 100000;
 const unsigned int N_MAX_PIXEL_SEGMENTS_PER_MODULE = 50000;
 const unsigned int N_MAX_PIXEL_TRACKLETS_PER_MODULE = 3000000;
-const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES_PER_MODULE = 2000000;
+const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES_PER_MODULE = 5000000;
 
 
 struct SDL::modules* SDL::modulesInGPU = nullptr;
@@ -388,7 +388,7 @@ __global__ void /*SDL::Event::*/addPixelSegmentToEventKernel(unsigned int* hitIn
     //step 2 : Add pixel segment
     unsigned int pixelSegmentIndex = pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE + segmentsInGPU.nSegments[pixelModuleIndex];
     //FIXME:Fake Pixel Segment gets added to Segment unified memory in a convoluted fashion!
-    addPixelSegmentToMemory(segmentsInGPU, mdsInGPU, hitsInGPU, modulesInGPU, innerMDIndex, outerMDIndex, pixelModuleIndex, hitIndices[0], hitIndices[2], dPhiChange, ptIn, ptErr, px, py, pz, etaErr, pixelSegmentIndex);
+    addPixelSegmentToMemory(segmentsInGPU, mdsInGPU, hitsInGPU, modulesInGPU, innerMDIndex, outerMDIndex, pixelModuleIndex, hitIndices[0], hitIndices[2], dPhiChange, ptIn, ptErr, px, py, pz, etaErr, pixelSegmentIndex, segmentsInGPU.nSegments[pixelModuleIndex]);
     segmentsInGPU.nSegments[pixelModuleIndex]++;
 }
 void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr)
@@ -416,7 +416,7 @@ __global__ void addPixelSegmentToEventKernelV2(unsigned int* hitIndices0,unsigne
       addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices2[tid], hitIndices3[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,outerMDIndex);
 
       unsigned int pixelSegmentIndex = pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE + tid;
-      addPixelSegmentToMemory(segmentsInGPU, mdsInGPU, hitsInGPU, modulesInGPU, innerMDIndex, outerMDIndex, pixelModuleIndex, hitIndices0[tid], hitIndices2[tid], dPhiChange[tid], ptIn[tid], ptErr[tid], px[tid], py[tid], pz[tid], etaErr[tid], pixelSegmentIndex);
+      addPixelSegmentToMemory(segmentsInGPU, mdsInGPU, hitsInGPU, modulesInGPU, innerMDIndex, outerMDIndex, pixelModuleIndex, hitIndices0[tid], hitIndices2[tid], dPhiChange[tid], ptIn[tid], ptErr[tid], px[tid], py[tid], pz[tid], etaErr[tid], pixelSegmentIndex, tid);
     }
 }
 void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> etaErr)
@@ -440,7 +440,7 @@ void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,
 #endif
     }
     const int size = ptIn.size();
-    unsigned int pixelModuleIndex = (*detIdToIndex)[1] -1; //double check the -1?
+    unsigned int pixelModuleIndex = (*detIdToIndex)[1]; //double check the -1?
     unsigned int* hitIndices0_host = &hitIndices0[0];
     unsigned int* hitIndices1_host = &hitIndices1[0];
     unsigned int* hitIndices2_host = &hitIndices2[0];
@@ -492,7 +492,10 @@ void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,
     unsigned int nThreads = 256;
     unsigned int nBlocks =  size % nThreads == 0 ? size/nThreads : size/nThreads + 1;
   addPixelSegmentToEventKernelV2<<<nBlocks,nThreads>>>(hitIndices0_dev,hitIndices1_dev,hitIndices2_dev,hitIndices3_dev,dPhiChange_dev,ptIn_dev,ptErr_dev,px_dev,py_dev,pz_dev,etaErr_dev,pixelModuleIndex, *modulesInGPU,*hitsInGPU,*mdsInGPU,*segmentsInGPU,size);
-  cudaDeviceSynchronize();
+   std::cout<<"Number of pixel segments = "<<size<<std::endl;
+   cudaDeviceSynchronize();
+   cudaMemcpy(&(segmentsInGPU->nSegments)[pixelModuleIndex], &size, sizeof(unsigned int), cudaMemcpyHostToDevice);
+
   cudaFree(hitIndices0_dev);
   cudaFree(hitIndices1_dev);
   cudaFree(hitIndices2_dev);
@@ -839,7 +842,10 @@ void SDL::Event::createPixelTracklets()
 //#if defined(AddObjects) && !defined(Full_Explicit)
  //   std::cout<<"Number of pixel tracklets = "<<trackletsInGPU->nTracklets[nLowerModules]<<std::endl;
 //#endif
-
+    unsigned int *nPixelTracklets;
+    cudaMallocHost(&nPixelTracklets, sizeof(unsigned int));
+    cudaMemcpy(nPixelTracklets, &(trackletsInGPU->nTracklets[nLowerModules]), sizeof(unsigned int), cudaMemcpyDeviceToHost);
+    std::cout<<"number of pixel tracklets = "<<*nPixelTracklets<<std::endl;
 }
 
 void SDL::Event::createTrackCandidates()
@@ -985,8 +991,8 @@ void SDL::Event::addTrackCandidatesToEventExplicit()
 {
 unsigned int nLowerModules = *(SDL::modulesInGPU->nLowerModules);
 unsigned int* nTrackCandidatesCPU;
-cudaMallocHost(&nTrackCandidatesCPU, nLowerModules * sizeof(unsigned int));
-cudaMemcpy(nTrackCandidatesCPU,trackCandidatesInGPU->nTrackCandidates,nLowerModules*sizeof(unsigned int),cudaMemcpyDeviceToHost);
+cudaMallocHost(&nTrackCandidatesCPU, (nLowerModules )* sizeof(unsigned int));
+cudaMemcpy(nTrackCandidatesCPU,trackCandidatesInGPU->nTrackCandidates,(nLowerModules)*sizeof(unsigned int),cudaMemcpyDeviceToHost);
 
     unsigned int idx;
     for(unsigned int i = 0; i<*(SDL::modulesInGPU->nLowerModules); i++)
@@ -1349,7 +1355,6 @@ __global__ void createPixelTrackletsInGPU(struct SDL::modules& modulesInGPU, str
     unsigned int nOuterSegments = segmentsInGPU.nSegments[outerInnerLowerModuleIndex];
     if(nOuterSegments == 0) return;
     if(nInnerSegments == 0) return;
-
     dim3 nThreads(16,16,1);
     dim3 nBlocks(nInnerSegments % nThreads.x == 0 ? nInnerSegments / nThreads.x : nInnerSegments / nThreads.x + 1, nOuterSegments % nThreads.y == 0 ? nOuterSegments / nThreads.y : nOuterSegments / nThreads.y + 1, 1);
 
@@ -1592,10 +1597,10 @@ __global__ void createTrackCandidatesInGPU(struct SDL::modules& modulesInGPU, st
     //inner tracklet/triplet inner segment inner MD lower module
     int innerInnerInnerLowerModuleArrayIndex = blockIdx.x * blockDim.x + threadIdx.x;
     //hack to include pixel detector
-    if(innerInnerInnerLowerModuleArrayIndex >= *modulesInGPU.nLowerModules /*+ 1*/) return; 
+    if(innerInnerInnerLowerModuleArrayIndex >= *modulesInGPU.nLowerModules + 1) return; 
 
     unsigned int nTracklets = trackletsInGPU.nTracklets[innerInnerInnerLowerModuleArrayIndex];
-    unsigned int nTriplets = tripletsInGPU.nTriplets[innerInnerInnerLowerModuleArrayIndex]; // should be zero for the pixels
+    unsigned int nTriplets = innerInnerInnerLowerModuleArrayIndex == *modulesInGPU.nLowerModules ? 0 : tripletsInGPU.nTriplets[innerInnerInnerLowerModuleArrayIndex]; // should be zero for the pixels
 
     unsigned int temp = max(nTracklets,nTriplets);
     unsigned int MAX_OBJECTS = max(N_MAX_TRACKLETS_PER_MODULE, N_MAX_TRIPLETS_PER_MODULE);
@@ -1871,11 +1876,10 @@ unsigned int SDL::Event::getNumberOfTrackCandidates()
     //hack - add pixel track candidate multiplicity
 #ifdef Explicit_Track
     unsigned int nLowerModules = *(SDL::modulesInGPU->nLowerModules);
-    unsigned int* nTrackCandidatesCPU;
-    cudaMallocHost(&nTrackCandidatesCPU, (nLowerModules+1) * sizeof(unsigned int));
-    cudaMemcpy(nTrackCandidatesCPU,trackCandidatesInGPU->nTrackCandidates,(1+nLowerModules)*sizeof(unsigned int),cudaMemcpyDeviceToHost);
-    trackCandidates += nTrackCandidatesCPU[nLowerModules];
-    cudaFreeHost(nTrackCandidatesCPU);
+    unsigned int nTrackCandidatesInPixelModule;
+    cudaMemcpy(&nTrackCandidatesInPixelModule,&trackCandidatesInGPU->nTrackCandidates[nLowerModules],sizeof(unsigned int),cudaMemcpyDeviceToHost);
+//    std::cout<<"number of pixel track candidates = "<<nTrackCandidatesInPixelModule<<std::endl;
+    trackCandidates += nTrackCandidatesInPixelModule;
 #else
     trackCandidates += trackCandidatesInGPU->nTrackCandidates[*(modulesInGPU->nLowerModules)];
 #endif

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -407,30 +407,24 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices, fl
 __global__ void addPixelSegmentToEventKernelV2(unsigned int* hitIndices0,unsigned int* hitIndices1,unsigned int* hitIndices2,unsigned int* hitIndices3, float* dPhiChange, float* ptIn, float* ptErr, float* px, float* py, float* pz, float* etaErr,unsigned int pixelModuleIndex, struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU,const int size)
 {
 
-    
-    //const int init_nMD = mdsInGPU.nMDs[pixelModuleIndex];
-    //const int init_nSeg = segmentsInGPU.nSegments[pixelModuleIndex];
-    //printf("Init test: %d %d\n",init_nMD,init_nSeg);
     for( int tid = blockIdx.x * blockDim.x + threadIdx.x; tid < size; tid += blockDim.x*gridDim.x)
     {
 
-      unsigned int innerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES + /*init_nMD +*/ 2*(tid); //mdsInGPU.nMDs[pixelModuleIndex];
+      unsigned int innerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES + 2*(tid); 
       addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices0[tid], hitIndices1[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,innerMDIndex);
-      unsigned int outerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES /*+ init_nMD*/ + 2*(tid) +1;//mdsInGPU.nMDs[pixelModuleIndex];
+      unsigned int outerMDIndex = pixelModuleIndex * N_MAX_MD_PER_MODULES + 2*(tid) +1;
       addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices2[tid], hitIndices3[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,outerMDIndex);
 
-      unsigned int pixelSegmentIndex = pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE /*+ init_nSeg*/ + tid;//segmentsInGPU.nSegments[pixelModuleIndex];
+      unsigned int pixelSegmentIndex = pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE + tid;
       addPixelSegmentToMemory(segmentsInGPU, mdsInGPU, hitsInGPU, modulesInGPU, innerMDIndex, outerMDIndex, pixelModuleIndex, hitIndices0[tid], hitIndices2[tid], dPhiChange[tid], ptIn[tid], ptErr[tid], px[tid], py[tid], pz[tid], etaErr[tid], pixelSegmentIndex);
     }
 }
 void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> etaErr)
 {
-//    assert(hitIndices.size() == 4);
     if(mdsInGPU == nullptr)
     {
         cudaMallocHost(&mdsInGPU, sizeof(SDL::miniDoublets));
 #ifdef Explicit_MD
-        //FIXME: Add memory locations for pixel MDs
     	createMDsInExplicitMemory(*mdsInGPU, N_MAX_MD_PER_MODULES, nModules, N_MAX_PIXEL_MD_PER_MODULES);
 #else
     	createMDsInUnifiedMemory(*mdsInGPU, N_MAX_MD_PER_MODULES, nModules, N_MAX_PIXEL_MD_PER_MODULES);
@@ -440,8 +434,6 @@ void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,
     {
         cudaMallocHost(&segmentsInGPU, sizeof(SDL::segments));
 #ifdef Explicit_Seg
-        //FIXME:Add memory locations for pixel segments
-        //createSegmentsInExplicitMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nModules);
         createSegmentsInExplicitMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE);
 #else
         createSegmentsInUnifiedMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE);
@@ -499,7 +491,7 @@ void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,
 
     unsigned int nThreads = 256;
     unsigned int nBlocks =  size % nThreads == 0 ? size/nThreads : size/nThreads + 1;
-  addPixelSegmentToEventKernelV2<<<1,1>>>(hitIndices0_dev,hitIndices1_dev,hitIndices2_dev,hitIndices3_dev,dPhiChange_dev,ptIn_dev,ptErr_dev,px_dev,py_dev,pz_dev,etaErr_dev,pixelModuleIndex, *modulesInGPU,*hitsInGPU,*mdsInGPU,*segmentsInGPU,size);
+  addPixelSegmentToEventKernelV2<<<nBlocks,nThreads>>>(hitIndices0_dev,hitIndices1_dev,hitIndices2_dev,hitIndices3_dev,dPhiChange_dev,ptIn_dev,ptErr_dev,px_dev,py_dev,pz_dev,etaErr_dev,pixelModuleIndex, *modulesInGPU,*hitsInGPU,*mdsInGPU,*segmentsInGPU,size);
   cudaDeviceSynchronize();
   cudaFree(hitIndices0_dev);
   cudaFree(hitIndices1_dev);
@@ -514,102 +506,6 @@ void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,
   cudaFree(etaErr_dev);
 }
 
-//void SDL::Event::addPixelSegmentToEventV2(std::vector<std::vector<float>> r3PCA, std::vector<std::vector<float>> r3LH, std::vector<std::vector<int>> hitIdxInNtuple,std::vector<std::vector<unsigned int>> hitIndicies, std::vector<std::vector<float>> pt){
-//
-//    const int loopsize = r3PCA.at(0).size() + r3LH.at(0).size();
-//
-//    float* r3PCA_X = &r3PCA.at(0);
-//    float* r3PCA_Y = &r3PCA.at(1);
-//    float* r3PCA_Z = &r3PCA.at(2);
-//    float* r3LH_X = &r3LH.at(0);
-//    float* r3LH_Y = &r3LH.at(1);
-//    float* r3LH_Z = &r3LH.at(2);
-//    int* hitIdxInNtuple0 = &hitIdxInNtuple.at(0);
-//    int* hitIdxInNtuple1 = &hitIdxInNtuple.at(1);
-//    int* hitIdxInNtuple2 = &hitIdxInNtuple.at(2);
-//    int* hitIdxInNtuple3 = &hitIdxInNtuple.at(3);
-//    unsigned int* hitIndices0 = &hitIndices.at(0);
-//    unsigned int* hitIndices1 = &hitIndices.at(1);
-//    unsigned int* hitIndices2 = &hitIndices.at(2);
-//    unsigned int* hitIndices3 = &hitIndices.at(3);
-//    float* ptIn = &pt.at(0);
-//    float* ptErr = &pt.at(1);
-//    float* etaErr = &pt.at(2);
-//    float* deltaPhi = &pt.at(3);
-//
-//    
-////#pragma omp parallel for  // this part can be run in parallel.
-//  for (int ihit=0; ihit<loopsize;ihit++){
-//    unsigned int moduleLayer = modulesInGPU->layers[(*detIdToIndex)[host_detId[ihit]]];
-//    unsigned int subdet = modulesInGPU->subdets[(*detIdToIndex)[host_detId[ihit]]];
-//    host_moduleIndex[ihit] = (*detIdToIndex)[host_detId[ihit]];
-//
-//    if(subdet == Barrel)
-//    {
-//        n_hits_by_layer_barrel_[moduleLayer-1]++;
-//    }
-//    else
-//    {
-//        n_hits_by_layer_endcap_[moduleLayer-1]++;
-//    }
-//  
-//
-//      host_rts[ihit] = sqrt(host_x[ihit]*host_x[ihit] + host_y[ihit]*host_y[ihit]);
-//      host_phis[ihit] = phi(host_x[ihit],host_y[ihit],host_z[ihit]);
-//      host_idxs[ihit] = ihit;
-////  }
-////// This part i think has a race condition. so this is not run in parallel. 
-//////#pragma omp parallel for
-////  for (int ihit=0; ihit<loopsize;ihit++){
-//      unsigned int this_index = host_moduleIndex[ihit];
-//      if(modulesInGPU->subdets[this_index] == Endcap && modulesInGPU->moduleType[this_index] == TwoS)
-//      {
-//          float xhigh, yhigh, xlow, ylow;
-//          getEdgeHits(host_detId[ihit],host_x[ihit],host_y[ihit],xhigh,yhigh,xlow,ylow);
-//          host_highEdgeXs[ihit] = xhigh;
-//          host_highEdgeYs[ihit] = yhigh;
-//          host_lowEdgeXs[ihit] = xlow;
-//          host_lowEdgeYs[ihit] = ylow;
-//
-//      }
-//
-//      //set the hit ranges appropriately in the modules struct
-//
-//      //start the index rolling if the module is encountered for the first time
-//      if(modulesInGPU->hitRanges[this_index * 2] == -1)
-//      {
-//          modulesInGPU->hitRanges[this_index * 2] = ihit;
-//      }
-//      //always update the end index
-//      modulesInGPU->hitRanges[this_index * 2 + 1] = ihit;
-//
-//  }
-////simply copy the host arrays to the hitsInGPU struct
-//    cudaMemcpy(hitsInGPU->xs,host_x,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->ys,host_y,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->zs,host_z,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->rts,host_rts,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->idxs,host_idxs,loopsize*sizeof(unsigned int),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->moduleIndices,host_moduleIndex,loopsize*sizeof(unsigned int),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->highEdgeXs,host_highEdgeXs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->highEdgeYs,host_highEdgeYs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->lowEdgeXs,host_lowEdgeXs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->lowEdgeYs,host_lowEdgeYs,loopsize*sizeof(float),cudaMemcpyHostToDevice); 
-//    cudaMemcpy(hitsInGPU->nHits,&loopsize,sizeof(unsigned int),cudaMemcpyHostToDevice);// value can't correctly be set in hit allocation 
-//    cudaDeviceSynchronize(); //doesn't seem to make a difference
-//
-//    cudaFreeHost(host_rts);
-//    cudaFreeHost(host_idxs);
-//    cudaFreeHost(host_phis);
-//    cudaFreeHost(host_moduleIndex);
-//    cudaFreeHost(host_highEdgeXs);
-//    cudaFreeHost(host_highEdgeYs);
-//    cudaFreeHost(host_lowEdgeXs);
-//    cudaFreeHost(host_lowEdgeYs);
-//
-//
-//
-//}
 
 void SDL::Event::addMiniDoubletsToEvent()
 {

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -54,6 +54,14 @@ namespace SDL
         struct triplets* tripletsInGPU;
         struct trackCandidates* trackCandidatesInGPU;
 
+        //CPU interface stuff
+        std::shared_ptr<hits> hitsInCPU;
+        std::shared_ptr<miniDoublets> mdsInCPU;
+        std::shared_ptr<segments> segmentsInCPU;
+        std::shared_ptr<tracklets> trackletsInCPU;
+        std::shared_ptr<triplets> tripletsInCPU;
+        std::shared_ptr<trackCandidates> trackCandidatesInCPU;
+
     public:
         Event();
         ~Event();

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <iostream>
 #include <cmath>
+#include <memory>
 #include <cuda_runtime.h>
 #include <omp.h>
 #include <chrono>
@@ -118,11 +119,12 @@ namespace SDL
         unsigned int getNumberOfTrackCandidatesByLayerBarrel(unsigned int layer);
         unsigned int getNumberOfTrackCandidatesByLayerEndcap(unsigned int layer);
 
-        struct hits* getHits();
-        struct miniDoublets* getMiniDoublets();
-        struct segments* getSegments() ;
-        struct tracklets* getTracklets();
-        struct triplets* getTriplets();
+        std::shared_ptr<hits> getHits();
+        std::shared_ptr<miniDoublets> getMiniDoublets();
+        std::shared_ptr<segments> getSegments() ;
+        std::shared_ptr<tracklets> getTracklets();
+        std::shared_ptr<triplets> getTriplets();
+        std::shared_ptr<trackCandidates> getTrackCandidates();
 
     };
 

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -123,6 +123,7 @@ namespace SDL
         unsigned int getNumberOfTripletsByLayerEndcap(unsigned int layer);
 
         unsigned int getNumberOfTrackCandidates();
+        unsigned int getNumberOfPixelTrackCandidates();
         unsigned int getNumberOfTrackCandidatesByLayer(unsigned int layer);
         unsigned int getNumberOfTrackCandidatesByLayerBarrel(unsigned int layer);
         unsigned int getNumberOfTrackCandidatesByLayerEndcap(unsigned int layer);

--- a/SDL/Hit.cu
+++ b/SDL/Hit.cu
@@ -20,6 +20,10 @@ SDL::hits::hits()
     lowEdgeXs = nullptr;
     lowEdgeYs = nullptr;
 }
+
+SDL::hits::~hits()
+{
+}
 //FIXME:New array!
 void SDL::createHitsInUnifiedMemory(struct hits& hitsInGPU,unsigned int nMaxHits,unsigned int nMax2SHits)
 {

--- a/SDL/Hit.cu
+++ b/SDL/Hit.cu
@@ -255,7 +255,7 @@ __global__ void SDL::addHitToMemoryKernel(struct hits& hitsInGPU, struct modules
 //    printf("checkHits: %d %f %f %f %f %f %u %u %f %f %f %f\n",ihit,hitsInGPU.xs[ihit],hitsInGPU.ys[ihit],hitsInGPU.zs[ihit],hitsInGPU.rts[ihit],hitsInGPU.phis[ihit],hitsInGPU.moduleIndices[ihit],hitsInGPU.idxs[ihit],hitsInGPU.highEdgeXs[ihit],hitsInGPU.highEdgeYs[ihit],hitsInGPU.lowEdgeXs[ihit],hitsInGPU.lowEdgeYs[ihit]);
 //  }
 //}
-inline float SDL::ATan2(float y, float x)
+float SDL::ATan2(float y, float x)
 {
     if (x != 0) return  atan2(y, x);
     if (y == 0) return  0;
@@ -264,7 +264,7 @@ inline float SDL::ATan2(float y, float x)
 }
 
 //TODO:Check if cuda atan2f will work here
-inline float SDL::phi(float x, float y, float z)
+float SDL::phi(float x, float y, float z)
 {
     return phi_mpi_pi(M_PI + ATan2(-y, -x)); 
 }

--- a/SDL/Hit.cuh
+++ b/SDL/Hit.cuh
@@ -54,8 +54,8 @@ namespace SDL
     //CUDA_G void checkHits(struct hits& hitsInGPU, const int loopsize);
     void addHitToMemory(struct hits& hitsInCPU,struct modules& modulesInGPU,float x, float y, float z, unsigned int detId, unsigned int idxInNtuple);
     CUDA_G void addHitToMemoryGPU(struct hits& hitsInCPU,struct modules& modulesInGPU,float x, float y, float z, unsigned int detId, unsigned int idxInNtuple,unsigned int moduleIndex, float phis);
-    CUDA_HOSTDEV inline float phi(float x, float y, float z);
-    CUDA_HOSTDEV inline float ATan2(float y, float x);
+    CUDA_HOSTDEV float phi(float x, float y, float z);
+    CUDA_HOSTDEV float ATan2(float y, float x);
     CUDA_HOSTDEV float phi_mpi_pi(float phi);
     CUDA_HOSTDEV float deltaPhi(float x1, float y1, float z1, float x2, float y2, float z2);
     CUDA_HOSTDEV float deltaPhiChange(float x1, float y1, float z1, float x2, float y2, float z2);

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -18,7 +18,7 @@ CXXFLAGS      =  -g --compiler-options -Wall --compiler-options -Wshadow --compi
 LD            = nvcc 
 #LDFLAGS       = -g -O2
 SOFLAGS       = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_52
-MEMFLAG       = -DExplicit_MD -DExplicit_Seg -DExplicit_Tracklet -DExplicit_Trips -DExplicit_Track 
+#MEMFLAG       = -DExplicit_MD -DExplicit_Seg -DExplicit_Tracklet -DExplicit_Trips -DExplicit_Track 
 PRINTFLAG     = -DAddObjects
 #CACHEFLAG     = -DCACHE_ALLOC
 # how to make it 

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -760,6 +760,10 @@ SDL::miniDoublets::miniDoublets()
 
 }
 
+SDL::miniDoublets::~miniDoublets()
+{
+}
+
 void SDL::miniDoublets::freeMemoryCache()
 {
 #ifdef Explicit_MD

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -46,6 +46,7 @@ namespace SDL
         float* noShiftedDphiChanges; //if shifted module
 
         miniDoublets();
+        ~miniDoublets();
       	void freeMemory();
       	void freeMemoryCache();
 

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -220,7 +220,7 @@ __device__ void SDL::addSegmentToMemory(struct segments& segmentsInGPU, unsigned
     segmentsInGPU.dAlphaInnerMDOuterMDs[idx] = dAlphaInnerMDOuterMD;
 }
 
-__device__ void SDL::addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, unsigned int pixelModuleIndex, unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, unsigned int idx)
+__device__ void SDL::addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, unsigned int pixelModuleIndex, unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, unsigned int idx, unsigned int pixelSegmentArrayIndex)
 {
     segmentsInGPU.mdIndices[idx * 2] = innerMDIndex;
     segmentsInGPU.mdIndices[idx * 2 + 1] = outerMDIndex;
@@ -229,7 +229,7 @@ __device__ void SDL::addPixelSegmentToMemory(struct segments& segmentsInGPU, str
     segmentsInGPU.innerMiniDoubletAnchorHitIndices[idx] = innerAnchorHitIndex;
     segmentsInGPU.outerMiniDoubletAnchorHitIndices[idx] = outerAnchorHitIndex;
     segmentsInGPU.dPhiChanges[idx] = dPhiChange;
-    unsigned int pixelSegmentArrayIndex = segmentsInGPU.nSegments[pixelModuleIndex]; //since the increment happens only after adding the segment to memory
+//    unsigned int pixelSegmentArrayIndex = segmentsInGPU.nSegments[pixelModuleIndex]; //since the increment happens only after adding the segment to memory
     segmentsInGPU.ptIn[pixelSegmentArrayIndex] = ptIn;
     segmentsInGPU.ptErr[pixelSegmentArrayIndex] = ptErr;
     segmentsInGPU.px[pixelSegmentArrayIndex] = px;

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -166,6 +166,10 @@ SDL::segments::segments()
     dAlphaInnerMDOuterMDs = nullptr;
 }
 
+SDL::segments::~segments()
+{
+}
+
 void SDL::segments::freeMemoryCache()
 {
 #ifdef Explicit_Seg

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -69,7 +69,7 @@ namespace SDL
     CUDA_DEV void addSegmentToMemory(struct segments& segmentsInGPU, unsigned int lowerMDIndex, unsigned int upperMDIndex, unsigned int innerLowerModuleIndex, unsigned int outerLowerModuleIndex, unsigned int innerMDAnchorHitIndex, unsigned int outerMDAnchorHitIndex, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float&
             dAlphaInnerMDOuterMD, unsigned int idx);
 
-    CUDA_DEV void addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, unsigned int pixelModuleIndex, unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, unsigned int idx);
+    CUDA_DEV void addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, unsigned int pixelModuleIndex, unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, unsigned int idx, unsigned int pixelSegmentArrayIndex);
 
 
 

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -56,8 +56,9 @@ namespace SDL
         float* etaErr;
 
         segments();
-	      void freeMemory();
-	      void freeMemoryCache();
+        ~segments();
+	void freeMemory();
+	void freeMemoryCache();
     };
 
     void createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned int maxSegments, unsigned int nModules, unsigned int maxPixelSegments);

--- a/SDL/Tracklet.cu
+++ b/SDL/Tracklet.cu
@@ -14,11 +14,12 @@ void SDL::createTrackletsInUnifiedMemory(struct tracklets& trackletsInGPU, unsig
 {
 
     unsigned int nMemoryLocations = maxTracklets * nLowerModules + maxPixelTracklets;
+    nLowerModules += 1;
 #ifdef CACHE_ALLOC
     cudaStream_t stream =0;
     trackletsInGPU.segmentIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(unsigned int) * 2,stream);
     trackletsInGPU.lowerModuleIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(unsigned int) * 4,stream);//split up to avoid runtime error of exceeding max byte allocation at a time
-    trackletsInGPU.nTracklets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int),stream);
+    trackletsInGPU.nTracklets = (unsigned int*)cms::cuda::allocate_managed((nLowerModules * sizeof(unsigned int),stream);
     trackletsInGPU.zOut = (float*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(float) * 4,stream);
     trackletsInGPU.betaIn = (float*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(float) * 2,stream);
 #else
@@ -28,7 +29,7 @@ void SDL::createTrackletsInUnifiedMemory(struct tracklets& trackletsInGPU, unsig
     cudaMallocManaged(&trackletsInGPU.zOut, nMemoryLocations *4* sizeof(float));
     cudaMallocManaged(&trackletsInGPU.betaIn, nMemoryLocations *2* sizeof(float));
 #endif
-    trackletsInGPU.rtOut = trackletsInGPU.zOut + maxTracklets * nLowerModules;
+    trackletsInGPU.rtOut = trackletsInGPU.zOut + nMemoryLocations;
     trackletsInGPU.deltaPhiPos = trackletsInGPU.zOut + nMemoryLocations * 2;
     trackletsInGPU.deltaPhi = trackletsInGPU.zOut + nMemoryLocations * 3;
     trackletsInGPU.betaOut = trackletsInGPU.betaIn + nMemoryLocations;
@@ -43,6 +44,7 @@ void SDL::createTrackletsInExplicitMemory(struct tracklets& trackletsInGPU, unsi
 {
 
     unsigned int nMemoryLocations = maxTracklets * nLowerModules + maxPixelTracklets;
+    nLowerModules += 1;
 #ifdef CACHE_ALLOC
     cudaStream_t stream =0;
     int dev;
@@ -60,7 +62,7 @@ void SDL::createTrackletsInExplicitMemory(struct tracklets& trackletsInGPU, unsi
     cudaMalloc(&trackletsInGPU.betaIn, nMemoryLocations *2* sizeof(float));
 #endif
     cudaMemset(trackletsInGPU.nTracklets,0,nLowerModules*sizeof(unsigned int));
-    trackletsInGPU.rtOut = trackletsInGPU.zOut + maxTracklets * nLowerModules;
+    trackletsInGPU.rtOut = trackletsInGPU.zOut + nMemoryLocations;
     trackletsInGPU.deltaPhiPos = trackletsInGPU.zOut + nMemoryLocations * 2;
     trackletsInGPU.deltaPhi = trackletsInGPU.zOut + nMemoryLocations * 3;
     trackletsInGPU.betaOut = trackletsInGPU.betaIn + nMemoryLocations;

--- a/SDL/Tracklet.cu
+++ b/SDL/Tracklet.cu
@@ -19,7 +19,7 @@ void SDL::createTrackletsInUnifiedMemory(struct tracklets& trackletsInGPU, unsig
     cudaStream_t stream =0;
     trackletsInGPU.segmentIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(unsigned int) * 2,stream);
     trackletsInGPU.lowerModuleIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(unsigned int) * 4,stream);//split up to avoid runtime error of exceeding max byte allocation at a time
-    trackletsInGPU.nTracklets = (unsigned int*)cms::cuda::allocate_managed((nLowerModules * sizeof(unsigned int),stream);
+    trackletsInGPU.nTracklets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int),stream);
     trackletsInGPU.zOut = (float*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(float) * 4,stream);
     trackletsInGPU.betaIn = (float*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(float) * 2,stream);
 #else

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -18,21 +18,21 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
     std::vector<float> px_vec;
     std::vector<float> py_vec;
     std::vector<float> pz_vec;
-    std::vector<float> vecX;
-    std::vector<float> vecY;
-    std::vector<float> vecZ;
-    std::vector<int> hitIdxInNtuple_vec0;
-    std::vector<int> hitIdxInNtuple_vec1;
-    std::vector<int> hitIdxInNtuple_vec2;
-    std::vector<int> hitIdxInNtuple_vec3;
+//    std::vector<float> vecX;
+//    std::vector<float> vecY;
+//    std::vector<float> vecZ;
+//    std::vector<int> hitIdxInNtuple_vec0;
+//    std::vector<int> hitIdxInNtuple_vec1;
+//    std::vector<int> hitIdxInNtuple_vec2;
+//    std::vector<int> hitIdxInNtuple_vec3;
     std::vector<unsigned int> hitIndices_vec0;
     std::vector<unsigned int> hitIndices_vec1;
     std::vector<unsigned int> hitIndices_vec2;
     std::vector<unsigned int> hitIndices_vec3;
-    std::vector<float> ptIn_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
-    std::vector<float> ptErr_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
-    std::vector<float> etaErr_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
-    std::vector<float> deltaPhi_vec;// (ptIn,ptErr,etaErr,pixelSegmentDeltaPhiChange)
+    std::vector<float> ptIn_vec;
+    std::vector<float> ptErr_vec;
+    std::vector<float> etaErr_vec;
+    std::vector<float> deltaPhi_vec;
     for (auto&& [iSeed, _] : iter::enumerate(trk.see_stateTrajGlbPx()))
     {
 
@@ -143,23 +143,23 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
 //
 //            event.addPixelSegmentToEvent(hitIndices, pixelSegmentDeltaPhiChange, ptIn, ptErr, px, py, pz, etaErr);
       // new explicit hits version. Works for both explicit and unified hits. 
-	          int hitIdx0InNtuple = trk.see_hitIdx()[iSeed][0];
+//	          int hitIdx0InNtuple = trk.see_hitIdx()[iSeed][0];
 //            event.addPixToEvent(r3PCA.X(), r3PCA.Y(), r3PCA.Z(), 1, hitIdx0InNtuple);
             unsigned int hitIdx0 = hit_size + count;
             count++; // incrementing the counter after the hitIdx should take care for the -1 right?
      
-            int hitIdx1InNtuple = trk.see_hitIdx()[iSeed][1];
+//            int hitIdx1InNtuple = trk.see_hitIdx()[iSeed][1];
 //            event.addPixToEvent(r3PCA.X(), r3PCA.Y(), r3PCA.Z(), 1, hitIdx1InNtuple);
             unsigned int hitIdx1 = hit_size + count;
             count++;
 
-            int hitIdx2InNtuple = trk.see_hitIdx()[iSeed][2];
+//            int hitIdx2InNtuple = trk.see_hitIdx()[iSeed][2];
 
 //            event.addPixToEvent(r3LH.X(), r3LH.Y(), r3LH.Z(),1,hitIdx2InNtuple);
             unsigned int hitIdx2 = hit_size + count;
             count++;
 
-            int hitIdx3InNtuple = trk.see_hitIdx()[iSeed].size() > 3 ? trk.see_hitIdx()[iSeed][3] : trk.see_hitIdx()[iSeed][2]; // repeat last one if triplet
+//            int hitIdx3InNtuple = trk.see_hitIdx()[iSeed].size() > 3 ? trk.see_hitIdx()[iSeed][3] : trk.see_hitIdx()[iSeed][2]; // repeat last one if triplet
             unsigned int hitIdx3;
             if(trk.see_hitIdx()[iSeed].size() <= 3)
             {   
@@ -172,10 +172,10 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
                 count++;
             }
 
-            std::vector<unsigned int> hitIndices = {hitIdx0, hitIdx1, hitIdx2, hitIdx3}; 
+//            std::vector<unsigned int> hitIndices = {hitIdx0, hitIdx1, hitIdx2, hitIdx3}; 
 
 //            event.addPixelSegmentToEvent(hitIndices, pixelSegmentDeltaPhiChange, ptIn, ptErr, px, py, pz, etaErr);
-//          printf("test: %u (%u,%u,%u,%u)\n",iSeed,hitIdx0,hitIdx1,hitIdx2,hitIdx3);
+
 //          NEWEST VERSION
             trkX.push_back(r3PCA.X());
             trkY.push_back(r3PCA.Y());
@@ -197,31 +197,10 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
             py_vec.push_back(py);
             pz_vec.push_back(pz);
 
-            //vecX.push_back(r3PCA.X());
-            //vecY.push_back(r3PCA.Y());
-            //vecZ.push_back(r3PCA.Z());
-            //vecX.push_back(r3PCA.X());
-            //vecY.push_back(r3PCA.Y());
-            //vecZ.push_back(r3PCA.Z());
-            //vecX.push_back(r3LH.X());
-            //vecY.push_back(r3LH.Y());
-            //vecZ.push_back(r3LH.Z());
-            //vecX.push_back(r3LH.X());
-            //vecY.push_back(r3LH.Y());
-            //vecZ.push_back(r3LH.Z());
-            //hitIndices_vec.push_back(1);
-            //hitIndices_vec.push_back(1);
-            //hitIndices_vec.push_back(1);
-            //hitIndices_vec.push_back(1);
             hitIndices_vec0.push_back(hitIdx0);
             hitIndices_vec1.push_back(hitIdx1);
             hitIndices_vec2.push_back(hitIdx2);
             hitIndices_vec3.push_back(hitIdx3);
-
-            hitIdxInNtuple_vec0.push_back(hitIdx0InNtuple);
-            hitIdxInNtuple_vec1.push_back(hitIdx1InNtuple);
-            hitIdxInNtuple_vec2.push_back(hitIdx2InNtuple);
-            hitIdxInNtuple_vec3.push_back(hitIdx3InNtuple);
             ptIn_vec.push_back(ptIn);
             ptErr_vec.push_back(ptErr);
             etaErr_vec.push_back(etaErr);

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -805,10 +805,16 @@ int main(int argc, char** argv)
             if (ana.verbose != 0) std::cout << "# of Triplets produced barrel layer 2: " << event.getNumberOfTripletsByLayerBarrel(1) << std::endl;
             if (ana.verbose != 0) std::cout << "# of Triplets produced barrel layer 3: " << event.getNumberOfTripletsByLayerBarrel(2) << std::endl;
             if (ana.verbose != 0) std::cout << "# of Triplets produced barrel layer 4: " << event.getNumberOfTripletsByLayerBarrel(3) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Triplets produced barrel layer 5: " << event.getNumberOfTripletsByLayerBarrel(4) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Triplets produced barrel layer 6: " << event.getNumberOfTripletsByLayerBarrel(5) << std::endl;
+
 
 	        if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 1: " << event.getNumberOfTripletsByLayerEndcap(0) << std::endl;
 	        if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 2: " << event.getNumberOfTripletsByLayerEndcap(1) << std::endl;
 	        if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 3: " << event.getNumberOfTripletsByLayerEndcap(2) << std::endl;
+	        if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 4: " << event.getNumberOfTripletsByLayerEndcap(3) << std::endl;
+	        if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 5: " << event.getNumberOfTripletsByLayerEndcap(4) << std::endl;
+
             // ----------------
 
             // ----------------
@@ -859,6 +865,7 @@ int main(int argc, char** argv)
             event_times[ana.looper.getCurrentEventIndex()][6] = tc_elapsed - tl_elapsed;
             if (ana.verbose != 0) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed - tl_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Pixel TrackCandidates produced: "<< event.getNumberOfPixelTrackCandidates() << std::endl;
             if (ana.verbose != 0) std::cout << "# of TrackCandidates produced barrel layer 1: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
             if (ana.verbose != 0) std::cout << "# of TrackCandidates produced barrel layer 2: " << event.getNumberOfTrackCandidatesByLayerBarrel(1) << std::endl;
             if (ana.verbose != 0) std::cout << "# of TrackCandidates produced barrel layer 3: " << event.getNumberOfTrackCandidatesByLayerBarrel(2) << std::endl;

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -762,6 +762,13 @@ int main(int argc, char** argv)
             if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 4: " << event.getNumberOfMiniDoubletsByLayerBarrel(3) << std::endl;
             if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 5: " << event.getNumberOfMiniDoubletsByLayerBarrel(4) << std::endl;
             if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 6: " << event.getNumberOfMiniDoubletsByLayerBarrel(5) << std::endl;
+
+            if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 1: " << event.getNumberOfMiniDoubletsByLayerEndcap(0) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 2: " << event.getNumberOfMiniDoubletsByLayerEndcap(1) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 3: " << event.getNumberOfMiniDoubletsByLayerEndcap(2) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 4: " << event.getNumberOfMiniDoubletsByLayerEndcap(3) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 5: " << event.getNumberOfMiniDoubletsByLayerEndcap(4) << std::endl;
+
             // ----------------
 
             // ----------------
@@ -772,11 +779,18 @@ int main(int argc, char** argv)
             event_times[ana.looper.getCurrentEventIndex()][2] = sg_elapsed - md_elapsed;
             if (ana.verbose != 0) std::cout << "Reco Segment processing time: " << sg_elapsed - md_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of Segments produced: " << event.getNumberOfSegments() << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Segments produced layer 1-2: " << event.getNumberOfSegmentsByLayerBarrel(0) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Segments produced layer 2-3: " << event.getNumberOfSegmentsByLayerBarrel(1) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Segments produced layer 3-4: " << event.getNumberOfSegmentsByLayerBarrel(2) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Segments produced layer 4-5: " << event.getNumberOfSegmentsByLayerBarrel(3) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Segments produced layer 5-6: " << event.getNumberOfSegmentsByLayerBarrel(4) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 1: " << event.getNumberOfSegmentsByLayerBarrel(0) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 2: " << event.getNumberOfSegmentsByLayerBarrel(1) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 3: " << event.getNumberOfSegmentsByLayerBarrel(2) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 4: " << event.getNumberOfSegmentsByLayerBarrel(3) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 5: " << event.getNumberOfSegmentsByLayerBarrel(4) << std::endl;
+
+            if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 1: " << event.getNumberOfSegmentsByLayerEndcap(0) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 2: " << event.getNumberOfSegmentsByLayerEndcap(1) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 3: " << event.getNumberOfSegmentsByLayerEndcap(2) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 4: " << event.getNumberOfSegmentsByLayerEndcap(3) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 5: " << event.getNumberOfSegmentsByLayerEndcap(4) << std::endl;
+
             // ----------------
 
             // ----------------
@@ -787,13 +801,14 @@ int main(int argc, char** argv)
             event_times[ana.looper.getCurrentEventIndex()][3] = tp_elapsed - sg_elapsed;
             if (ana.verbose != 0) std::cout << "Reco Triplet processing time: " << tp_elapsed - sg_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of Triplets produced: " << event.getNumberOfTriplets() << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Triplets produced layer 1-2-3: " << event.getNumberOfTripletsByLayerBarrel(0) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Triplets produced layer 2-3-4: " << event.getNumberOfTripletsByLayerBarrel(1) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Triplets produced layer 3-4-5: " << event.getNumberOfTripletsByLayerBarrel(2) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Triplets produced layer 4-5-6: " << event.getNumberOfTripletsByLayerBarrel(3) << std::endl;
-	          if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 1-2-3: " << event.getNumberOfTripletsByLayerEndcap(0) << std::endl;
-	          if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 2-3-4: " << event.getNumberOfTripletsByLayerEndcap(1) << std::endl;
-	          if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 3-4-5: " << event.getNumberOfTripletsByLayerEndcap(2) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Triplets produced barrel layer 1: " << event.getNumberOfTripletsByLayerBarrel(0) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Triplets produced barrel layer 2: " << event.getNumberOfTripletsByLayerBarrel(1) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Triplets produced barrel layer 3: " << event.getNumberOfTripletsByLayerBarrel(2) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Triplets produced barrel layer 4: " << event.getNumberOfTripletsByLayerBarrel(3) << std::endl;
+
+	        if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 1: " << event.getNumberOfTripletsByLayerEndcap(0) << std::endl;
+	        if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 2: " << event.getNumberOfTripletsByLayerEndcap(1) << std::endl;
+	        if (ana.verbose != 0) std::cout << "# of Triplets produced endcap layer 3: " << event.getNumberOfTripletsByLayerEndcap(2) << std::endl;
             // ----------------
 
             // ----------------
@@ -821,13 +836,19 @@ int main(int argc, char** argv)
             event_times[ana.looper.getCurrentEventIndex()][5] = tl_elapsed - ptl_elapsed;
             if (ana.verbose != 0) std::cout << "Reco Tracklet processing time: " << tl_elapsed - ptl_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of Tracklets produced: " << event.getNumberOfTracklets() << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerBarrel(1) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 3-4-5-6: " << event.getNumberOfTrackletsByLayerBarrel(2) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced barrel layer 1: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced barrel layer 2: " << event.getNumberOfTrackletsByLayerBarrel(1) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced barrel layer 3: " << event.getNumberOfTrackletsByLayerBarrel(2) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced barrel layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced barrel layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced barrel layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
             // ----------------
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced endcap layer 1: " << event.getNumberOfTrackletsByLayerEndcap(0) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced endcap layer 2: " << event.getNumberOfTrackletsByLayerEndcap(1) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced endcap layer 3: " << event.getNumberOfTrackletsByLayerEndcap(2) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced endcap layer 4: " << event.getNumberOfTrackletsByLayerEndcap(3) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of Tracklets produced endcap layer 5: " << event.getNumberOfTrackletsByLayerEndcap(4) << std::endl;
+
 
             if (ana.verbose != 0) std::cout << "Reco TrackCandidate start" << std::endl;
             my_timer.Start(kFALSE);
@@ -838,13 +859,19 @@ int main(int argc, char** argv)
             event_times[ana.looper.getCurrentEventIndex()][6] = tc_elapsed - tl_elapsed;
             if (ana.verbose != 0) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed - tl_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
-            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 2: " << event.getNumberOfTrackCandidatesByLayerBarrel(1) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 3: " << event.getNumberOfTrackCandidatesByLayerBarrel(2) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 4: " << event.getNumberOfTrackCandidatesByLayerBarrel(3) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 5: " << event.getNumberOfTrackCandidatesByLayerBarrel(4) << std::endl;
-            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 6: " << event.getNumberOfTrackCandidatesByLayerBarrel(5) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced barrel layer 1: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced barrel layer 2: " << event.getNumberOfTrackCandidatesByLayerBarrel(1) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced barrel layer 3: " << event.getNumberOfTrackCandidatesByLayerBarrel(2) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced barrel layer 4: " << event.getNumberOfTrackCandidatesByLayerBarrel(3) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced barrel layer 5: " << event.getNumberOfTrackCandidatesByLayerBarrel(4) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced barrel layer 6: " << event.getNumberOfTrackCandidatesByLayerBarrel(5) << std::endl;
             // ----------------*/
+
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 1: " << event.getNumberOfTrackCandidatesByLayerEndcap(0) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 2: " << event.getNumberOfTrackCandidatesByLayerEndcap(1) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 3: " << event.getNumberOfTrackCandidatesByLayerEndcap(2) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 4: " << event.getNumberOfTrackCandidatesByLayerEndcap(3) << std::endl;
+            if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 5: " << event.getNumberOfTrackCandidatesByLayerEndcap(4) << std::endl;
 
             if (ana.verbose != 0) std::cout << "Reco SDL end" << std::endl;
 
@@ -893,7 +920,7 @@ int main(int argc, char** argv)
     float avg_noload = 0.;
     for(int ev=0;ev<ana.n_events;ev++){
         float total =event_times[ev][0]+event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+event_times[ev][4]+ event_times[ev][5]+event_times[ev][6];//+event_times[ev][7];
-        float no_load =event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+ event_times[ev][5]+event_times[ev][6];//+event_times[ev][7];
+        float no_load =event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+ event_times[ev][4] + event_times[ev][5]+event_times[ev][6];//+event_times[ev][7];
         avg_hit += event_times[ev][0]; 
         avg_md += event_times[ev][1]; 
         avg_seg += event_times[ev][2]; 

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -233,7 +233,7 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
 //    trkZ.insert(trkZ.end(),vecZ.begin(),vecZ.end());
 //    hitId.insert(hitId.end(),hitIndices_vec.begin(),hitIndices_vec.end());
     event.addHitToEventOMP(trkX,trkY,trkZ,hitId);
-//    event.addPixelSegmentToEventV2(hitIndices_vec0,hitIndices_vec1,hitIndices_vec2,hitIndices_vec3, deltaPhi_vec, ptIn_vec, ptErr_vec, px_vec, py_vec, pz_vec, etaErr_vec);
+    event.addPixelSegmentToEventV2(hitIndices_vec0,hitIndices_vec1,hitIndices_vec2,hitIndices_vec3, deltaPhi_vec, ptIn_vec, ptErr_vec, px_vec, py_vec, pz_vec, etaErr_vec);
 }
 
 int main(int argc, char** argv)
@@ -817,19 +817,19 @@ int main(int argc, char** argv)
             // ----------------
 
             // ----------------
-            if(ana.verbose != 0) std::cout<<"Adding Pixel Segments!"<<std::endl;
-            my_timer.Start(kFALSE);
+//            if(ana.verbose != 0) std::cout<<"Adding Pixel Segments!"<<std::endl;
+//            my_timer.Start(kFALSE);
 //            addPixelSegments(event,-1,trk.ph2_x().size());
 //            addPixelSegments(event,-1,trk.ph2_x(),trk.ph2_y(),trk.ph2_z(),trk.ph2_detId()); //loads both pixels and hits at same time
-            float pix_elapsed = my_timer.RealTime();
-            event_times[ana.looper.getCurrentEventIndex()][4] = pix_elapsed - tp_elapsed;
+//            float pix_elapsed = my_timer.RealTime();
+//            event_times[ana.looper.getCurrentEventIndex()][4] = pix_elapsed - tp_elapsed;
    
             if(ana.verbose != 0) std::cout<<" Reco Pixel Tracklet start"<<std::endl;
             my_timer.Start(kFALSE);
-//            event.createPixelTracklets();
+            event.createPixelTracklets();
             float ptl_elapsed = my_timer.RealTime();
-            event_times[ana.looper.getCurrentEventIndex()][5] = ptl_elapsed - pix_elapsed;
-            if (ana.verbose != 0) std::cout << "Reco Pixel Tracklet processing time: " << ptl_elapsed - pix_elapsed << " secs" << std::endl;
+            event_times[ana.looper.getCurrentEventIndex()][4] = ptl_elapsed - tp_elapsed;
+            if (ana.verbose != 0) std::cout << "Reco Pixel Tracklet processing time: " << ptl_elapsed - tp_elapsed << " secs" << std::endl;
  
             if (ana.verbose != 0) std::cout << "Reco Tracklet start" << std::endl;
             my_timer.Start(kFALSE);
@@ -838,7 +838,7 @@ int main(int argc, char** argv)
 //             event.createTrackletsWithAGapWithModuleMap();
             //event.createTrackletsViaNavigation();
             float tl_elapsed = my_timer.RealTime();
-            event_times[ana.looper.getCurrentEventIndex()][6] = tl_elapsed - ptl_elapsed;
+            event_times[ana.looper.getCurrentEventIndex()][5] = tl_elapsed - ptl_elapsed;
             if (ana.verbose != 0) std::cout << "Reco Tracklet processing time: " << tl_elapsed - ptl_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of Tracklets produced: " << event.getNumberOfTracklets() << std::endl;
             if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
@@ -855,7 +855,7 @@ int main(int argc, char** argv)
             event.createTrackCandidates();
             //event.createTrackCandidatesFromTracklets();
             float tc_elapsed = my_timer.RealTime();
-            event_times[ana.looper.getCurrentEventIndex()][7] = tc_elapsed - tl_elapsed;
+            event_times[ana.looper.getCurrentEventIndex()][6] = tc_elapsed - tl_elapsed;
             if (ana.verbose != 0) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed - tl_elapsed << " secs" << std::endl;
             if (ana.verbose != 0) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
             if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
@@ -900,33 +900,33 @@ int main(int argc, char** argv)
     std::cout<<setprecision(2);
     std::cout<<right;
     std::cout<< "Timing summary"<<std::endl;
-    std::cout<< "Evt     Hits       MD   Segments Triplets  Pixels  pTracklet  Tracklet  Tracks    Total  Total(no load)"<<std::endl;
+    std::cout<< "Evt     Hits       MD   Segments Triplets  pTracklet  Tracklet  Tracks    Total  Total(no load)"<<std::endl;
     float avg_hit = 0.;
     float avg_md = 0.;
     float avg_seg = 0.;
     float avg_trip = 0.;
-    float avg_pix = 0.;
+    //float avg_pix = 0.;
     float avg_plet = 0.;
     float avg_tlet = 0.;
     float avg_track = 0.;
     float avg_tot = 0.;
     float avg_noload = 0.;
     for(int ev=0;ev<ana.n_events;ev++){
-        float total =event_times[ev][0]+event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+event_times[ev][4]+ event_times[ev][5]+event_times[ev][6]+event_times[ev][7];
-        float no_load =event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+ event_times[ev][5]+event_times[ev][6]+event_times[ev][7];
+        float total =event_times[ev][0]+event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+event_times[ev][4]+ event_times[ev][5]+event_times[ev][6];//+event_times[ev][7];
+        float no_load =event_times[ev][1] +event_times[ev][2]+event_times[ev][3]+ event_times[ev][5]+event_times[ev][6];//+event_times[ev][7];
         avg_hit += event_times[ev][0]; 
         avg_md += event_times[ev][1]; 
         avg_seg += event_times[ev][2]; 
         avg_trip += event_times[ev][3]; 
-        avg_pix += event_times[ev][4]; 
-        avg_plet += event_times[ev][5]; 
-        avg_tlet += event_times[ev][6]; 
-        avg_track += event_times[ev][7]; 
+       // avg_pix += event_times[ev][4]; 
+        avg_plet += event_times[ev][4]; 
+        avg_tlet += event_times[ev][5]; 
+        avg_track += event_times[ev][6]; 
         avg_tot += total;
         avg_noload += no_load;
-        std::cout<<ev<<"      "<<setw(6)<<event_times[ev][0]*1000 <<"   "<<setw(6)<<event_times[ev][1]*1000 <<"   "<<setw(6)<<event_times[ev][2]*1000 <<"   "<<setw(6)<<event_times[ev][3]*1000 <<"   "<<setw(7)<<event_times[ev][4]*1000 <<"   "<<setw(6)<<event_times[ev][5]*1000<<"   "<<setw(6)<<event_times[ev][6]*1000<<"   "<<setw(6)<<event_times[ev][7]*1000<<"   "<<setw(7)<<total*1000<<"   "<<setw(7)<<no_load*1000<<std::endl;
+        std::cout<<ev<<"      "<<setw(6)<<event_times[ev][0]*1000 <<"   "<<setw(6)<<event_times[ev][1]*1000 <<"   "<<setw(6)<<event_times[ev][2]*1000 <<"   "<<setw(6)<<event_times[ev][3]*1000 <<"   "<<setw(7)<<event_times[ev][4]*1000 <<"   "<<setw(6)<<event_times[ev][5]*1000<<"   "<<setw(6)<<event_times[ev][6]*1000<<"   "/*<<setw(6)<<event_times[ev][7]*1000<<"   "*/<<setw(7)<<total*1000<<"   "<<setw(7)<<no_load*1000<<std::endl;
     }
-        std::cout<<"avg:   "<<setw(6)<<avg_hit*1000/ana.n_events <<"   "<<setw(6)<<avg_md*1000/ana.n_events <<"   "<<setw(6)<<avg_seg*1000/ana.n_events <<"   "<<setw(6)<<avg_trip*1000/ana.n_events <<"   "<<setw(7)<<avg_pix*1000/ana.n_events<<"   "<<setw(6)<<avg_plet*1000/ana.n_events<<"   "<<setw(6)<<avg_tlet*1000/ana.n_events<<"   "<<setw(6)<<avg_track*1000/ana.n_events<<"   "<<setw(7)<<avg_tot*1000/ana.n_events<<"   "<<setw(7)<<avg_noload*1000/ana.n_events<<std::endl;
+        std::cout<<"avg:   "<<setw(6)<<avg_hit*1000/ana.n_events <<"   "<<setw(6)<<avg_md*1000/ana.n_events <<"   "<<setw(6)<<avg_seg*1000/ana.n_events <<"   "<<setw(6)<<avg_trip*1000/ana.n_events <<"   "/*<<setw(7)<<avg_pix*1000/ana.n_events<<"   "*/<<setw(6)<<avg_plet*1000/ana.n_events<<"   "<<setw(6)<<avg_tlet*1000/ana.n_events<<"   "<<setw(6)<<avg_track*1000/ana.n_events<<"   "<<setw(7)<<avg_tot*1000/ana.n_events<<"   "<<setw(7)<<avg_noload*1000/ana.n_events<<std::endl;
 
     SDL::cleanModules();
 

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -33,6 +33,8 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
     std::vector<float> ptErr_vec;
     std::vector<float> etaErr_vec;
     std::vector<float> deltaPhi_vec;
+    const int hit_size = trkX.size();
+
     for (auto&& [iSeed, _] : iter::enumerate(trk.see_stateTrajGlbPx()))
     {
 
@@ -109,7 +111,6 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
         float px = p3LH.X();
         float py = p3LH.Y();
         float pz = p3LH.Z();
-        const int hit_size = trkX.size();
         if ((ptIn > 0.7) and (fabs(p3LH.Eta()) < 3))
         {
       // old unified hits version

--- a/bin/doAnalysis.cc
+++ b/bin/doAnalysis.cc
@@ -100,7 +100,7 @@ void addPixelSegments(SDL::Event& event, int isimtrk, std::vector<float> trkX, s
         float seedSD_dr = (r3LH - r3PCA).Pt();
         float seedSD_d = seedSD_rt - r3PCA.Pt();
         float seedSD_zeta = seedSD_p3.Pt() / seedSD_p3.Z();
-        struct SDL::hits* hitsInGPU = event.getHits();
+//        struct SDL::hits* hitsInGPU = event.getHits();
         // Inner most hit
         //FIXME:There is no SDL::Hit now!
    

--- a/src/trkCore.cc
+++ b/src/trkCore.cc
@@ -537,6 +537,25 @@ void runTriplet(SDL::Event& event)
 
 }
 
+void runTrackCandidateTest_v2(SDL::Event& event)
+{
+    TStopwatch my_timer;
+    if (ana.verbose != 0) std::cout << "Reco TrackCandidate start" << std::endl;
+    my_timer.Start(kFALSE);
+    event.createTrackCandidates();
+    float tc_elapsed = my_timer.RealTime();
+    if (ana.verbose != 0) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed << " secs" << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 2: " << event.getNumberOfTrackCandidatesByLayerBarrel(1) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 3: " << event.getNumberOfTrackCandidatesByLayerBarrel(2) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 4: " << event.getNumberOfTrackCandidatesByLayerBarrel(3) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 5: " << event.getNumberOfTrackCandidatesByLayerBarrel(4) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 6: " << event.getNumberOfTrackCandidatesByLayerBarrel(5) << std::endl;
+
+}
+
+
 bool goodEvent()
 {
     if (ana.specific_event_index >= 0)

--- a/src/trkCore.h
+++ b/src/trkCore.h
@@ -40,6 +40,7 @@ void runMiniDoublet(SDL::Event& event);
 void runSegment(SDL::Event& event);
 void runTracklet(SDL::Event& event);
 void runTriplet(SDL::Event& event);
+void runTrackCandidateTest_v2(SDL::Event& event);
 std::vector<float> getPtBounds();
 bool inTimeTrackWithPdgId(int isimtrk, int pdgid);
 std::vector<int> matchedSimTrkIdxs(std::vector<int> hitidxs, std::vector<int> hittypes);

--- a/src/write_sdl_ntuple.cc
+++ b/src/write_sdl_ntuple.cc
@@ -56,7 +56,7 @@ void write_sdl_ntuple()
 //        printTripletSummary(event);
 
         // Run TrackCandidate
-//        runTrackCandidateTest_v2(event);
+        runTrackCandidateTest_v2(event);
 //        printTrackCandidateSummary(event);
 
         // *********************************************************************
@@ -66,11 +66,11 @@ void write_sdl_ntuple()
         // Each SDL::Event object in simtrkevents will hold single sim-track related hits
         // It will be a vector of tuple of <sim_track_index, SDL::Event*>.
         std::vector<std::tuple<unsigned int, SDL::Event*>> simtrkevents;
-        std::vector<std::tuple<unsigned int, SDL::EventForAnalysisInterface*>> simtrkeventsForAnalysisInterface;
+//        std::vector<std::tuple<unsigned int, SDL::EventForAnalysisInterface*>> simtrkeventsForAnalysisInterface;
 
         // Loop over sim-tracks that is from in time (bx = 0) tracks with pdgid matching (against ana.pdg_id) and per sim-track aggregate reco hits
         // and only use those hits, and run SDL on them
-        for (auto&& isimtrk : iter::filter([&](int i) { return inTimeTrackWithPdgId(i, ana.pdg_id); }, iter::range(trk.sim_pt().size())))
+/*        for (auto&& isimtrk : iter::filter([&](int i) { return inTimeTrackWithPdgId(i, ana.pdg_id); }, iter::range(trk.sim_pt().size())))
         {
 
             // event just for this track
@@ -106,7 +106,7 @@ void write_sdl_ntuple()
         // ************************************************
 
         // Fill all the histograms
-        ana.cutflow.fill();
+        ana.cutflow.fill();*/
 
         // <--------------------------
         // <--------------------------


### PR DESCRIPTION
Multiple bug fixes

1. Pixel segments were not being written into memory due to a counter issue. I had used nSegments[pixelModuleIndex] directly as a counter since I was using unified memory, but now we need to use the tid instead
2. Since pixel segments were not being written into memory, Pixel quadruplet kernel threads were simply starting and immediately stopping, which explains the "too-good-to-be-true" performance of the pixel quadruplets. (Anti climax : The kernel takes anywhere from 4-10 seconds now, at least we matched!). This got compounded by the fact that we didn't have a sanity check in the form of a prinout of the number of pixel quadruplets produced
3. Some other fixes to ensure appropriate memory locations existed for the counters and other arrays so that track candidates can run without a hitch

The task is not over yet, because I still see some multiplicity issues between my personal repo (unified memory) and this one (approx 5-10%) , but hey, we're at least in the ballpark now!