### PR TITLE
Track candidate memory reduction

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -2213,9 +2213,18 @@ __global__ void createTrackCandidatesFromInnerInnerInnerLowerModule(struct SDL::
                 }
                 else
                 {
-		    unsigned int trackCandidateIdx = innerInnerInnerLowerModuleArrayIndex * N_MAX_TRACK_CANDIDATES_PER_MODULE + trackCandidateModuleIdx;
+//		    unsigned int trackCandidateIdx = innerInnerInnerLowerModuleArrayIndex * N_MAX_TRACK_CANDIDATES_PER_MODULE + trackCandidateModuleIdx;
+                    if(modulesInGPU.trackCandidateModuleIndices[innerInnerInnerLowerModuleArrayIndex] == -1)
+                    {
+                       printf("Track candidates: no memory for module at module index = %d\n",innerInnerInnerLowerModuleArrayIndex);
 
-                    addTrackCandidateToMemory(trackCandidatesInGPU, trackCandidateType, innerObjectIndex, outerObjectIndex, trackCandidateIdx);
+                    }
+                    else
+                   {
+                        unsigned int trackCandidateIdx = modulesInGPU.trackCandidateModuleIndices[innerInnerInnerLowerModuleArrayIndex] + trackCandidateModuleIdx;
+                        addTrackCandidateToMemory(trackCandidatesInGPU, trackCandidateType, innerObjectIndex, outerObjectIndex, trackCandidateIdx);
+                    }
+
                 }
             }
 
@@ -2242,9 +2251,17 @@ __global__ void createTrackCandidatesFromInnerInnerInnerLowerModule(struct SDL::
                 else
                 {
  
-                    unsigned int trackCandidateIdx = innerInnerInnerLowerModuleArrayIndex * N_MAX_TRACK_CANDIDATES_PER_MODULE + trackCandidateModuleIdx;
-
-                    addTrackCandidateToMemory(trackCandidatesInGPU, trackCandidateType, innerObjectIndex, outerObjectIndex, trackCandidateIdx);
+//                    unsigned int trackCandidateIdx = innerInnerInnerLowerModuleArrayIndex * N_MAX_TRACK_CANDIDATES_PER_MODULE + trackCandidateModuleIdx;
+                    if(modulesInGPU.trackCandidateModuleIndices[innerInnerInnerLowerModuleArrayIndex] == -1)
+                    {
+                        printf("Track candidates: no memory for module at module index = %d\n",innerInnerInnerLowerModuleArrayIndex);
+                    }
+                    else
+                    {
+                        unsigned int trackCandidateIdx = modulesInGPU.trackCandidateModuleIndices[innerInnerInnerLowerModuleArrayIndex] + trackCandidateModuleIdx;
+ 
+                        addTrackCandidateToMemory(trackCandidatesInGPU, trackCandidateType, innerObjectIndex, outerObjectIndex, trackCandidateIdx);
+                    }
                 }
             }
 
@@ -2275,7 +2292,7 @@ __global__ void createTrackCandidatesFromInnerInnerInnerLowerModule(struct SDL::
 //              	    unsigned int trackCandidateIdx = innerInnerInnerLowerModuleArrayIndex * N_MAX_TRACK_CANDIDATES_PER_MODULE + trackCandidateModuleIdx;
                     if(modulesInGPU.trackCandidateModuleIndices[innerInnerInnerLowerModuleArrayIndex] == -1)
                     {
-                        printf("Track candidates: no memory for module at module index = %d\n",innerInnerInnerLowerModuleArrayIndex);
+                        printf("Track candidates: no memory for module at module index = %d, outer T4 module index = %d\n",innerInnerInnerLowerModuleArrayIndex, outerInnerInnerLowerModuleIndex);
                     }
                     else
                     {

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -30,6 +30,7 @@ void SDL::createModulesInUnifiedMemory(struct modules& modulesInGPU,unsigned int
     cudaMallocManaged(&modulesInGPU.moduleType,nModules * sizeof(ModuleType));
     cudaMallocManaged(&modulesInGPU.moduleLayerType,nModules * sizeof(ModuleLayerType));
 
+
     *modulesInGPU.nModules = nModules;
 
 }
@@ -61,14 +62,20 @@ void SDL::freeModulesInUnifiedMemory(struct modules& modulesInGPU)
   cudaFree(modulesInGPU.moduleLayerType);
   cudaFree(modulesInGPU.lowerModuleIndices);
   cudaFree(modulesInGPU.reverseLookupLowerModuleIndices);
+  cudaFree(modulesInGPU.trackCandidateModuleIndices);
 }
 
 void SDL::createLowerModuleIndexMap(struct modules& modulesInGPU, unsigned int nLowerModules, unsigned int nModules)
 {
     //FIXME:some hacks to get the pixel module in the lower modules index without incrementing nLowerModules counter!
     //Reproduce these hacks in the explicit memory for identical results (or come up with a better method)
+
     cudaMallocManaged(&modulesInGPU.lowerModuleIndices,(nLowerModules + 1) * sizeof(unsigned int));
     cudaMallocManaged(&modulesInGPU.reverseLookupLowerModuleIndices,nModules * sizeof(int));
+
+    //new kid in the block - trackCandidateModuleIndices
+    cudaMallocManaged(&modulesInGPU.trackCandidateModuleIndices, (nLowerModules + 1) * sizeof(int));
+
 
     unsigned int lowerModuleCounter = 0;
     for(auto it = (*detIdToIndex).begin(); it != (*detIdToIndex).end(); it++)

--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -57,6 +57,8 @@ namespace SDL
         unsigned int *lowerModuleIndices;
         int *reverseLookupLowerModuleIndices; //module index to lower module index reverse lookup
 
+        int *trackCandidateModuleIndices;
+
         
         short* layers;
         short* rings;

--- a/SDL/TrackCandidate.cu
+++ b/SDL/TrackCandidate.cu
@@ -61,7 +61,8 @@ void SDL::createTrackCandidatesInUnifiedMemory(struct trackCandidates& trackCand
 }
 void SDL::createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules ,unsigned int nEligibleModules)
 {
-    unsigned int nMemoryLocations = maxTrackCandidates * nEligibleModules + maxPixelTrackCandidates;
+    unsigned int nMemoryLocations = maxTrackCandidates * (nEligibleModules-1) + maxPixelTrackCandidates;
+    std::cout<<"Number of eligible modules = "<<nEligibleModules<<std::endl;
 #ifdef CACHE_ALLOC
     cudaStream_t stream=0;
     int dev;

--- a/SDL/TrackCandidate.cuh
+++ b/SDL/TrackCandidate.cuh
@@ -39,8 +39,11 @@ namespace SDL
         void freeMemoryCache();
     };
 
-    void createTrackCandidatesInUnifiedMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules);
-    void createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules);
+    void createEligibleModulesListForTrackCandidates(struct modules& modulesInGPU, unsigned int nEligibleModules, unsigned int maxTrackCandidates);
+
+    void createTrackCandidatesInUnifiedMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules, unsigned int neligibleModules);
+
+    void createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules, unsigned int nEligibleModules);
     
     CUDA_DEV void addTrackCandidateToMemory(struct trackCandidates& trackCandidatesInGPU, short trackCandidateType, unsigned int innerTrackletIndex, unsigned int outerTrackletIndex, unsigned int trackCandidateIndex);
    

--- a/SDL/TrackCandidate.cuh
+++ b/SDL/TrackCandidate.cuh
@@ -39,9 +39,9 @@ namespace SDL
         void freeMemoryCache();
     };
 
-    void createEligibleModulesListForTrackCandidates(struct modules& modulesInGPU, unsigned int nEligibleModules, unsigned int maxTrackCandidates);
+    void createEligibleModulesListForTrackCandidates(struct modules& modulesInGPU, unsigned int& nEligibleModules, unsigned int maxTrackCandidates);
 
-    void createTrackCandidatesInUnifiedMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules, unsigned int neligibleModules);
+    void createTrackCandidatesInUnifiedMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules, unsigned int nEligibleModules);
 
     void createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules, unsigned int nEligibleModules);
     

--- a/code/AnalysisInterface/EventForAnalysisInterface.cc
+++ b/code/AnalysisInterface/EventForAnalysisInterface.cc
@@ -211,9 +211,13 @@ void SDL::EventForAnalysisInterface::addTrackCandidatesToAnalysisInterface(struc
 {
     for(unsigned int idx = 0; idx <= lowerModulePointers.size(); idx++) //cheating to include pixel track candidate lower module
     {
+        if(SDL::modulesInGPU.trackCandidateModuleIndices[idx] == -1)
+            continue;
+
         for(unsigned int jdx = 0; jdx < trackCandidatesInGPU.nTrackCandidates[idx]; jdx++)
         {
-            unsigned int trackCandidateIndex = idx * N_MAX_TRACK_CANDIDATES_PER_MODULE + jdx;
+//            unsigned int trackCandidateIndex = idx * N_MAX_TRACK_CANDIDATES_PER_MODULE + jdx;
+            unsigned int trackCandidateIndex = SDL::modulesInGPU.trackCandidateModuleIndices[idx] + jdx;
             short trackCandidateType = trackCandidatesInGPU.trackCandidateType[trackCandidateIndex];
             std::shared_ptr<TrackletBase> innerTrackletPtr = nullptr;
             std::shared_ptr<TrackletBase> outerTrackletPtr = nullptr;

--- a/code/AnalysisInterface/EventForAnalysisInterface.cc
+++ b/code/AnalysisInterface/EventForAnalysisInterface.cc
@@ -207,17 +207,17 @@ void SDL::EventForAnalysisInterface::addTripletsToAnalysisInterface(struct tripl
 }
 
 
-void SDL::EventForAnalysisInterface::addTrackCandidatesToAnalysisInterface(struct trackCandidates& trackCandidatesInGPU)
+void SDL::EventForAnalysisInterface::addTrackCandidatesToAnalysisInterface(struct trackCandidates& trackCandidatesInGPU, struct modules& modulesInGPU)
 {
     for(unsigned int idx = 0; idx <= lowerModulePointers.size(); idx++) //cheating to include pixel track candidate lower module
     {
-        if(SDL::modulesInGPU.trackCandidateModuleIndices[idx] == -1)
+        if(modulesInGPU.trackCandidateModuleIndices[idx] == -1)
             continue;
 
         for(unsigned int jdx = 0; jdx < trackCandidatesInGPU.nTrackCandidates[idx]; jdx++)
         {
 //            unsigned int trackCandidateIndex = idx * N_MAX_TRACK_CANDIDATES_PER_MODULE + jdx;
-            unsigned int trackCandidateIndex = SDL::modulesInGPU.trackCandidateModuleIndices[idx] + jdx;
+            unsigned int trackCandidateIndex = modulesInGPU.trackCandidateModuleIndices[idx] + jdx;
             short trackCandidateType = trackCandidatesInGPU.trackCandidateType[trackCandidateIndex];
             std::shared_ptr<TrackletBase> innerTrackletPtr = nullptr;
             std::shared_ptr<TrackletBase> outerTrackletPtr = nullptr;
@@ -364,7 +364,7 @@ SDL::EventForAnalysisInterface::EventForAnalysisInterface(struct modules* module
     }
     if(trackCandidatesInGPU != nullptr)
     {
-        addTrackCandidatesToAnalysisInterface(*trackCandidatesInGPU);
+        addTrackCandidatesToAnalysisInterface(*trackCandidatesInGPU, *modulesInGPU);
     }
 }
 

--- a/code/AnalysisInterface/EventForAnalysisInterface.h
+++ b/code/AnalysisInterface/EventForAnalysisInterface.h
@@ -72,7 +72,7 @@ namespace SDL
             void addSegmentsToAnalysisInterface(struct segments& segmentsInGPU);
             void addTrackletsToAnalysisInterface(struct tracklets& trackletsInGPU);
             void addTripletsToAnalysisInterface(struct triplets& tripletsInGPU);
-            void addTrackCandidatesToAnalysisInterface(struct trackCandidates& trackCandidatesInGPU);
+            void addTrackCandidatesToAnalysisInterface(struct trackCandidates& trackCandidatesInGPU, struct modules& modulesInGPU);
             void printTrackCandidateLayers(std::shared_ptr<TrackCandidate> tc);
 
         //add the get list of functions here

--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -494,6 +494,13 @@ float runMiniDoublet(SDL::Event& event)
     if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 5: " << event.getNumberOfMiniDoubletsByLayerBarrel(4) << std::endl;
     if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 6: " << event.getNumberOfMiniDoubletsByLayerBarrel(5) << std::endl;
 
+    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 1: " << event.getNumberOfMiniDoubletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 2: " << event.getNumberOfMiniDoubletsByLayerEndcap(1) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 3: " << event.getNumberOfMiniDoubletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 4: " << event.getNumberOfMiniDoubletsByLayerEndcap(3) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 5: " << event.getNumberOfMiniDoubletsByLayerEndcap(4) << std::endl;
+
+
     return md_elapsed;
 
 }
@@ -513,6 +520,12 @@ float runSegment(SDL::Event& event)
     if (ana.verbose != 0) std::cout << "# of Segments produced layer 3-4: " << event.getNumberOfSegmentsByLayerBarrel(2) << std::endl;
     if (ana.verbose != 0) std::cout << "# of Segments produced layer 4-5: " << event.getNumberOfSegmentsByLayerBarrel(3) << std::endl;
     if (ana.verbose != 0) std::cout << "# of Segments produced layer 5-6: " << event.getNumberOfSegmentsByLayerBarrel(4) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 1: " << event.getNumberOfSegmentsByLayerEndcap(0) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 2: " << event.getNumberOfSegmentsByLayerEndcap(1) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 3: " << event.getNumberOfSegmentsByLayerEndcap(2) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 4: " << event.getNumberOfSegmentsByLayerEndcap(3) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 5: " << event.getNumberOfSegmentsByLayerEndcap(4) << std::endl;
+
 
     return sg_elapsed;
 
@@ -533,6 +546,11 @@ float runT4(SDL::Event& event)
     if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
     if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
     if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 1: " << event.getNumberOfTrackletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 2: " << event.getNumberOfTrackletsByLayerEndcap(1) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 3: " << event.getNumberOfTrackletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 4: " << event.getNumberOfTrackletsByLayerEndcap(3) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 5: " << event.getNumberOfTrackletsByLayerEndcap(4) << std::endl;
 
     return t4_elapsed;
 
@@ -553,6 +571,14 @@ float runT4x(SDL::Event& event)
     if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
     if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
     if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 1: " << event.getNumberOfTrackletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 2: " << event.getNumberOfTrackletsByLayerEndcap(1) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 3: " << event.getNumberOfTrackletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 4: " << event.getNumberOfTrackletsByLayerEndcap(3) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 5: " << event.getNumberOfTrackletsByLayerEndcap(4) << std::endl;
+
 
     return t4x_elapsed;
 
@@ -587,6 +613,11 @@ float runT3(SDL::Event& event)
     if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 1-2-3: " << event.getNumberOfTripletsByLayerEndcap(0) << std::endl;
     if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 2-3-4: " << event.getNumberOfTripletsByLayerEndcap(1) << std::endl;
     if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 3-4-5: " << event.getNumberOfTripletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 1: " << event.getNumberOfTripletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 2: " << event.getNumberOfTripletsByLayerEndcap(1) << std::endl;
+     if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 3: " << event.getNumberOfTripletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 4: " << event.getNumberOfTripletsByLayerEndcap(3) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 5: " << event.getNumberOfTripletsByLayerEndcap(4) << std::endl;
 
     return t3_elapsed;
 
@@ -606,12 +637,19 @@ float runTrackCandidateTest_v2(SDL::Event& event)
     float tc_elapsed = my_timer.RealTime();
     if (ana.verbose != 0) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed << " secs" << std::endl;
     if (ana.verbose != 0) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
+    if (ana.verbose != 0) std::cout << "# of Pixel TrackCandidates produced: "<< event.getNumberOfPixelTrackCandidates() << std::endl;
+
     if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
     if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 2: " << event.getNumberOfTrackCandidatesByLayerBarrel(1) << std::endl;
     if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 3: " << event.getNumberOfTrackCandidatesByLayerBarrel(2) << std::endl;
     if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 4: " << event.getNumberOfTrackCandidatesByLayerBarrel(3) << std::endl;
     if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 5: " << event.getNumberOfTrackCandidatesByLayerBarrel(4) << std::endl;
     if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 6: " << event.getNumberOfTrackCandidatesByLayerBarrel(5) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 1: " << event.getNumberOfTrackCandidatesByLayerEndcap(0) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 2: " << event.getNumberOfTrackCandidatesByLayerEndcap(1) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 3: " << event.getNumberOfTrackCandidatesByLayerEndcap(2) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 4: " << event.getNumberOfTrackCandidatesByLayerEndcap(3) << std::endl;
+    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 5: " << event.getNumberOfTrackCandidatesByLayerEndcap(4) << std::endl;
 
     return tc_elapsed;
 

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -1075,9 +1075,12 @@ void printTCs(SDL::Event& event)
     int nTrackCandidates = 0;
     for (unsigned int idx = 0; idx <= *(SDL::modulesInGPU->nLowerModules); ++idx)
     {
+            if(SDL::modulesInGPU.trackCandidateModuleIndices[idx] == -1)
+                continue;
         for (unsigned int jdx = 0; jdx < trackCandidatesInGPU.nTrackCandidates[idx]; jdx++)
         {
-            unsigned int trackCandidateIndex = idx * 50000/*_N_MAX_TRACK_CANDIDATES_PER_MODULE*/ + jdx;
+            //unsigned int trackCandidateIndex = idx * 50000/*_N_MAX_TRACK_CANDIDATES_PER_MODULE*/ + jdx;
+            unsigned int trackCandidateIndex = SDL::modulesInGPU.trakCandidateModuleIndices[idx] + jdx;
 
             short trackCandidateType = trackCandidatesInGPU.trackCandidateType[trackCandidateIndex];
 

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -244,6 +244,8 @@ void fillOutputBranches(SDL::Event& event)
     std::vector<int> sim_TC_matched(trk.sim_pt().size());
     for (unsigned int idx = 0; idx <= *(SDL::modulesInGPU->nLowerModules); idx++) // "<=" because cheating to include pixel track candidate lower module
     {
+        if(SDL::modulesInGPU->trackCandidateModuleIndices[idx] == -1)
+            continue;
         unsigned int nTrackCandidates = trackCandidatesInGPU.nTrackCandidates[idx];
         if(idx == *SDL::modulesInGPU->nLowerModules and nTrackCandidates > 5000000)
         {
@@ -255,7 +257,8 @@ void fillOutputBranches(SDL::Event& event)
         }
         for (unsigned int jdx = 0; jdx < nTrackCandidates; jdx++)
         {
-            unsigned int trackCandidateIndex = idx * 50000/*_N_MAX_TRACK_CANDIDATES_PER_MODULE*/ + jdx;
+//            unsigned int trackCandidateIndex = idx * 50000/*_N_MAX_TRACK_CANDIDATES_PER_MODULE*/ + jdx;
+            unsigned int trackCandidateIndex = SDL::modulesInGPU->trackCandidateModuleIndices[idx] + jdx;            
 
             short trackCandidateType = trackCandidatesInGPU.trackCandidateType[trackCandidateIndex];
             unsigned int innerTrackletIdx = trackCandidatesInGPU.objectIndices[2 * trackCandidateIndex];
@@ -1075,12 +1078,12 @@ void printTCs(SDL::Event& event)
     int nTrackCandidates = 0;
     for (unsigned int idx = 0; idx <= *(SDL::modulesInGPU->nLowerModules); ++idx)
     {
-            if(SDL::modulesInGPU.trackCandidateModuleIndices[idx] == -1)
+            if(SDL::modulesInGPU->trackCandidateModuleIndices[idx] == -1)
                 continue;
         for (unsigned int jdx = 0; jdx < trackCandidatesInGPU.nTrackCandidates[idx]; jdx++)
         {
             //unsigned int trackCandidateIndex = idx * 50000/*_N_MAX_TRACK_CANDIDATES_PER_MODULE*/ + jdx;
-            unsigned int trackCandidateIndex = SDL::modulesInGPU.trakCandidateModuleIndices[idx] + jdx;
+            unsigned int trackCandidateIndex = SDL::modulesInGPU->trackCandidateModuleIndices[idx] + jdx;
 
             short trackCandidateType = trackCandidatesInGPU.trackCandidateType[trackCandidateIndex];
 


### PR DESCRIPTION
Turns out there are no track candidates that start at barrel layers 5 and 6, and endcap layers 2,3,4,5. These constitute around 8000 out of the 13000 lower modules. Given that track candidates take up around 6 GB, not allocating memory for these outer layers can save us around 3-3.5 GB. 

Observations post implementation:-
As anticipated, only 5313 modules even have track candidates, and our memory footprint has come down to 12333MiB (12.07 GiB) from 16139MiB (15.76 GiB) - a 23% reduction in memory footprint
