### PR TITLE
Timing package and new verbose flags

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -666,7 +666,7 @@ void SDL::Event::addPixelSegmentToEventV2(std::vector<unsigned int> hitIndices0,
     unsigned int nThreads = 256;
     unsigned int nBlocks =  size % nThreads == 0 ? size/nThreads : size/nThreads + 1;
   addPixelSegmentToEventKernelV2<<<nBlocks,nThreads>>>(hitIndices0_dev,hitIndices1_dev,hitIndices2_dev,hitIndices3_dev,dPhiChange_dev,ptIn_dev,ptErr_dev,px_dev,py_dev,pz_dev,etaErr_dev,pixelModuleIndex, *modulesInGPU,*hitsInGPU,*mdsInGPU,*segmentsInGPU,size);
-   std::cout<<"Number of pixel segments = "<<size<<std::endl;
+   //std::cout<<"Number of pixel segments = "<<size<<std::endl;
    cudaDeviceSynchronize();
    cudaMemcpy(&(segmentsInGPU->nSegments)[pixelModuleIndex], &size, sizeof(unsigned int), cudaMemcpyHostToDevice);
    unsigned int mdSize = 2 * size;
@@ -929,7 +929,7 @@ void SDL::Event::createMiniDoublets()
       }
     }
     #endif
-    printf("maxThreadsPerModule=%d\n", maxThreadsPerModule);
+    //printf("maxThreadsPerModule=%d\n", maxThreadsPerModule);
     dim3 nThreads(1,128);
     dim3 nBlocks((nLowerModules % nThreads.x == 0 ? nLowerModules/nThreads.x : nLowerModules/nThreads.x + 1), (maxThreadsPerModule % nThreads.y == 0 ? maxThreadsPerModule/nThreads.y : maxThreadsPerModule/nThreads.y + 1));
 #else
@@ -1046,7 +1046,7 @@ void SDL::Event::createSegmentsWithModuleMap()
       sq_max_nMDs = sq_max_nMDs > limit_local ? sq_max_nMDs : limit_local;
     }
   #endif
-    printf("max nConnectedModules=%d nonZeroModules=%d max sq_max_nMDs=%d\n", max_cModules, nonZeroModules, sq_max_nMDs);
+    //printf("max nConnectedModules=%d nonZeroModules=%d max sq_max_nMDs=%d\n", max_cModules, nonZeroModules, sq_max_nMDs);
     dim3 nThreads(256,1,1);
     dim3 nBlocks((sq_max_nMDs%nThreads.x==0 ? sq_max_nMDs/nThreads.x : sq_max_nMDs/nThreads.x + 1), (max_cModules%nThreads.y==0 ? max_cModules/nThreads.y : max_cModules/nThreads.y + 1), (nLowerModules%nThreads.z==0 ? nLowerModules/nThreads.z : nLowerModules/nThreads.z + 1));
     free(nMDs);
@@ -1157,7 +1157,7 @@ void SDL::Event::createTriplets()
     }
     */
     max_OuterSeg = N_MAX_SEGMENTS_PER_MODULE;
-    printf("nonZeroModules=%d max_InnerSeg=%d max_OuterSeg=%d\n", nonZeroModules, max_InnerSeg, max_OuterSeg);
+    //printf("nonZeroModules=%d max_InnerSeg=%d max_OuterSeg=%d\n", nonZeroModules, max_InnerSeg, max_OuterSeg);
     dim3 nThreads(32,16,1);
     dim3 nBlocks((max_OuterSeg % nThreads.x == 0 ? max_OuterSeg / nThreads.x : max_OuterSeg / nThreads.x + 1),(max_InnerSeg % nThreads.y == 0 ? max_InnerSeg/nThreads.y : max_InnerSeg/nThreads.y + 1), (nonZeroModules % nThreads.z == 0 ? nonZeroModules/nThreads.z : nonZeroModules/nThreads.z + 1));
     createTripletsInGPU<<<nBlocks,nThreads>>>(*modulesInGPU, *hitsInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, index_gpu);
@@ -1298,7 +1298,7 @@ void SDL::Event::createTrackletsWithModuleMap()
     }
   #endif
     cudaMemcpy(index_gpu, index, nonZeroSegModules*sizeof(unsigned int), cudaMemcpyHostToDevice);
-    printf("max_cModules=%d sq_max_segments=%d nonZeroSegModules=%d\n", max_cModules, sq_max_segments, nonZeroSegModules);
+    //printf("max_cModules=%d sq_max_segments=%d nonZeroSegModules=%d\n", max_cModules, sq_max_segments, nonZeroSegModules);
 
     dim3 nThreads(128,1,1);
     dim3 nBlocks((sq_max_segments%nThreads.x==0 ? sq_max_segments/nThreads.x : sq_max_segments/nThreads.x + 1), (max_cModules%nThreads.y==0 ? max_cModules/nThreads.y : max_cModules/nThreads.y + 1), (nonZeroSegModules%nThreads.z==0 ? nonZeroSegModules/nThreads.z : nonZeroSegModules/nThreads.z + 1));
@@ -1363,7 +1363,7 @@ void SDL::Event::createPixelTracklets()
 //#endif
     unsigned int nPixelTracklets;
     cudaMemcpy(&nPixelTracklets, &(trackletsInGPU->nTracklets[nLowerModules]), sizeof(unsigned int), cudaMemcpyDeviceToHost);
-    std::cout<<"number of pixel tracklets = "<<nPixelTracklets<<std::endl;
+    //std::cout<<"number of pixel tracklets = "<<nPixelTracklets<<std::endl;
 }
 
 void SDL::Event::createTrackCandidates()
@@ -1733,8 +1733,10 @@ __global__ void createMiniDoubletsInGPU(struct SDL::modules& modulesInGPU, struc
         unsigned int mdModuleIndex = atomicAdd(&mdsInGPU.nMDs[lowerModuleIndex],1);
         if(mdModuleIndex >= N_MAX_MD_PER_MODULES)
         {
+            #ifdef Warnings
             if(mdModuleIndex == N_MAX_MD_PER_MODULES)
                 printf("Mini-doublet excess alert! Module index =  %d\n",lowerModuleIndex);
+            #endif
         }
         else
         {
@@ -1777,8 +1779,10 @@ __global__ void createMiniDoubletsFromLowerModule(struct SDL::modules& modulesIn
 
         if(mdModuleIndex >= N_MAX_MD_PER_MODULES)
         {
+            #ifdef Warnings
             if(mdModuleIndex == N_MAX_MD_PER_MODULES)
                 printf("Mini-doublet excess alert! Module index = %d\n",lowerModuleIndex);
+            #endif
         }
         else
         {
@@ -1879,8 +1883,10 @@ __global__ void createSegmentsInGPU(struct SDL::modules& modulesInGPU, struct SD
         unsigned int segmentModuleIdx = atomicAdd(&segmentsInGPU.nSegments[innerLowerModuleIndex],1);
         if(segmentModuleIdx >= N_MAX_SEGMENTS_PER_MODULE)
         {
+            #ifdef Warnings
             if(segmentModuleIdx == N_MAX_SEGMENTS_PER_MODULE)
                 printf("Segment excess alert! Module index = %d\n",innerLowerModuleIndex);
+            #endif
         }
         else
         {
@@ -1935,8 +1941,10 @@ __global__ void createSegmentsFromInnerLowerModule(struct SDL::modules&modulesIn
         unsigned int segmentModuleIdx = atomicAdd(&segmentsInGPU.nSegments[innerLowerModuleIndex],1);
         if(segmentModuleIdx >= N_MAX_SEGMENTS_PER_MODULE)
         {
+            #ifdef Warnings
             if(segmentModuleIdx == N_MAX_SEGMENTS_PER_MODULE)
                 printf("Segment excess alert! Module index = %d\n",innerLowerModuleIndex);
+            #endif
         }
         else
         {
@@ -2027,8 +2035,10 @@ __global__ void createTrackletsInGPU(struct SDL::modules& modulesInGPU, struct S
       unsigned int trackletModuleIndex = atomicAdd(&trackletsInGPU.nTracklets[innerInnerLowerModuleArrayIndex],1);
       if(trackletModuleIndex >= N_MAX_TRACKLETS_PER_MODULE)
       {
+          #ifdef Warnings
           if(trackletModuleIndex == N_MAX_TRACKLETS_PER_MODULE)
               printf("Tracklet excess alert! Module index = %d\n",innerInnerLowerModuleIndex);
+          #endif
       }
       else
       {
@@ -2091,8 +2101,10 @@ __global__ void createTrackletsFromInnerInnerLowerModule(struct SDL::modules& mo
         unsigned int trackletModuleIndex = atomicAdd(&trackletsInGPU.nTracklets[innerInnerLowerModuleArrayIndex],1);
         if(trackletModuleIndex >= N_MAX_TRACKLETS_PER_MODULE)
         {
+            #ifdef Warnings
             if(trackletModuleIndex == N_MAX_TRACKLETS_PER_MODULE)
                 printf("Tracklet excess alert! Module index = %d\n",innerInnerLowerModuleIndex);
+            #endif
         }
         else
         {
@@ -2169,8 +2181,10 @@ __global__ void createPixelTrackletsFromOuterInnerLowerModule(struct SDL::module
         unsigned int trackletModuleIndex = atomicAdd(&trackletsInGPU.nTracklets[pixelLowerModuleArrayIndex], 1);
         if(trackletModuleIndex >= N_MAX_PIXEL_TRACKLETS_PER_MODULE)
         {
+            #ifdef Warnings
             if(trackletModuleIndex == N_MAX_PIXEL_TRACKLETS_PER_MODULE)
                 printf("Pixel Tracklet excess alert! Module index = %d\n",pixelModuleIndex);
+            #endif
         }
         else
         {
@@ -2238,8 +2252,10 @@ __global__ void createTrackletsWithAGapFromInnerInnerLowerModule(struct SDL::mod
         unsigned int trackletModuleIndex = atomicAdd(&trackletsInGPU.nTracklets[innerInnerLowerModuleArrayIndex],1);
         if(trackletModuleIndex >= N_MAX_TRACKLETS_PER_MODULE)
         {
+            #ifdef Warnings
             if(trackletModuleIndex == N_MAX_TRACKLETS_PER_MODULE)
                  printf("T4x excess alert! Module index = %d\n",innerInnerLowerModuleIndex);
+            #endif
         }
         else
         {
@@ -2396,8 +2412,10 @@ __global__ void createTripletsInGPU(struct SDL::modules& modulesInGPU, struct SD
       unsigned int tripletModuleIndex = atomicAdd(&tripletsInGPU.nTriplets[innerInnerLowerModuleArrayIndex], 1);
       if(tripletModuleIndex >= N_MAX_TRIPLETS_PER_MODULE)
       {
+          #ifdef Warnings
           if(tripletModuleIndex == N_MAX_TRIPLETS_PER_MODULE)
               printf("Triplet excess alert! Module index = %d\n",innerInnerLowerModuleIndex);
+          #endif
       }
       unsigned int tripletIndex = innerInnerLowerModuleArrayIndex * N_MAX_TRIPLETS_PER_MODULE + tripletModuleIndex;
 #ifdef CUT_VALUE_DEBUG
@@ -2443,8 +2461,10 @@ __global__ void createTripletsFromInnerInnerLowerModule(struct SDL::modules& mod
         unsigned int tripletModuleIndex = atomicAdd(&tripletsInGPU.nTriplets[innerInnerLowerModuleArrayIndex], 1);
         if(tripletModuleIndex >= N_MAX_TRIPLETS_PER_MODULE)
         {
+            #ifdef Warnings
             if(tripletModuleIndex == N_MAX_TRIPLETS_PER_MODULE)
                 printf("Triplet excess alert! Module index = %d\n",innerInnerLowerModuleIndex);
+            #endif
         }
         else
         {
@@ -2541,16 +2561,20 @@ __global__ void createTrackCandidatesFromInnerInnerInnerLowerModule(struct SDL::
                 atomicAdd(&trackCandidatesInGPU.nTrackCandidatesT4T4[innerInnerInnerLowerModuleArrayIndex],1);
                 if((innerInnerInnerLowerModuleArrayIndex < *modulesInGPU.nLowerModules  && trackCandidateModuleIdx >= N_MAX_TRACK_CANDIDATES_PER_MODULE) || (innerInnerInnerLowerModuleArrayIndex == *modulesInGPU.nLowerModules && trackCandidateModuleIdx >= N_MAX_PIXEL_TRACK_CANDIDATES_PER_MODULE))
                 {
+                    #ifdef Warnings
                     if((innerInnerInnerLowerModuleArrayIndex < *modulesInGPU.nLowerModules  && trackCandidateModuleIdx == N_MAX_TRACK_CANDIDATES_PER_MODULE) || (innerInnerInnerLowerModuleArrayIndex == *modulesInGPU.nLowerModules && trackCandidateModuleIdx == N_MAX_PIXEL_TRACK_CANDIDATES_PER_MODULE))
 
                         printf("Track Candidate excess alert! lower Module array index = %d\n",innerInnerInnerLowerModuleArrayIndex); 
+                    #endif
                 }
                 else
                 {
 //		    unsigned int trackCandidateIdx = innerInnerInnerLowerModuleArrayIndex * N_MAX_TRACK_CANDIDATES_PER_MODULE + trackCandidateModuleIdx;
                     if(modulesInGPU.trackCandidateModuleIndices[innerInnerInnerLowerModuleArrayIndex] == -1)
                     {
+                       #ifdef Warnings
                        printf("Track candidates: no memory for module at module index = %d\n",innerInnerInnerLowerModuleArrayIndex);
+                       #endif
 
                     }
                     else
@@ -2579,8 +2603,10 @@ __global__ void createTrackCandidatesFromInnerInnerInnerLowerModule(struct SDL::
                 atomicAdd(&trackCandidatesInGPU.nTrackCandidatesT4T3[innerInnerInnerLowerModuleArrayIndex],1);
                 if((innerInnerInnerLowerModuleArrayIndex < *modulesInGPU.nLowerModules  && trackCandidateModuleIdx >= N_MAX_TRACK_CANDIDATES_PER_MODULE) || (innerInnerInnerLowerModuleArrayIndex == *modulesInGPU.nLowerModules && trackCandidateModuleIdx >= N_MAX_PIXEL_TRACK_CANDIDATES_PER_MODULE))
                 {
+                    #ifdef Warnings
                     if((innerInnerInnerLowerModuleArrayIndex < *modulesInGPU.nLowerModules  && trackCandidateModuleIdx == N_MAX_TRACK_CANDIDATES_PER_MODULE) || (innerInnerInnerLowerModuleArrayIndex == *modulesInGPU.nLowerModules && trackCandidateModuleIdx == N_MAX_PIXEL_TRACK_CANDIDATES_PER_MODULE))
                         printf("Track Candidate excess alert! lower Module array index = %d\n",innerInnerInnerLowerModuleArrayIndex); 
+                    #endif
                 }
                 else
                 {
@@ -2588,7 +2614,9 @@ __global__ void createTrackCandidatesFromInnerInnerInnerLowerModule(struct SDL::
 //                    unsigned int trackCandidateIdx = innerInnerInnerLowerModuleArrayIndex * N_MAX_TRACK_CANDIDATES_PER_MODULE + trackCandidateModuleIdx;
                     if(modulesInGPU.trackCandidateModuleIndices[innerInnerInnerLowerModuleArrayIndex] == -1)
                     {
+                        #ifdef Warnings
                         printf("Track candidates: no memory for module at module index = %d\n",innerInnerInnerLowerModuleArrayIndex);
+                        #endif
                     }
                     else
                     {
@@ -2618,15 +2646,19 @@ __global__ void createTrackCandidatesFromInnerInnerInnerLowerModule(struct SDL::
                 atomicAdd(&trackCandidatesInGPU.nTrackCandidatesT3T4[innerInnerInnerLowerModuleArrayIndex],1);
 	        if(trackCandidateModuleIdx >= N_MAX_TRACK_CANDIDATES_PER_MODULE)
                 {
+                   #ifdef Warnings
                    if(trackCandidateModuleIdx == N_MAX_TRACK_CANDIDATES_PER_MODULE)
                        printf("Track Candidate excess alert! Module index = %d\n",innerInnerInnerLowerModuleArrayIndex); 
+                   #endif
                 }
                 else
                 {
 //              	    unsigned int trackCandidateIdx = innerInnerInnerLowerModuleArrayIndex * N_MAX_TRACK_CANDIDATES_PER_MODULE + trackCandidateModuleIdx;
                     if(modulesInGPU.trackCandidateModuleIndices[innerInnerInnerLowerModuleArrayIndex] == -1)
                     {
+                        #ifdef Warnings
                         printf("Track candidates: no memory for module at module index = %d, outer T4 module index = %d\n",innerInnerInnerLowerModuleArrayIndex, outerInnerInnerLowerModuleIndex);
+                        #endif
                     }
                     else
                     {

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -21,7 +21,7 @@ CXX                  = nvcc
 CXXFLAGS             =  -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_52 -I/mnt/data1/dsr/cub 
 LD                   = nvcc 
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_52
-PRINTFLAG            = -DAddObjects
+PRINTFLAG            = -DAddObjects #-DWarnings
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = -DNESTED_PARA

--- a/SDL/TrackCandidate.cu
+++ b/SDL/TrackCandidate.cu
@@ -53,7 +53,7 @@ void SDL::createEligibleModulesListForTrackCandidates(struct modules& modulesInG
 void SDL::createTrackCandidatesInUnifiedMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules, unsigned int nEligibleModules)
 {
     unsigned int nMemoryLocations = maxTrackCandidates * (nEligibleModules-1) + maxPixelTrackCandidates;
-    std::cout<<"Number of eligible modules = "<<nEligibleModules<<std::endl;
+    //std::cout<<"Number of eligible modules = "<<nEligibleModules<<std::endl;
 #ifdef CACHE_ALLOC
     cudaStream_t stream=0;
     trackCandidatesInGPU.trackCandidateType = (short*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(short),stream);
@@ -84,7 +84,7 @@ void SDL::createTrackCandidatesInUnifiedMemory(struct trackCandidates& trackCand
 void SDL::createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates, unsigned int maxPixelTrackCandidates, unsigned int nLowerModules ,unsigned int nEligibleModules)
 {
     unsigned int nMemoryLocations = maxTrackCandidates * (nEligibleModules-1) + maxPixelTrackCandidates;
-    std::cout<<"Number of eligible modules = "<<nEligibleModules<<std::endl;
+    //std::cout<<"Number of eligible modules = "<<nEligibleModules<<std::endl;
 #ifdef CACHE_ALLOC
     cudaStream_t stream=0;
     int dev;

--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -313,7 +313,7 @@ int main(int argc, char** argv)
         //case 4: tracklet(); break;
         case 5: write_sdl_ntuple(false,true); break;
         case 6 : write_sdl_ntuple(true,true); break;
-        case 7 : write_sdl_ntuple(false,false); break; // quick run, not validation
+        case 7 : write_sdl_ntuple(false,false,targetdata.Data()); break; // quick run, not validation
         //case 6: pixel_tracklet_eff(); break;
         default:
                 std::cout << options.help() << std::endl;

--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -311,8 +311,9 @@ int main(int argc, char** argv)
         //case 2: mtv(); break;
         //case 3: algo_eff(); break;
         //case 4: tracklet(); break;
-        case 5: write_sdl_ntuple(); break;
-        case 6 : write_sdl_ntuple(true); break;
+        case 5: write_sdl_ntuple(false,true); break;
+        case 6 : write_sdl_ntuple(true,true); break;
+        case 7 : write_sdl_ntuple(false,false); break; // quick run, not validation
         //case 6: pixel_tracklet_eff(); break;
         default:
                 std::cout << options.help() << std::endl;

--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -448,7 +448,7 @@ float addOuterTrackerHits(SDL::CPU::Event& event)
 {
 
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Loading Outer Tracker Hits for CPU...." << std::endl;
+    if (ana.verbose == 1) std::cout << "Loading Outer Tracker Hits for CPU...." << std::endl;
     my_timer.Start();
 
     // Adding hits to modules
@@ -472,33 +472,33 @@ float addOuterTrackerHits(SDL::CPU::Event& event)
     }
 
     float hit_loading_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Loading outer tracker hits processing time: " << hit_loading_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Loading outer tracker hits processing time: " << hit_loading_elapsed << " secs" << std::endl;
     return hit_loading_elapsed;
 }
 
 float runMiniDoublet(SDL::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Mini-Doublet start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Mini-Doublet start" << std::endl;
     my_timer.Start();
     event.createMiniDoublets();
     float md_elapsed = my_timer.RealTime();
             
-    if (ana.verbose != 0) std::cout << "Reco Mini-doublet processing time: " << md_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Mini-doublet processing time: " << md_elapsed << " secs" << std::endl;
 
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced: " << event.getNumberOfMiniDoublets() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 1: " << event.getNumberOfMiniDoubletsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 2: " << event.getNumberOfMiniDoubletsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 3: " << event.getNumberOfMiniDoubletsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 4: " << event.getNumberOfMiniDoubletsByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 5: " << event.getNumberOfMiniDoubletsByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 6: " << event.getNumberOfMiniDoubletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced: " << event.getNumberOfMiniDoublets() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 1: " << event.getNumberOfMiniDoubletsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 2: " << event.getNumberOfMiniDoubletsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 3: " << event.getNumberOfMiniDoubletsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 4: " << event.getNumberOfMiniDoubletsByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 5: " << event.getNumberOfMiniDoubletsByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 6: " << event.getNumberOfMiniDoubletsByLayerBarrel(5) << std::endl;
 
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 1: " << event.getNumberOfMiniDoubletsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 2: " << event.getNumberOfMiniDoubletsByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 3: " << event.getNumberOfMiniDoubletsByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 4: " << event.getNumberOfMiniDoubletsByLayerEndcap(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 5: " << event.getNumberOfMiniDoubletsByLayerEndcap(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 1: " << event.getNumberOfMiniDoubletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 2: " << event.getNumberOfMiniDoubletsByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 3: " << event.getNumberOfMiniDoubletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 4: " << event.getNumberOfMiniDoubletsByLayerEndcap(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 5: " << event.getNumberOfMiniDoubletsByLayerEndcap(4) << std::endl;
 
 
     return md_elapsed;
@@ -508,23 +508,23 @@ float runMiniDoublet(SDL::Event& event)
 float runSegment(SDL::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Segment start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Segment start" << std::endl;
     my_timer.Start();
     event.createSegmentsWithModuleMap();
     float sg_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco Segment processing time: " << sg_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Segment processing time: " << sg_elapsed << " secs" << std::endl;
 
-    if (ana.verbose != 0) std::cout << "# of Segments produced: " << event.getNumberOfSegments() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced layer 1-2: " << event.getNumberOfSegmentsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced layer 2-3: " << event.getNumberOfSegmentsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced layer 3-4: " << event.getNumberOfSegmentsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced layer 4-5: " << event.getNumberOfSegmentsByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced layer 5-6: " << event.getNumberOfSegmentsByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 1: " << event.getNumberOfSegmentsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 2: " << event.getNumberOfSegmentsByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 3: " << event.getNumberOfSegmentsByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 4: " << event.getNumberOfSegmentsByLayerEndcap(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 5: " << event.getNumberOfSegmentsByLayerEndcap(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced: " << event.getNumberOfSegments() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced layer 1-2: " << event.getNumberOfSegmentsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced layer 2-3: " << event.getNumberOfSegmentsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced layer 3-4: " << event.getNumberOfSegmentsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced layer 4-5: " << event.getNumberOfSegmentsByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced layer 5-6: " << event.getNumberOfSegmentsByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced endcap layer 1: " << event.getNumberOfSegmentsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced endcap layer 2: " << event.getNumberOfSegmentsByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced endcap layer 3: " << event.getNumberOfSegmentsByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced endcap layer 4: " << event.getNumberOfSegmentsByLayerEndcap(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced endcap layer 5: " << event.getNumberOfSegmentsByLayerEndcap(4) << std::endl;
 
 
     return sg_elapsed;
@@ -534,23 +534,23 @@ float runSegment(SDL::Event& event)
 float runT4(SDL::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Quadruplet T4 start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Quadruplet T4 start" << std::endl;
     my_timer.Start();
     event.createTrackletsWithModuleMap();
     float t4_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco T4 (just T4) processing time: " << t4_elapsed << " secs" << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced: " << event.getNumberOfTracklets() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 3-4-5-6: " << event.getNumberOfTrackletsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 1: " << event.getNumberOfTrackletsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 2: " << event.getNumberOfTrackletsByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 3: " << event.getNumberOfTrackletsByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 4: " << event.getNumberOfTrackletsByLayerEndcap(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 5: " << event.getNumberOfTrackletsByLayerEndcap(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco T4 (just T4) processing time: " << t4_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced: " << event.getNumberOfTracklets() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 3-4-5-6: " << event.getNumberOfTrackletsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 1: " << event.getNumberOfTrackletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 2: " << event.getNumberOfTrackletsByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 3: " << event.getNumberOfTrackletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 4: " << event.getNumberOfTrackletsByLayerEndcap(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 5: " << event.getNumberOfTrackletsByLayerEndcap(4) << std::endl;
 
     return t4_elapsed;
 
@@ -559,25 +559,25 @@ float runT4(SDL::Event& event)
 float runT4x(SDL::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Quadruplet T4x start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Quadruplet T4x start" << std::endl;
     my_timer.Start();
     event.createTrackletsWithAGapWithModuleMap();
     float t4x_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco T4x (just T4x) processing time: " << t4x_elapsed << " secs" << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced: " << event.getNumberOfTracklets() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 3-4-5-6: " << event.getNumberOfTrackletsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 1: " << event.getNumberOfTrackletsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 2: " << event.getNumberOfTrackletsByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 3: " << event.getNumberOfTrackletsByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 4: " << event.getNumberOfTrackletsByLayerEndcap(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 5: " << event.getNumberOfTrackletsByLayerEndcap(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco T4x (just T4x) processing time: " << t4x_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced: " << event.getNumberOfTracklets() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 3-4-5-6: " << event.getNumberOfTrackletsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 1: " << event.getNumberOfTrackletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 2: " << event.getNumberOfTrackletsByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 3: " << event.getNumberOfTrackletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 4: " << event.getNumberOfTrackletsByLayerEndcap(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of all T4s (both T4 and T4x) produced endcap layer 5: " << event.getNumberOfTrackletsByLayerEndcap(4) << std::endl;
 
 
     return t4x_elapsed;
@@ -587,11 +587,11 @@ float runT4x(SDL::Event& event)
 float runpT4(SDL::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Quadruplet pT4 start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Quadruplet pT4 start" << std::endl;
     my_timer.Start();
     event.createPixelTracklets();
     float pt4_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco pT4 processing time: " << pt4_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco pT4 processing time: " << pt4_elapsed << " secs" << std::endl;
 
     return pt4_elapsed;
 
@@ -600,24 +600,24 @@ float runpT4(SDL::Event& event)
 float runT3(SDL::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco T3 start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco T3 start" << std::endl;
     my_timer.Start();
     event.createTriplets();
     float t3_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco T3 processing time: " << t3_elapsed<< " secs" << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced: " << event.getNumberOfTriplets() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced layer 1-2-3: " << event.getNumberOfTripletsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced layer 2-3-4: " << event.getNumberOfTripletsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced layer 3-4-5: " << event.getNumberOfTripletsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced layer 4-5-6: " << event.getNumberOfTripletsByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 1-2-3: " << event.getNumberOfTripletsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 2-3-4: " << event.getNumberOfTripletsByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 3-4-5: " << event.getNumberOfTripletsByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 1: " << event.getNumberOfTripletsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 2: " << event.getNumberOfTripletsByLayerEndcap(1) << std::endl;
-     if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 3: " << event.getNumberOfTripletsByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 4: " << event.getNumberOfTripletsByLayerEndcap(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of T3s produced endcap layer 5: " << event.getNumberOfTripletsByLayerEndcap(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco T3 processing time: " << t3_elapsed<< " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced: " << event.getNumberOfTriplets() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced layer 1-2-3: " << event.getNumberOfTripletsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced layer 2-3-4: " << event.getNumberOfTripletsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced layer 3-4-5: " << event.getNumberOfTripletsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced layer 4-5-6: " << event.getNumberOfTripletsByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced endcap layer 1-2-3: " << event.getNumberOfTripletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced endcap layer 2-3-4: " << event.getNumberOfTripletsByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced endcap layer 3-4-5: " << event.getNumberOfTripletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced endcap layer 1: " << event.getNumberOfTripletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced endcap layer 2: " << event.getNumberOfTripletsByLayerEndcap(1) << std::endl;
+     if (ana.verbose == 1) std::cout << "# of T3s produced endcap layer 3: " << event.getNumberOfTripletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced endcap layer 4: " << event.getNumberOfTripletsByLayerEndcap(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of T3s produced endcap layer 5: " << event.getNumberOfTripletsByLayerEndcap(4) << std::endl;
 
     return t3_elapsed;
 
@@ -631,25 +631,25 @@ float runTrackCandidate(SDL::Event& event)
 float runTrackCandidateTest_v2(SDL::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco TrackCandidate start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco TrackCandidate start" << std::endl;
     my_timer.Start();
     event.createTrackCandidates();
     float tc_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed << " secs" << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Pixel TrackCandidates produced: "<< event.getNumberOfPixelTrackCandidates() << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Pixel TrackCandidates produced: "<< event.getNumberOfPixelTrackCandidates() << std::endl;
 
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 2: " << event.getNumberOfTrackCandidatesByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 3: " << event.getNumberOfTrackCandidatesByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 4: " << event.getNumberOfTrackCandidatesByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 5: " << event.getNumberOfTrackCandidatesByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 6: " << event.getNumberOfTrackCandidatesByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 1: " << event.getNumberOfTrackCandidatesByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 2: " << event.getNumberOfTrackCandidatesByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 3: " << event.getNumberOfTrackCandidatesByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 4: " << event.getNumberOfTrackCandidatesByLayerEndcap(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced endcap layer 5: " << event.getNumberOfTrackCandidatesByLayerEndcap(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 2: " << event.getNumberOfTrackCandidatesByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 3: " << event.getNumberOfTrackCandidatesByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 4: " << event.getNumberOfTrackCandidatesByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 5: " << event.getNumberOfTrackCandidatesByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 6: " << event.getNumberOfTrackCandidatesByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced endcap layer 1: " << event.getNumberOfTrackCandidatesByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced endcap layer 2: " << event.getNumberOfTrackCandidatesByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced endcap layer 3: " << event.getNumberOfTrackCandidatesByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced endcap layer 4: " << event.getNumberOfTrackCandidatesByLayerEndcap(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced endcap layer 5: " << event.getNumberOfTrackCandidatesByLayerEndcap(4) << std::endl;
 
     return tc_elapsed;
 
@@ -798,7 +798,7 @@ std::vector<int> matchedSimTrkIdxs(std::vector<int> hitidxs, std::vector<int> hi
     }
 
     // print
-/*    if (ana.verbose != 0)
+/*    if (ana.verbose == 1)
     {
         std::cout << "va print" << std::endl;
         for (auto& vec : simtrk_idxs)
@@ -1206,7 +1206,7 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
 {
 
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Loading Inputs (i.e. outer tracker hits, and pixel line segements) to the Line Segment Tracking.... " << std::endl;
+    if (ana.verbose == 1) std::cout << "Loading Inputs (i.e. outer tracker hits, and pixel line segements) to the Line Segment Tracking.... " << std::endl;
     my_timer.Start();
 
     unsigned int count = 0;
@@ -1373,7 +1373,7 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
     event.addPixelSegmentToEventV2(hitIndices_vec0, hitIndices_vec1, hitIndices_vec2, hitIndices_vec3, deltaPhi_vec, ptIn_vec, ptErr_vec, px_vec, py_vec, pz_vec, etaErr_vec);
 
     float hit_loading_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Loading inputs processing time: " << hit_loading_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Loading inputs processing time: " << hit_loading_elapsed << " secs" << std::endl;
     return hit_loading_elapsed;
 }
 
@@ -1406,7 +1406,7 @@ float addPixelSegments(SDL::CPU::Event& event, int isimtrk)
 {
 
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Loading pixel line segments for CPU...." << std::endl;
+    if (ana.verbose == 1) std::cout << "Loading pixel line segments for CPU...." << std::endl;
     my_timer.Start();
 
     for (auto&& [iSeed, _] : iter::enumerate(trk.see_stateTrajGlbPx()))
@@ -1669,7 +1669,7 @@ float addPixelSegments(SDL::CPU::Event& event, int isimtrk)
     }
 
     float pls_loading_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Loading pixel line segments processing time: " << pls_loading_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Loading pixel line segments processing time: " << pls_loading_elapsed << " secs" << std::endl;
     return pls_loading_elapsed;
 }
 
@@ -1677,11 +1677,11 @@ float addPixelSegments(SDL::CPU::Event& event, int isimtrk)
 float runMiniDoublet_on_CPU(SDL::CPU::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Mini-Doublet start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Mini-Doublet start" << std::endl;
     my_timer.Start();
     event.createMiniDoublets();
     float md_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco Mini-doublet processing time: " << md_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Mini-doublet processing time: " << md_elapsed << " secs" << std::endl;
     return md_elapsed;
 }
 
@@ -1689,11 +1689,11 @@ float runMiniDoublet_on_CPU(SDL::CPU::Event& event)
 float runSegment_on_CPU(SDL::CPU::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Segment start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Segment start" << std::endl;
     my_timer.Start();
     event.createSegmentsWithModuleMap();
     float sg_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco Segment processing time: " << sg_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Segment processing time: " << sg_elapsed << " secs" << std::endl;
     return sg_elapsed;
 }
 
@@ -1701,11 +1701,11 @@ float runSegment_on_CPU(SDL::CPU::Event& event)
 float runT4_on_CPU(SDL::CPU::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Quadruplet T4 start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Quadruplet T4 start" << std::endl;
     my_timer.Start();
     event.createTrackletsWithModuleMap();
     float t4_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco T4 (just T4) processing time: " << t4_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco T4 (just T4) processing time: " << t4_elapsed << " secs" << std::endl;
     return t4_elapsed;
 }
 
@@ -1713,11 +1713,11 @@ float runT4_on_CPU(SDL::CPU::Event& event)
 float runT4x_on_CPU(SDL::CPU::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Quadruplet T4x start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Quadruplet T4x start" << std::endl;
     my_timer.Start();
     event.createTrackletsWithAGapWithModuleMap();
     float t4x_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco T4x (just T4x) processing time: " << t4x_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco T4x (just T4x) processing time: " << t4x_elapsed << " secs" << std::endl;
     return t4x_elapsed;
 }
 
@@ -1725,11 +1725,11 @@ float runT4x_on_CPU(SDL::CPU::Event& event)
 float runpT4_on_CPU(SDL::CPU::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco Quadruplet pT4 start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco Quadruplet pT4 start" << std::endl;
     my_timer.Start();
     event.createTrackletsWithPixelLineSegments();
     float pt4_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco pT4 processing time: " << pt4_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco pT4 processing time: " << pt4_elapsed << " secs" << std::endl;
     return pt4_elapsed;
 }
 
@@ -1737,11 +1737,11 @@ float runpT4_on_CPU(SDL::CPU::Event& event)
 float runT3_on_CPU(SDL::CPU::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco T3 start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco T3 start" << std::endl;
     my_timer.Start();
     event.createTriplets();
     float t3_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco T3 processing time: " << t3_elapsed<< " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco T3 processing time: " << t3_elapsed<< " secs" << std::endl;
     return t3_elapsed;
 }
 
@@ -1749,113 +1749,113 @@ float runT3_on_CPU(SDL::CPU::Event& event)
 float runTrackCandidate_on_CPU(SDL::CPU::Event& event)
 {
     TStopwatch my_timer;
-    if (ana.verbose != 0) std::cout << "Reco TrackCandidate start" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco TrackCandidate start" << std::endl;
     my_timer.Start();
     event.createTrackCandidates();
     float tc_elapsed = my_timer.RealTime();
-    if (ana.verbose != 0) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed << " secs" << std::endl;
+    if (ana.verbose == 1) std::cout << "Reco TrackCandidate processing time: " << tc_elapsed << " secs" << std::endl;
     return tc_elapsed;
 }
 
 //__________________________________________________________________________________________
 void printHitSummary(SDL::CPU::Event& event)
 {
-    if (ana.verbose != 0) std::cout << "Summary of hits" << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits: " << event.getNumberOfHits() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in barrel layer 1: " << event.getNumberOfHitsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in barrel layer 2: " << event.getNumberOfHitsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in barrel layer 3: " << event.getNumberOfHitsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in barrel layer 4: " << event.getNumberOfHitsByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in barrel layer 5: " << event.getNumberOfHitsByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in barrel layer 6: " << event.getNumberOfHitsByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in endcap layer 1: " << event.getNumberOfHitsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in endcap layer 2: " << event.getNumberOfHitsByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in endcap layer 3: " << event.getNumberOfHitsByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in endcap layer 4: " << event.getNumberOfHitsByLayerEndcap(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits in endcap layer 5: " << event.getNumberOfHitsByLayerEndcap(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits Upper Module in layer 1: " << event.getNumberOfHitsByLayerBarrelUpperModule(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits Upper Module in layer 2: " << event.getNumberOfHitsByLayerBarrelUpperModule(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits Upper Module in layer 3: " << event.getNumberOfHitsByLayerBarrelUpperModule(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits Upper Module in layer 4: " << event.getNumberOfHitsByLayerBarrelUpperModule(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits Upper Module in layer 5: " << event.getNumberOfHitsByLayerBarrelUpperModule(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Hits Upper Module in layer 6: " << event.getNumberOfHitsByLayerBarrelUpperModule(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "Summary of hits" << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits: " << event.getNumberOfHits() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in barrel layer 1: " << event.getNumberOfHitsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in barrel layer 2: " << event.getNumberOfHitsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in barrel layer 3: " << event.getNumberOfHitsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in barrel layer 4: " << event.getNumberOfHitsByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in barrel layer 5: " << event.getNumberOfHitsByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in barrel layer 6: " << event.getNumberOfHitsByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in endcap layer 1: " << event.getNumberOfHitsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in endcap layer 2: " << event.getNumberOfHitsByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in endcap layer 3: " << event.getNumberOfHitsByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in endcap layer 4: " << event.getNumberOfHitsByLayerEndcap(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits in endcap layer 5: " << event.getNumberOfHitsByLayerEndcap(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits Upper Module in layer 1: " << event.getNumberOfHitsByLayerBarrelUpperModule(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits Upper Module in layer 2: " << event.getNumberOfHitsByLayerBarrelUpperModule(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits Upper Module in layer 3: " << event.getNumberOfHitsByLayerBarrelUpperModule(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits Upper Module in layer 4: " << event.getNumberOfHitsByLayerBarrelUpperModule(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits Upper Module in layer 5: " << event.getNumberOfHitsByLayerBarrelUpperModule(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Hits Upper Module in layer 6: " << event.getNumberOfHitsByLayerBarrelUpperModule(5) << std::endl;
 }
 
 //__________________________________________________________________________________________
 void printMiniDoubletSummary(SDL::CPU::Event& event)
 {
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced: " << event.getNumberOfMiniDoublets() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 1: " << event.getNumberOfMiniDoubletsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 2: " << event.getNumberOfMiniDoubletsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 3: " << event.getNumberOfMiniDoubletsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 4: " << event.getNumberOfMiniDoubletsByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 5: " << event.getNumberOfMiniDoubletsByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced barrel layer 6: " << event.getNumberOfMiniDoubletsByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 1: " << event.getNumberOfMiniDoubletsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 2: " << event.getNumberOfMiniDoubletsByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 3: " << event.getNumberOfMiniDoubletsByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 4: " << event.getNumberOfMiniDoubletsByLayerEndcap(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets produced endcap layer 5: " << event.getNumberOfMiniDoubletsByLayerEndcap(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered: " << event.getNumberOfMiniDoubletCandidates() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered barrel layer 1: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered barrel layer 2: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered barrel layer 3: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered barrel layer 4: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered barrel layer 5: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered barrel layer 6: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered endcap layer 1: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered endcap layer 2: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered endcap layer 3: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered endcap layer 4: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Mini-doublets considered endcap layer 5: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced: " << event.getNumberOfMiniDoublets() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 1: " << event.getNumberOfMiniDoubletsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 2: " << event.getNumberOfMiniDoubletsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 3: " << event.getNumberOfMiniDoubletsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 4: " << event.getNumberOfMiniDoubletsByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 5: " << event.getNumberOfMiniDoubletsByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced barrel layer 6: " << event.getNumberOfMiniDoubletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 1: " << event.getNumberOfMiniDoubletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 2: " << event.getNumberOfMiniDoubletsByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 3: " << event.getNumberOfMiniDoubletsByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 4: " << event.getNumberOfMiniDoubletsByLayerEndcap(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets produced endcap layer 5: " << event.getNumberOfMiniDoubletsByLayerEndcap(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered: " << event.getNumberOfMiniDoubletCandidates() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered barrel layer 1: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered barrel layer 2: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered barrel layer 3: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered barrel layer 4: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered barrel layer 5: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered barrel layer 6: " << event.getNumberOfMiniDoubletCandidatesByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered endcap layer 1: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered endcap layer 2: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered endcap layer 3: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered endcap layer 4: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Mini-doublets considered endcap layer 5: " << event.getNumberOfMiniDoubletCandidatesByLayerEndcap(4) << std::endl;
 }
 
 //__________________________________________________________________________________________
 void printSegmentSummary(SDL::CPU::Event& event)
 {
-    if (ana.verbose != 0) std::cout << "# of Pixel Segments: " << event.getPixelLayer().getSegmentPtrs().size() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced: " << event.getNumberOfSegments() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 1-2: " << event.getNumberOfSegmentsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 2-3: " << event.getNumberOfSegmentsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 3-4: " << event.getNumberOfSegmentsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 4-5: " << event.getNumberOfSegmentsByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced barrel layer 5-6: " << event.getNumberOfSegmentsByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 1-2: " << event.getNumberOfSegmentsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 2-3: " << event.getNumberOfSegmentsByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 3-4: " << event.getNumberOfSegmentsByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments produced endcap layer 4-5: " << event.getNumberOfSegmentsByLayerEndcap(3) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Segments produced layer 6: " << event.getNumberOfSegmentsByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered: " << event.getNumberOfSegmentCandidates() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered layer 1-2: " << event.getNumberOfSegmentCandidatesByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered layer 2-3: " << event.getNumberOfSegmentCandidatesByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered layer 3-4: " << event.getNumberOfSegmentCandidatesByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered layer 4-5: " << event.getNumberOfSegmentCandidatesByLayerBarrel(3) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered layer 5-6: " << event.getNumberOfSegmentCandidatesByLayerBarrel(4) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered layer 1-2: " << event.getNumberOfSegmentCandidatesByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered layer 2-3: " << event.getNumberOfSegmentCandidatesByLayerEndcap(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered layer 3-4: " << event.getNumberOfSegmentCandidatesByLayerEndcap(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Segments considered layer 4-5: " << event.getNumberOfSegmentCandidatesByLayerEndcap(3) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Segments considered layer 6: " << event.getNumberOfSegmentCandidatesByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Pixel Segments: " << event.getPixelLayer().getSegmentPtrs().size() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced: " << event.getNumberOfSegments() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced barrel layer 1-2: " << event.getNumberOfSegmentsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced barrel layer 2-3: " << event.getNumberOfSegmentsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced barrel layer 3-4: " << event.getNumberOfSegmentsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced barrel layer 4-5: " << event.getNumberOfSegmentsByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced barrel layer 5-6: " << event.getNumberOfSegmentsByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced endcap layer 1-2: " << event.getNumberOfSegmentsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced endcap layer 2-3: " << event.getNumberOfSegmentsByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced endcap layer 3-4: " << event.getNumberOfSegmentsByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments produced endcap layer 4-5: " << event.getNumberOfSegmentsByLayerEndcap(3) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Segments produced layer 6: " << event.getNumberOfSegmentsByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered: " << event.getNumberOfSegmentCandidates() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered layer 1-2: " << event.getNumberOfSegmentCandidatesByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered layer 2-3: " << event.getNumberOfSegmentCandidatesByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered layer 3-4: " << event.getNumberOfSegmentCandidatesByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered layer 4-5: " << event.getNumberOfSegmentCandidatesByLayerBarrel(3) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered layer 5-6: " << event.getNumberOfSegmentCandidatesByLayerBarrel(4) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered layer 1-2: " << event.getNumberOfSegmentCandidatesByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered layer 2-3: " << event.getNumberOfSegmentCandidatesByLayerEndcap(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered layer 3-4: " << event.getNumberOfSegmentCandidatesByLayerEndcap(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Segments considered layer 4-5: " << event.getNumberOfSegmentCandidatesByLayerEndcap(3) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Segments considered layer 6: " << event.getNumberOfSegmentCandidatesByLayerBarrel(5) << std::endl;
 }
 
 //__________________________________________________________________________________________
 void printTripletSummary(SDL::CPU::Event& event)
 {
     // ----------------
-    if (ana.verbose != 0) std::cout << "# of Triplets produced: " << event.getNumberOfTriplets() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Triplets produced layer 1-2-3: " << event.getNumberOfTripletsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Triplets produced layer 2-3-4: " << event.getNumberOfTripletsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Triplets produced layer 3-4-5: " << event.getNumberOfTripletsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Triplets produced layer 4-5-6: " << event.getNumberOfTripletsByLayerBarrel(3) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Triplets produced layer 5: " << event.getNumberOfTripletsByLayerBarrel(4) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Triplets produced layer 6: " << event.getNumberOfTripletsByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Triplets considered: " << event.getNumberOfTripletCandidates() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Triplets considered layer 1-2-3: " << event.getNumberOfTripletCandidatesByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Triplets considered layer 2-3-4: " << event.getNumberOfTripletCandidatesByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Triplets considered layer 3-4-5: " << event.getNumberOfTripletCandidatesByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Triplets considered layer 4-5-6: " << event.getNumberOfTripletCandidatesByLayerBarrel(3) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Triplets considered layer 5: " << event.getNumberOfTripletCandidatesByLayerBarrel(4) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Triplets considered layer 6: " << event.getNumberOfTripletCandidatesByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets produced: " << event.getNumberOfTriplets() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets produced layer 1-2-3: " << event.getNumberOfTripletsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets produced layer 2-3-4: " << event.getNumberOfTripletsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets produced layer 3-4-5: " << event.getNumberOfTripletsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets produced layer 4-5-6: " << event.getNumberOfTripletsByLayerBarrel(3) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Triplets produced layer 5: " << event.getNumberOfTripletsByLayerBarrel(4) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Triplets produced layer 6: " << event.getNumberOfTripletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets considered: " << event.getNumberOfTripletCandidates() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets considered layer 1-2-3: " << event.getNumberOfTripletCandidatesByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets considered layer 2-3-4: " << event.getNumberOfTripletCandidatesByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets considered layer 3-4-5: " << event.getNumberOfTripletCandidatesByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Triplets considered layer 4-5-6: " << event.getNumberOfTripletCandidatesByLayerBarrel(3) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Triplets considered layer 5: " << event.getNumberOfTripletCandidatesByLayerBarrel(4) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Triplets considered layer 6: " << event.getNumberOfTripletCandidatesByLayerBarrel(5) << std::endl;
     // ----------------
 }
 
@@ -1863,25 +1863,25 @@ void printTripletSummary(SDL::CPU::Event& event)
 void printTrackletSummary(SDL::CPU::Event& event)
 {
     // ----------------
-    if (ana.verbose != 0) std::cout << "# of Tracklets produced with pixel segment: " << event.getPixelLayer().getTrackletPtrs().size() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets produced: " << event.getNumberOfTracklets() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 3-4-5-6: " << event.getNumberOfTrackletsByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerEndcap(1) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Tracklets produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets considered: " << event.getNumberOfTrackletCandidates() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets considered layer 1-2-3-4: " << event.getNumberOfTrackletCandidatesByLayerBarrel(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets considered layer 2-3-4-5: " << event.getNumberOfTrackletCandidatesByLayerBarrel(1) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets considered layer 3-4-5-6: " << event.getNumberOfTrackletCandidatesByLayerBarrel(2) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets considered layer 1-2-3-4: " << event.getNumberOfTrackletCandidatesByLayerEndcap(0) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of Tracklets considered layer 2-3-4-5: " << event.getNumberOfTrackletCandidatesByLayerEndcap(1) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Tracklets considered layer 4: " << event.getNumberOfTrackletCandidatesByLayerBarrel(3) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Tracklets considered layer 5: " << event.getNumberOfTrackletCandidatesByLayerBarrel(4) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of Tracklets considered layer 6: " << event.getNumberOfTrackletCandidatesByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets produced with pixel segment: " << event.getPixelLayer().getTrackletPtrs().size() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets produced: " << event.getNumberOfTracklets() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets produced layer 3-4-5-6: " << event.getNumberOfTrackletsByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets produced layer 1-2-3-4: " << event.getNumberOfTrackletsByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets produced layer 2-3-4-5: " << event.getNumberOfTrackletsByLayerEndcap(1) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Tracklets produced layer 4: " << event.getNumberOfTrackletsByLayerBarrel(3) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Tracklets produced layer 5: " << event.getNumberOfTrackletsByLayerBarrel(4) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Tracklets produced layer 6: " << event.getNumberOfTrackletsByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets considered: " << event.getNumberOfTrackletCandidates() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets considered layer 1-2-3-4: " << event.getNumberOfTrackletCandidatesByLayerBarrel(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets considered layer 2-3-4-5: " << event.getNumberOfTrackletCandidatesByLayerBarrel(1) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets considered layer 3-4-5-6: " << event.getNumberOfTrackletCandidatesByLayerBarrel(2) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets considered layer 1-2-3-4: " << event.getNumberOfTrackletCandidatesByLayerEndcap(0) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of Tracklets considered layer 2-3-4-5: " << event.getNumberOfTrackletCandidatesByLayerEndcap(1) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Tracklets considered layer 4: " << event.getNumberOfTrackletCandidatesByLayerBarrel(3) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Tracklets considered layer 5: " << event.getNumberOfTrackletCandidatesByLayerBarrel(4) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of Tracklets considered layer 6: " << event.getNumberOfTrackletCandidatesByLayerBarrel(5) << std::endl;
     // ----------------
 }
 
@@ -1889,20 +1889,20 @@ void printTrackletSummary(SDL::CPU::Event& event)
 void printTrackCandidateSummary(SDL::CPU::Event& event)
 {
     // ----------------
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 2: " << event.getNumberOfTrackCandidatesByLayerBarrel(1) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 3: " << event.getNumberOfTrackCandidatesByLayerBarrel(2) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 4: " << event.getNumberOfTrackCandidatesByLayerBarrel(3) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 5: " << event.getNumberOfTrackCandidatesByLayerBarrel(4) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates produced layer 6: " << event.getNumberOfTrackCandidatesByLayerBarrel(5) << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates considered: " << event.getNumberOfTrackCandidateCandidates() << std::endl;
-    if (ana.verbose != 0) std::cout << "# of TrackCandidates considered layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(0) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates considered layer 2: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(1) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates considered layer 3: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(2) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates considered layer 4: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(3) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates considered layer 5: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(4) << std::endl;
-    // if (ana.verbose != 0) std::cout << "# of TrackCandidates considered layer 6: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced: " << event.getNumberOfTrackCandidates() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidatesByLayerBarrel(0) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 2: " << event.getNumberOfTrackCandidatesByLayerBarrel(1) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 3: " << event.getNumberOfTrackCandidatesByLayerBarrel(2) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 4: " << event.getNumberOfTrackCandidatesByLayerBarrel(3) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 5: " << event.getNumberOfTrackCandidatesByLayerBarrel(4) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates produced layer 6: " << event.getNumberOfTrackCandidatesByLayerBarrel(5) << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates considered: " << event.getNumberOfTrackCandidateCandidates() << std::endl;
+    if (ana.verbose == 1) std::cout << "# of TrackCandidates considered layer 1-2-3-4-5-6: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(0) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates considered layer 2: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(1) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates considered layer 3: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(2) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates considered layer 4: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(3) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates considered layer 5: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(4) << std::endl;
+    // if (ana.verbose == 1) std::cout << "# of TrackCandidates considered layer 6: " << event.getNumberOfTrackCandidateCandidatesByLayerBarrel(5) << std::endl;
     // ----------------
 
 }

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -1,7 +1,7 @@
 #include "write_sdl_ntuple.h"
 
 //________________________________________________________________________________________________________________________________
-void write_sdl_ntuple(bool cut_value_ntuple,bool validate)
+void write_sdl_ntuple(bool cut_value_ntuple,bool validate, std::string targetData)
 {
 
     // Load various maps used in the SDL reconstruction
@@ -171,7 +171,7 @@ void write_sdl_ntuple(bool cut_value_ntuple,bool validate)
 
     }
 
-    printTimingInformation(timing_information);
+    printTimingInformation(timing_information,targetData);
 
     SDL::cleanModules();
 
@@ -553,7 +553,7 @@ void fillOutputBranches_for_CPU(SDL::CPU::Event& event)
 }
 
 //________________________________________________________________________________________________________________________________
-void printTimingInformation(std::vector<std::vector<float>> timing_information)
+void printTimingInformation(std::vector<std::vector<float>> timing_information, std::string targetData)
 {
 
     if (ana.verbose != 2 and ana.verbose != 1)
@@ -614,6 +614,7 @@ void printTimingInformation(std::vector<std::vector<float>> timing_information)
     timing_total_avg += timing_sum_information[5]; // pT4
     timing_total_avg += timing_sum_information[6]; // T3
     timing_total_avg += timing_sum_information[7]; // T3
+    std::cout << setprecision(0);
     std::cout << setw(6) << "avg";
     std::cout << "   "<<setw(6) << timing_sum_information[0]; // Hits
     std::cout << "   "<<setw(6) << timing_sum_information[1]; // MD
@@ -624,6 +625,7 @@ void printTimingInformation(std::vector<std::vector<float>> timing_information)
     std::cout << "   "<<setw(6) << timing_sum_information[6]; // T3
     std::cout << "   "<<setw(6) << timing_sum_information[7]; // T3
     std::cout << "   "<<setw(7) << timing_total_avg; // Average total time
+    std::cout << "    "<<targetData;
     std::cout << std::endl;
 
     std::cout << left;

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -1,7 +1,7 @@
 #include "write_sdl_ntuple.h"
 
 //________________________________________________________________________________________________________________________________
-void write_sdl_ntuple(bool cut_value_ntuple)
+void write_sdl_ntuple(bool cut_value_ntuple,bool validate)
 {
 
     // Load various maps used in the SDL reconstruction
@@ -45,11 +45,11 @@ void write_sdl_ntuple(bool cut_value_ntuple)
 
             // Add hits to the event
             float timing_input_loading = addInputsToLineSegmentTrackingUsingExplicitMemory(event);
-            printHitMultiplicities(event);
+            //printHitMultiplicities(event);
 
             // Run Mini-doublet
             float timing_MD = runMiniDoublet(event);
-            printMiniDoubletMultiplicities(event);
+            //printMiniDoubletMultiplicities(event);
 
             // Run Segment
             float timing_LS = runSegment(event);
@@ -64,7 +64,7 @@ void write_sdl_ntuple(bool cut_value_ntuple)
 
             // Run T4
             float timing_T4 = runT4(event);
-            printQuadrupletMultiplicities(event);
+            //printQuadrupletMultiplicities(event);
 
             // Run T3
             float timing_T3 = runT3(event);
@@ -91,17 +91,19 @@ void write_sdl_ntuple(bool cut_value_ntuple)
                 debugPrintOutlierMultiplicities(event);
             }
 
-            if(not cut_value_ntuple)
-            {
-                fillOutputBranches(event);
-            }
-            else
-            {
-                //call the function from WriteSDLNtupleV2.cc
-                SDL::EventForAnalysisInterface* eventForAnalysisInterface = new SDL::EventForAnalysisInterface(event.getFullModules(), event.getHits(), event.getMiniDoublets(), event.getSegments(), event.getTracklets(), event.getTriplets(), event.getTrackCandidates());
+            if(validate){
+              if(not cut_value_ntuple)
+              {
+                  fillOutputBranches(event);
+              }
+              else
+              {
+                  //call the function from WriteSDLNtupleV2.cc
+                  SDL::EventForAnalysisInterface* eventForAnalysisInterface = new SDL::EventForAnalysisInterface(event.getFullModules(), event.getHits(), event.getMiniDoublets(), event.getSegments(), event.getTracklets(), event.getTriplets(), event.getTrackCandidates());
 
-                study->doStudy(*eventForAnalysisInterface);
-                ana.cutflow.fill();
+                  study->doStudy(*eventForAnalysisInterface);
+                  ana.cutflow.fill();
+              }
             }
 
         }
@@ -554,7 +556,7 @@ void fillOutputBranches_for_CPU(SDL::CPU::Event& event)
 void printTimingInformation(std::vector<std::vector<float>> timing_information)
 {
 
-    if (ana.verbose == 0)
+    if (ana.verbose != 2 and ana.verbose != 1)
         return;
 
     std::cout << showpoint;

--- a/code/core/write_sdl_ntuple.h
+++ b/code/core/write_sdl_ntuple.h
@@ -11,7 +11,7 @@
 #include "trkCore.h"
 
 // Main code
-void write_sdl_ntuple(bool cut_value_ntuple = false);
+void write_sdl_ntuple(bool cut_value_ntuple = false,bool validate = false);
 void createOutputBranches();
 void fillOutputBranches(SDL::Event& event);
 void fillOutputBranches_for_CPU(SDL::CPU::Event& event);

--- a/code/core/write_sdl_ntuple.h
+++ b/code/core/write_sdl_ntuple.h
@@ -11,13 +11,13 @@
 #include "trkCore.h"
 
 // Main code
-void write_sdl_ntuple(bool cut_value_ntuple = false,bool validate = false);
+void write_sdl_ntuple(bool cut_value_ntuple = false,bool validate = false, std::string targetData="");
 void createOutputBranches();
 void fillOutputBranches(SDL::Event& event);
 void fillOutputBranches_for_CPU(SDL::CPU::Event& event);
 
 // Timing
-void printTimingInformation(std::vector<std::vector<float>> timing_information);
+void printTimingInformation(std::vector<std::vector<float>> timing_information, std::string targetData="");
 
 // Print multiplicities
 void printQuadrupletMultiplicities(SDL::Event& event);

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+run_gpu()
+{
+    version=$1
+    sample=$2
+    nevents=$3
+    shift
+    shift
+    shift
+    # GPU unified
+    sdl_make_tracklooper -m $*
+    sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}.root -v 2 -m 7 -i ${sample}
+}
+
+validate_efficiency_usage()
+{
+    echo "ERROR - Usage:"
+    echo
+    echo "      sh $(basename $0) SAMPLETYPE [SPECIFICGPUVERISON] [NEVENTS]"
+    echo
+    echo "Arguments:"
+    echo "   SAMPLETYPE                          muonGun, PU200, or pionGun"
+    echo "   SPECIFICGPUVERSION (optional)       Run only one of the unified, unified_cache, ... , explicit, explicit_newgrid, ... , etc."
+    echo "                                       If nothing provided, then it checks all possible tests."
+    echo "   NEVENTS            (optional)       200, 10000, -1, etc."
+    echo ""
+    exit
+}
+
+# Parsing command-line opts
+while getopts ":h" OPTION; do
+  case $OPTION in
+    h) usage;;
+    :) usage;;
+  esac
+done
+
+# Shift away the parsed options
+shift $(($OPTIND - 1))
+
+if [ -z ${1} ]; then validate_efficiency_usage; fi
+
+SAMPLE=${1}
+if [[ ${SAMPLE} == *"pionGun"* ]]; then
+    PDGID=211
+elif [[ ${SAMPLE} == *"muonGun"* ]]; then
+    PDGID=13
+elif [[ ${SAMPLE} == *"PU200"* ]]; then
+    PDGID=0
+fi
+
+SPECIFICGPUVERSION=${2}
+
+if [ -z ${3} ]; then
+    NEVENTS=200 # If no number of events provided, validate on first 200 events
+    if [[ ${SAMPLE} == *"PU200"* ]]; then
+        NEVENTS=30 # If PU200 then run 30 events
+    fi
+else
+    NEVENTS=${3} # If provided set the NEVENTS
+fi
+
+pushd ${TRACKLOOPERDIR}
+GITHASH=$(git rev-parse --short HEAD)
+DIRTY=""
+DIFF=$(git diff)
+if [ -z "${DIFF}" ]; then
+    DIRTY=""
+else
+    DIRTY="DIRTY"
+fi
+popd
+GITHASH=${GITHASH}${DIRTY}
+
+OUTDIR=output/outputs_${GITHASH}_${SAMPLE}
+
+# Verbose
+echo "*****************************************************"
+echo ""
+echo ""
+echo "Efficiency Validation Program                        "
+echo ""
+echo ""
+echo "*****************************************************"
+echo ""
+echo "  GITHASH              : ${GITHASH}"
+echo "  SAMPLE               : ${SAMPLE}"
+echo "  NEVENTS              : ${NEVENTS}"
+if [ -n ${SPECIFICGPUVERSION} ]; then
+echo "  SPECIFICGPUVERSION   : ${SPECIFICGPUVERSION}"
+else
+echo "  SPECIFICGPUVERSION   : all configurations"
+fi
+echo ""
+
+## Delete old run
+rm -rf ${OUTDIR}
+mkdir -p ${OUTDIR}
+
+# Run different GPU configurations
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified" ]]; then
+    run_gpu unified ${SAMPLE} ${NEVENTS}
+    :
+fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
+    run_gpu unified_cache ${SAMPLE} ${NEVENTS} -c
+    :
+fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache_newgrid" ]]; then
+    run_gpu unified_cache_newgrid ${SAMPLE} ${NEVENTS} -c -g
+    :
+fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_newgrid" ]]; then
+    run_gpu unified_newgrid ${SAMPLE} ${NEVENTS} -g
+    :
+fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; then
+    run_gpu explicit ${SAMPLE} ${NEVENTS} -x
+    :
+fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
+#     run_gpu explicit_cache ${SAMPLE} -x -c # Does not run on phi3
+    :
+fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache_newgrid" ]]; then
+#     run_gpu explicit_cache_newgrid ${SAMPLE} -x -c -g # Does not run on phi3
+    :
+fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_newgrid" ]]; then
+    run_gpu explicit_newgrid ${SAMPLE} ${NEVENTS} -x -g
+fi
+
+#sdl_compare_efficiencies -i ${SAMPLE} -t ${GITHASH} -f

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -120,11 +120,11 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; 
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
-#     run_gpu explicit_cache ${SAMPLE} -x -c # Does not run on phi3
+     run_gpu explicit_cache ${SAMPLE} ${NEVENTS} -x -c # Does not run on phi3
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache_newgrid" ]]; then
-#     run_gpu explicit_cache_newgrid ${SAMPLE} -x -c -g # Does not run on phi3
+     run_gpu explicit_cache_newgrid ${SAMPLE} ${NEVENTS} -x -c -g # Does not run on phi3
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_newgrid" ]]; then

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -10,7 +10,7 @@ run_gpu()
     shift
     # GPU unified
     sdl_make_tracklooper -m $*
-    sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}.root -v 2 -m 7 -i ${sample}
+    sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}.root -v 2 -m 7 -i ${sample} | tee -a timing_temp.txt
 }
 
 validate_efficiency_usage()
@@ -97,6 +97,7 @@ echo ""
 ## Delete old run
 rm -rf ${OUTDIR}
 mkdir -p ${OUTDIR}
+rm timing_temp.txt
 
 # Run different GPU configurations
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified" ]]; then
@@ -131,4 +132,7 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_newgr
     run_gpu explicit_newgrid ${SAMPLE} ${NEVENTS} -x -g
 fi
 
+echo "Total Timing Summary"
+echo "Evt     Hits         MD       LS      T4      T4x       pT4        T3       TC       Total"
+grep -hr "avg " timing_temp.txt # space is needed to not get certain bad lines 
 #sdl_compare_efficiencies -i ${SAMPLE} -t ${GITHASH} -f


### PR DESCRIPTION
running bin/sdl with -m 7 flag will run without doing work needed for the validation plots after every event, which will run faster for timing and testing when validation plots are not needed
-v 0 no verbose printouts
-v 1 flag prints out object multiplicities and final timing results
-v 2 flag prints out just final timing results
All object excess warnings are under an #ifdef Warnings flag that is togglable in the SDL/Makefile
all other printouts are commented out now. 

running sdl_timing will make and run all versions with -m 7 and -v 2 flags to produce timing results for all of them. 

Current results (not including PR26)

                                Evt     Hits         MD       LS            T4             T4x       pT4        T3           TC       Total
unified :                   avg   397.99   123.47   238.14   248.87   1923.52   4459.98   131.81   412.90   7936.67
unified cache:          avg   389.46   109.89   283.48   382.29   1873.74   4404.24    98.29   409.44   7950.81
uni cache new grid: avg   384.68     8.04    22.90   176.07   1861.07   4194.11    46.59   418.17   7111.62
uni new grid:           avg   386.04    15.88    69.92   193.17   1948.21   4627.23    94.31   426.01   7760.77
explicit:                    avg   385.26   111.78   277.89   416.79   1893.24   4486.65    86.21   416.85   8074.67
explicit newgrid:      avg   382.98     9.01    20.88   175.34   1887.76   4553.56    30.47   392.70   7452.70
explicit cache:          avg   361.12   115.25   288.50   427.39   1901.78   4600.97    85.90   401.47   8182.38
explilcit cache grid:  avg   362.33     7.10    21.43   185.17   1903.47   4470.77    27.28   438.80   7416.35