### PR TITLE
CPU T5s

### DIFF
--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -210,6 +210,9 @@ void SDL::CPU::Event::addTripletToEvent(SDL::CPU::Triplet tp, unsigned int detId
 
     // And get the layer andd the triplet to it
     getLayer(layerIdx, subdet).addTriplet(&(triplets_.back()));
+
+    // Link segments to mini-doublets
+    triplets_.back().addSelfPtrToSegments();
 }
 
 [[deprecated("SDL::CPU:: addSegmentToLowerModule() is deprecated. Use addSegmentToEvent")]]
@@ -1485,6 +1488,105 @@ void SDL::CPU::Event::createTrackletsFromTwoLayers(int innerLayerIdx, SDL::CPU::
                 addTrackletToLowerLayer(tlCand, innerLayerIdx, innerLayerSubDet);
             }
 
+        }
+    }
+}
+
+// Create T5s from two triplets
+void SDL::CPU::Event::createT5s()
+{
+
+    // Loop over lower modules
+    for (auto& lowerModulePtr : getLowerModulePtrs())
+    {
+
+        unsigned int detId = lowerModulePtr->detId();
+
+        // Get reference to the inner lower Module
+        Module& innerLowerModule = getModule(detId);
+
+        // std::cout <<  " innerLowerModule.getTripletPtrs().size(): " << innerLowerModule.getTripletPtrs().size() <<  std::endl;
+        // int i_in_tp = 0;;
+
+        // Triple nested loops
+        // Loop over inner lower module for segments
+        for (auto& innerTripletPtr : innerLowerModule.getTripletPtrs())
+        {
+
+            // i_in_tp ++;
+
+            // Get reference to segment in inner lower module
+            SDL::CPU::Triplet& innerTriplet = *innerTripletPtr;
+
+            // Get the outer mini-doublet module detId
+            const std::vector<Segment*>& outwardSegmentPtrs = innerTriplet.outerSegmentPtr()->outerMiniDoubletPtr()->getListOfOutwardSegmentPtrs();
+
+            // std::cout <<  " outwardSegmentPtrs.size(): " << outwardSegmentPtrs.size() <<  std::endl;
+            // int i_ow_sg = 0;
+
+            for (auto& outwardSegmentPtr : outwardSegmentPtrs)
+            {
+
+                // i_ow_sg ++;
+
+                const std::vector<Triplet*>& outerTripletPtrs = outwardSegmentPtr->getListOfOutwardTripletPtrs();
+
+                // Loop over outer lower module mini-doublets
+                // std::cout <<  " outerTripletPtrs.size(): " << outerTripletPtrs.size() <<  std::endl;
+                // int i_out_tp = 0;
+
+                for (auto& outerTripletPtr : outerTripletPtrs)
+                {
+
+                    // i_out_tp ++;
+
+                    // std::cout <<  " detId: " << detId <<  " i_in_tp: " << i_in_tp <<  " i_ow_sg: " << i_ow_sg <<  " i_out_tp: " << i_out_tp <<  std::endl;
+                    // std::cout << innerTripletPtr;
+                    // std::cout << outerTripletPtr;
+
+                    // Count the # of tlCands considered by layer
+                    incrementNumberOfTrackCandidateCandidates(innerLowerModule);
+
+                    // // Tracklet between Seg1 - Seg3
+                    // SDL::CPU::Tracklet tlCand13(innerTripletPtr->innerSegmentPtr(), outerTripletPtr->innerSegmentPtr());
+
+                    // // Run the tracklet algo
+                    // tlCand13.runTrackletAlgo(SDL::CPU::Default_TLAlgo, logLevel_);
+
+                    // if (not (tlCand13.passesTrackletAlgo(SDL::CPU::Default_TLAlgo)))
+                    // {
+                    //     continue;
+                    // }
+
+                    // // Tracklet between Seg1 - Seg4
+                    // SDL::CPU::Tracklet tlCand14(innerTripletPtr->innerSegmentPtr(), outerTripletPtr->outerSegmentPtr());
+
+                    // // Run the tracklet algo
+                    // tlCand14.runTrackletAlgo(SDL::CPU::Default_TLAlgo, logLevel_);
+
+                    // if (not (tlCand14.passesTrackletAlgo(SDL::CPU::Default_TLAlgo)))
+                    // {
+                    //     continue;
+                    // }
+
+                    SDL::CPU::TrackCandidate tcCand(innerTripletPtr, outerTripletPtr);
+
+                    tcCand.runTrackCandidateT5(logLevel_);
+
+                    if (tcCand.passesTrackCandidateAlgo(Default_TCAlgo))
+                    {
+
+                        // Count the # of track candidates considered
+                        incrementNumberOfTrackCandidates(innerLowerModule);
+
+                        if (innerLowerModule.subdet() == SDL::CPU::Module::Barrel)
+                            addTrackCandidateToLowerLayer(tcCand, innerLowerModule.layer(), SDL::CPU::Layer::Barrel);
+                        else
+                            addTrackCandidateToLowerLayer(tcCand, innerLowerModule.layer(), SDL::CPU::Layer::Endcap);
+                    }
+
+                }
+            }
         }
     }
 }

--- a/SDL/Event.h
+++ b/SDL/Event.h
@@ -303,6 +303,9 @@ namespace SDL
                 // Create tracklets from two layers (inefficient way)
                 void createTrackletsFromTwoLayers(int innerLayerIdx, SDL::CPU::Layer::SubDet innerLayerSubDet, int outerLayerIdx, SDL::CPU::Layer::SubDet outerLayerSubDet, TLAlgo algo=Default_TLAlgo);
 
+                // Create T5s
+                void createT5s();
+
                 // Create tracklets
                 void createTrackletsViaNavigation(TLAlgo algo=Default_TLAlgo);
 

--- a/SDL/MathUtil.cc
+++ b/SDL/MathUtil.cc
@@ -113,3 +113,4 @@ float SDL::CPU::MathUtil::angleCorr(float dr, float pt, float angle)
     const float sinAlphaMax = 0.95;
     return copysign(std::asin(std::min(dr * k2Rinv1GeVf / std::abs(pt), sinAlphaMax)), angle);
 }
+

--- a/SDL/Segment.cc
+++ b/SDL/Segment.cc
@@ -81,6 +81,26 @@ void SDL::CPU::Segment::addInwardTrackletPtr(SDL::CPU::Tracklet* tl)
     inwardTrackletPtrs.push_back(tl);
 }
 
+const std::vector<SDL::CPU::Triplet*>& SDL::CPU::Segment::getListOfOutwardTripletPtrs()
+{
+    return outwardTripletPtrs;
+}
+
+const std::vector<SDL::CPU::Triplet*>& SDL::CPU::Segment::getListOfInwardTripletPtrs()
+{
+    return inwardTripletPtrs;
+}
+
+void SDL::CPU::Segment::addOutwardTripletPtr(SDL::CPU::Triplet* tp)
+{
+    outwardTripletPtrs.push_back(tp);
+}
+
+void SDL::CPU::Segment::addInwardTripletPtr(SDL::CPU::Triplet* tp)
+{
+    inwardTripletPtrs.push_back(tp);
+}
+
 SDL::CPU::MiniDoublet* SDL::CPU::Segment::innerMiniDoubletPtr() const
 {
     return innerMiniDoubletPtr_;

--- a/SDL/Segment.h
+++ b/SDL/Segment.h
@@ -58,6 +58,12 @@ namespace SDL
                 // Pointers of tracklets containing this segment as outer segment
                 std::vector<Tracklet*> inwardTrackletPtrs;
 
+                // Pointers of triplets containing this segment as inner segment
+                std::vector<Triplet*> outwardTripletPtrs;
+
+                // Pointers of triplets containing this segment as outer segment
+                std::vector<Triplet*> inwardTripletPtrs;
+
             public:
                 enum SegmentSelection
                 {
@@ -111,6 +117,12 @@ namespace SDL
 
                 void addOutwardTrackletPtr(Tracklet* tl);
                 void addInwardTrackletPtr(Tracklet* tl);
+
+                const std::vector<Triplet*>& getListOfOutwardTripletPtrs();
+                const std::vector<Triplet*>& getListOfInwardTripletPtrs();
+
+                void addOutwardTripletPtr(Triplet* tl);
+                void addInwardTripletPtr(Triplet* tl);
 
                 MiniDoublet* innerMiniDoubletPtr() const;
                 MiniDoublet* outerMiniDoubletPtr() const;

--- a/SDL/TrackCandidate.h
+++ b/SDL/TrackCandidate.h
@@ -81,6 +81,15 @@ namespace SDL
                     nCut
                 };
 
+                enum T5Selection
+                {
+                    tracklet13 = 0,
+                    tracklet14,
+                    radiusConsistency,
+                    nCutT5
+                };
+
+
             private:
                 // Bits to flag whether this tracklet passes which cut of default algorithm
                 int passBitsDefaultAlgo_;
@@ -124,8 +133,25 @@ namespace SDL
                 // Connecting inner triplet to outer tracklet with share segment
                 void runTrackCandidateInnerTripletToOuterTracklet(SDL::CPU::LogLevel logLevel);
 
+                // Connecting inner triplet to outer triplet with share mini-doublet
+                void runTrackCandidateT5(SDL::CPU::LogLevel logLevel);
+
                 bool isIdxMatched(const TrackCandidate&) const;
                 bool isAnchorHitIdxMatched(const TrackCandidate&) const;
+
+                bool matchRadiiBBBBB(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax);
+                bool matchRadiiBBBBE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax);
+                bool matchRadiiBBBEE12378(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax);
+                bool matchRadiiBBBEE23478(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax);
+                bool matchRadiiBBBEE34578(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax);
+                bool matchRadiiBBBEE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax);
+                bool matchRadiiBBEEE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax);
+                bool matchRadiiBEEEE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax); 
+                bool matchRadiiEEEEE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax);
+                bool checkIntervalOverlap(const float& firstMin, const float& firstMax, const float& secondMin, const float& secondMax);
+
+                float computeRadiusFromThreeAnchorHits(float x1, float y1, float x2, float y2, float x3, float y3, float& g, float& f);
+                void computeErrorInRadius(std::vector<float> x1Vec, std::vector<float> y1Vec, std::vector<float> x2Vec, std::vector<float> y2Vec, std::vector<float> x3Vec, std::vector<float> y3Vec, float& minimumRadius, float& maximumRadius);
 
                 // cout printing
                 friend std::ostream& operator<<(std::ostream& out, const TrackCandidate& tc);

--- a/SDL/Triplet.cc
+++ b/SDL/Triplet.cc
@@ -19,6 +19,12 @@ SDL::CPU::Triplet::Triplet(SDL::CPU::Segment* innerSegmentPtr, SDL::CPU::Segment
 {
 }
 
+void SDL::CPU::Triplet::addSelfPtrToSegments()
+{
+    innerSegmentPtr_->addOutwardTripletPtr(this);
+    outerSegmentPtr_->addInwardTripletPtr(this);
+}
+
 bool SDL::CPU::Triplet::passesTripletAlgo(SDL::CPU::TPAlgo algo) const
 {
     // Each algorithm is an enum shift it by its value and check against the flag

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -69,6 +69,8 @@ namespace SDL
                 Triplet(Segment* innerSegmentPtr, Segment* outerSegmentPtr);
                 ~Triplet();
 
+                void addSelfPtrToSegments();
+
                 // return whether it passed the algorithm
                 bool passesTripletAlgo(TPAlgo algo) const;
 

--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -429,17 +429,17 @@ void run_sdl()
             printTripletSummary(event);
 
             // Run Tracklet
-            float timing_T4 = 0; // runT4_on_CPU(event);
+            float timing_T4 = runT4_on_CPU(event);
             printTrackletSummary(event);
-            float timing_T4x = 0; // runT4x_on_CPU(event);
+            float timing_T4x = 0; // runT4x_on_CPU(event); // T4x's are turned off right now
             printTrackletSummary(event);
-            float timing_pT4 = 0; // runpT4_on_CPU(event);
+            float timing_pT4 = runpT4_on_CPU(event);
             printTrackletSummary(event);
 
             // Run T5s
             float timing_T5 = runT5_on_CPU(event);
             // Run TrackCandidate
-            float timing_TC = 0; // runTrackCandidate_on_CPU(event);
+            float timing_TC = runTrackCandidate_on_CPU(event); // {T4, T3 based TC's, and no T5};
             printTrackCandidateSummary(event);
 
             timing_information.push_back({ timing_input_loading,

--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -429,15 +429,17 @@ void run_sdl()
             printTripletSummary(event);
 
             // Run Tracklet
-            float timing_T4 = runT4_on_CPU(event);
+            float timing_T4 = 0; // runT4_on_CPU(event);
             printTrackletSummary(event);
             float timing_T4x = 0; // runT4x_on_CPU(event);
             printTrackletSummary(event);
-            float timing_pT4 = runpT4_on_CPU(event);
+            float timing_pT4 = 0; // runpT4_on_CPU(event);
             printTrackletSummary(event);
 
+            // Run T5s
+            float timing_T5 = runT5_on_CPU(event);
             // Run TrackCandidate
-            float timing_TC = runTrackCandidate_on_CPU(event);
+            float timing_TC = 0; // runTrackCandidate_on_CPU(event);
             printTrackCandidateSummary(event);
 
             timing_information.push_back({ timing_input_loading,
@@ -488,20 +490,21 @@ void writeMetaData()
 
     // Write out metadata of the code to the output_tfile
     ana.output_tfile->cd();
-    gSystem->Exec("echo '' > .gitversion.txt");
-    gSystem->Exec("git rev-parse HEAD >> .gitversion.txt");
-    gSystem->Exec("echo 'git status' >> .gitversion.txt");
-    gSystem->Exec("git status >> .gitversion.txt");
-    gSystem->Exec("echo 'git log -n5' >> .gitversion.txt");
-    gSystem->Exec("git log >> .gitversion.txt");
-    gSystem->Exec("echo 'git diff' >> .gitversion.txt");
-    gSystem->Exec("git diff >> .gitversion.txt");
-    std::ifstream t(".gitversion.txt");
+    gSystem->Exec(TString::Format("echo '' > %s.gitversion.txt", ana.output_tfile->GetName()));
+    gSystem->Exec(TString::Format("git rev-parse HEAD >> %s.gitversion.txt", ana.output_tfile->GetName()));
+    gSystem->Exec(TString::Format("echo 'git status' >> %s.gitversion.txt", ana.output_tfile->GetName()));
+    gSystem->Exec(TString::Format("git status >> %s.gitversion.txt", ana.output_tfile->GetName()));
+    gSystem->Exec(TString::Format("echo 'git log -n5' >> .%s.gitversion.txt", ana.output_tfile->GetName()));
+    gSystem->Exec(TString::Format("git log >> %s.gitversion.txt", ana.output_tfile->GetName()));
+    gSystem->Exec(TString::Format("echo 'git diff' >> %s.gitversion.txt", ana.output_tfile->GetName()));
+    gSystem->Exec(TString::Format("git diff >> %s.gitversion.txt", ana.output_tfile->GetName()));
+    std::ifstream t(TString::Format("%s.gitversion.txt", ana.output_tfile->GetName()));
     std::string str((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
     TString tstr = str.c_str();
     TObjString tobjstr("code_tag_data");
     tobjstr.SetString(tstr.Data());
     ana.output_tfile->WriteObject(&tobjstr, "code_tag_data");
+    gSystem->Exec(TString::Format("rm %s.gitversion.txt", ana.output_tfile->GetName()));
     TString make_log_path = TString::Format("%s/.make.log", ana.track_looper_dir_path.Data());
     std::ifstream makelog(make_log_path.Data());
     std::string makestr((std::istreambuf_iterator<char>(makelog)), std::istreambuf_iterator<char>());
@@ -511,13 +514,14 @@ void writeMetaData()
     ana.output_tfile->WriteObject(&maketobjstr, "make_log");
 
     // Write git diff output in a separate string to gauge the difference
-    gSystem->Exec("git diff > .gitdiff.txt");
-    std::ifstream gitdiff(".gitdiff.txt");
+    gSystem->Exec(TString::Format("git diff > %s.gitdiff.txt", ana.output_tfile->GetName()));
+    std::ifstream gitdiff(TString::Format("%s.gitdiff.txt", ana.output_tfile->GetName()));
     std::string strgitdiff((std::istreambuf_iterator<char>(gitdiff)), std::istreambuf_iterator<char>());
     TString tstrgitdiff = strgitdiff.c_str();
     TObjString tobjstrgitdiff("gitdiff");
     tobjstrgitdiff.SetString(tstrgitdiff.Data());
     ana.output_tfile->WriteObject(&tobjstrgitdiff, "gitdiff");
+    gSystem->Exec(TString::Format("rm %s.gitdiff.txt", ana.output_tfile->GetName()));
 
     // Parse from makestr the TARGET
     TString rawstrdata = maketstr.ReplaceAll("MAKETARGET=", "%");

--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -1849,6 +1849,18 @@ float runTrackCandidate_on_CPU(SDL::CPU::Event& event)
 }
 
 //__________________________________________________________________________________________
+float runT5_on_CPU(SDL::CPU::Event& event)
+{
+    TStopwatch my_timer;
+    if (ana.verbose >= 2) std::cout << "Reco T5 start" << std::endl;
+    my_timer.Start();
+    event.createT5s();
+    float t5_elapsed = my_timer.RealTime();
+    if (ana.verbose >= 2) std::cout << "Reco T5 processing time: " << t5_elapsed << " secs" << std::endl;
+    return t5_elapsed;
+}
+
+//__________________________________________________________________________________________
 void printHitSummary(SDL::CPU::Event& event)
 {
     if (ana.verbose >= 2) std::cout << "Summary of hits" << std::endl;

--- a/code/core/trkCore.h
+++ b/code/core/trkCore.h
@@ -76,6 +76,7 @@ float runT4x_on_CPU(SDL::CPU::Event& event);
 float runpT4_on_CPU(SDL::CPU::Event& event);
 float runT3_on_CPU(SDL::CPU::Event& event);
 float runTrackCandidate_on_CPU(SDL::CPU::Event& event);
+float runT5_on_CPU(SDL::CPU::Event& event);
 
 // Printing SDL information
 void printHitSummary(SDL::CPU::Event& event);

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -98,6 +98,9 @@ void createLowerLevelOutputBranches()
     //T5 - new kid
     ana.tx->createBranch<vector<int>>("sim_T5_matched");
     ana.tx->createBranch<vector<vector<int>>>("sim_T5_types");
+    ana.tx->createBranch<vector<float>>("t5_pt");
+    ana.tx->createBranch<vector<float>>("t5_eta");
+    ana.tx->createBranch<vector<float>>("t5_phi");
     ana.tx->createBranch<vector<int>>("t5_isFake");
     ana.tx->createBranch<vector<int>>("t5_isDuplicate");
 #endif
@@ -2082,6 +2085,9 @@ void fillLowerLevelOutputBranches_for_CPU(SDL::CPU::Event& event)
     fillQuadrupletOutputBranches_for_CPU(event);
     fillTripletOutputBranches_for_CPU(event);
     fillPixelQuadrupletOutputBranches_for_CPU(event);
+#ifdef DO_QUINTUPLET
+    fillQuintupletOutputBranches_for_CPU(event);
+#endif
 }
 
 //________________________________________________________________________________________________________________________________
@@ -2498,6 +2504,272 @@ void fillPixelQuadrupletOutputBranches_for_CPU(SDL::CPU::Event& event)
     ana.tx->setBranch<vector<float>>("pT4_phi", pT4_phi);
     ana.tx->setBranch<vector<int>>("pT4_isFake", pT4_isFake);
     ana.tx->setBranch<vector<int>>("pT4_isDuplicate", pT4_isDuplicate);
+
+}
+
+//________________________________________________________________________________________________________________________________
+void fillQuintupletOutputBranches_for_CPU(SDL::CPU::Event& event)
+{
+    // Did it match to track candidate?
+    std::vector<int> sim_T5_matched(trk.sim_pt().size());
+    std::vector<vector<int>> sim_T5_types(trk.sim_pt().size());
+
+    // get layer ptrs
+    std::vector<SDL::CPU::Layer*> layerPtrs = event.getLayerPtrs();
+    layerPtrs.push_back(&(event.getPixelLayer()));
+
+    std::vector<int> t5_isFake;
+    std::vector<vector<int>> t5_matched_simIdx;
+    std::vector<float> t5_pt;
+    std::vector<float> t5_eta;
+    std::vector<float> t5_phi;
+
+    // Loop over layers and access track candidates
+    for (auto& layerPtr : layerPtrs)
+    {
+
+        // Track Candidate ptrs
+        const std::vector<SDL::CPU::TrackCandidate*>& trackCandidatePtrs = layerPtr->getTrackCandidatePtrs();
+
+
+        // Loop over trackCandidate ptrs
+        for (auto& trackCandidatePtr : trackCandidatePtrs)
+        {
+
+            // hit idx
+            std::vector<int> hit_idx;
+            hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->upperHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->upperHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->upperHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->upperHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->upperHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->upperHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->upperHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->upperHitPtr()->idx());
+
+            std::vector<int> hit_types;
+            if (trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule().detId() == 1)
+            {
+                hit_types.push_back(0);
+                hit_types.push_back(0);
+                hit_types.push_back(0);
+                hit_types.push_back(0);
+            }
+            else
+            {
+                hit_types.push_back(4);
+                hit_types.push_back(4);
+                hit_types.push_back(4);
+                hit_types.push_back(4);
+            }
+
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+
+            // 0 -- 0
+            //      0 -- 0
+            //
+            //           0 -- 0
+            //                0 -- 0
+            // 01  23   
+            //     45   67
+            //          89   1011
+            //               1213  1415
+
+            // 0 -- 0
+            //      0 -- 0
+            //
+            //           0 -- 0
+            //                0 -- 0
+            // 0    2   
+            //      4    6
+            //           8   10  
+            //               1213  1415
+
+            bool isInnerTrackletTriplet = (hit_idx[2] == hit_idx[4] and hit_idx[3] == hit_idx[5] and hit_types[2] == hit_types[4] and hit_types[3] == hit_types[5]);
+            bool isOuterTrackletTriplet = (hit_idx[10] == hit_idx[12] and hit_idx[11] == hit_idx[13] and hit_types[10] == hit_types[12] and hit_types[11] == hit_types[13]);
+            bool isMiddleTrackletTriplet = (hit_idx[6] == hit_idx[8] and hit_idx[7] == hit_idx[9] and hit_types[6] == hit_types[8] and hit_types[7] == hit_types[9]);
+            bool isT5 = isInnerTrackletTriplet and isOuterTrackletTriplet and isMiddleTrackletTriplet;
+
+            if (not isT5)
+                continue;
+
+            const SDL::CPU::Module& module0  = trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module2  = trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module4  = trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module6  = trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module8  = trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module10 = trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module12 = trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module14 = trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
+
+            bool isPixel0  = module0.isPixelLayerModule();
+            bool isPixel2  = module2.isPixelLayerModule();
+            bool isPixel4  = module4.isPixelLayerModule();
+            bool isPixel6  = module6.isPixelLayerModule();
+            bool isPixel8  = module8.isPixelLayerModule();
+            bool isPixel10 = module10.isPixelLayerModule();
+            bool isPixel12 = module12.isPixelLayerModule();
+            bool isPixel14 = module14.isPixelLayerModule();
+
+            int layer0  = module0.layer();
+            int layer2  = module2.layer();
+            int layer4  = module4.layer();
+            int layer6  = module6.layer();
+            int layer8  = module8.layer();
+            int layer10 = module10.layer();
+            int layer12 = module12.layer();
+            int layer14 = module14.layer();
+
+            int subdet0  = module0.subdet();
+            int subdet2  = module2.subdet();
+            int subdet4  = module4.subdet();
+            int subdet6  = module6.subdet();
+            int subdet8  = module8.subdet();
+            int subdet10 = module10.subdet();
+            int subdet12 = module12.subdet();
+            int subdet14 = module14.subdet();
+
+            int logicallayer0  = isPixel0  ? 0 : layer0  + 6 * (subdet0  == 4);
+            int logicallayer2  = isPixel2  ? 0 : layer2  + 6 * (subdet2  == 4);
+            int logicallayer4  = isPixel4  ? 0 : layer4  + 6 * (subdet4  == 4);
+            int logicallayer6  = isPixel6  ? 0 : layer6  + 6 * (subdet6  == 4);
+            int logicallayer8  = isPixel8  ? 0 : layer8  + 6 * (subdet8  == 4);
+            int logicallayer10 = isPixel10 ? 0 : layer10 + 6 * (subdet10 == 4);
+            int logicallayer12 = isPixel12 ? 0 : layer12 + 6 * (subdet12 == 4);
+            int logicallayer14 = isPixel14 ? 0 : layer14 + 6 * (subdet14 == 4);
+
+            int layer_binary = 0;
+            layer_binary |= (1 << logicallayer0);
+            layer_binary |= (1 << logicallayer2);
+            layer_binary |= (1 << logicallayer4);
+            layer_binary |= (1 << logicallayer6);
+            layer_binary |= (1 << logicallayer8);
+            layer_binary |= (1 << logicallayer10);
+            layer_binary |= (1 << logicallayer12);
+            layer_binary |= (1 << logicallayer14);
+
+            // sim track matched index
+            std::vector<int> matched_sim_trk_idxs = matchedSimTrkIdxs(hit_idx, hit_types);
+
+            for (auto& isimtrk : matched_sim_trk_idxs)
+            {
+                sim_T5_matched[isimtrk]++;
+            }
+
+            for (auto& isimtrk : matched_sim_trk_idxs)
+            {
+                sim_T5_types[isimtrk].push_back(layer_binary);
+            }
+
+            // Compute pt, eta, phi of T5
+            float eta = -999;
+            float phi = -999;
+
+            // // if (isInnerTrackletTriplet and isOuterTrackletTriplet)
+            // if (true)
+            // {
+            //     std::cout << "here1" << std::endl;
+            //     std::cout <<  " isInnerTrackletTriplet: " << isInnerTrackletTriplet <<  " isOuterTrackletTriplet: " << isOuterTrackletTriplet <<  std::endl;
+            //     std::cout <<  " logicallayer0: " << logicallayer0 <<  " logicallayer2: " << logicallayer2 <<  " logicallayer4: " << logicallayer4 <<  " logicallayer6: " << logicallayer6 <<  " logicallayer8: " << logicallayer8 <<  " logicallayer10: " << logicallayer10 <<  std::endl;
+            //     for (unsigned int ihit = 0; ihit < hit_idx.size(); ++ihit)
+            //     {
+            //         std::cout <<  " ihit: " << ihit <<  " hit_idx[ihit]: " << hit_idx[ihit] <<  std::endl;
+            //     }
+            //     for (unsigned int ihit = 0; ihit < hit_types.size(); ++ihit)
+            //     {
+            //         std::cout <<  " ihit: " << ihit <<  " hit_types[ihit]: " << hit_types[ihit] <<  std::endl;
+            //     }
+            //     std::cout << "recovar size: " << ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand.getRecoVars().size() << std::endl;
+            //     for (auto& [k, v]: ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand.getRecoVars())
+            //     {
+            //         std::cout <<  " k: " << k <<  std::endl;
+            //     }
+            //     std::cout << "recovar size: " << ((SDL::CPU::Triplet*) trackCandidatePtr->outerTrackletBasePtr())->tlCand.getRecoVars().size() << std::endl;
+            //     for (auto& [k, v]: ((SDL::CPU::Triplet*) trackCandidatePtr->outerTrackletBasePtr())->tlCand.getRecoVars())
+            //     {
+            //         std::cout <<  " k: " << k <<  std::endl;
+            //     }
+            // }
+            float pt_in  = isInnerTrackletTriplet ? ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand.getRecoVar("pt_beta") : trackCandidatePtr->innerTrackletBasePtr()->getRecoVar("pt_beta");
+            // std::cout <<  " pt_in: " << pt_in <<  std::endl;
+            float pt_out = isOuterTrackletTriplet ? ((SDL::CPU::Triplet*) trackCandidatePtr->outerTrackletBasePtr())->tlCand.getRecoVar("pt_beta") : trackCandidatePtr->outerTrackletBasePtr()->getRecoVar("pt_beta");
+            // std::cout <<  " pt_out: " << pt_out <<  std::endl;
+            float pt = (pt_in + pt_out) / 2.;
+            // std::cout << "here2" << std::endl;
+
+            // float ptBetaIn_in = isInnerTrackletTriplet ? ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand.getRecoVar("pt_betaIn") : trackCandidatePtr->innerTrackletBasePtr()->getRecoVar("pt_betaIn");
+            // float ptBetaOut_in = isInnerTrackletTriplet ? ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand.getRecoVar("pt_betaOut") : trackCandidatePtr->innerTrackletBasePtr()->getRecoVar("pt_betaOut");
+
+            // if ((trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule().detId() == 1))
+            //     std::cout << " " << (trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule().detId() == 1) <<  " " << hit_idx[0] <<  " " << hit_idx[1] <<  " " << hit_idx[2] <<  " " << hit_idx[3] <<  " " << hit_idx[4] <<  " " << hit_idx[5] <<  " " << hit_idx[6] <<  " " << hit_idx[7] <<  " " << hit_idx[8] <<  " " << hit_idx[9] <<  " " << hit_idx[10] <<  " " << hit_idx[11] <<  " pt_in: " << pt_in <<  " pt_out: " << pt_out <<  " ptBetaIn_in: " << ptBetaIn_in <<  " ptBetaOut_in: " << ptBetaOut_in << std::endl;
+
+            if (hit_types[0] == 4)
+            {
+                SDL::CPU::Hit hitA(trk.ph2_x()[hit_idx[0]], trk.ph2_y()[hit_idx[0]], trk.ph2_z()[hit_idx[0]]);
+                SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[15]], trk.ph2_y()[hit_idx[15]], trk.ph2_z()[hit_idx[15]]);
+                eta = hitB.eta();
+                phi = hitA.phi();
+            }
+            else
+            {
+                SDL::CPU::Hit hitA(trk.pix_x()[hit_idx[0]], trk.pix_y()[hit_idx[0]], trk.pix_z()[hit_idx[0]]);
+                SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[15]], trk.ph2_y()[hit_idx[15]], trk.ph2_z()[hit_idx[15]]);
+                eta = hitB.eta();
+                phi = hitA.phi();
+            }
+
+            t5_isFake.push_back(matched_sim_trk_idxs.size() == 0);
+            t5_pt.push_back(pt);
+            t5_eta.push_back(eta);
+            t5_phi.push_back(phi);
+            t5_matched_simIdx.push_back(matched_sim_trk_idxs);
+
+        }
+
+    }
+
+    ana.tx->setBranch<vector<int>>("sim_T5_matched", sim_T5_matched);
+    ana.tx->setBranch<vector<vector<int>>>("sim_T5_types", sim_T5_types);
+
+    vector<int> t5_isDuplicate(t5_matched_simIdx.size());
+
+    for (unsigned int i = 0; i < t5_matched_simIdx.size(); ++i)
+    {
+        bool isDuplicate = false;
+        for (unsigned int isim = 0; isim < t5_matched_simIdx[i].size(); ++isim)
+        {
+            if (sim_T5_matched[t5_matched_simIdx[i][isim]] > 1)
+            {
+                isDuplicate = true;
+            }
+        }
+        t5_isDuplicate[i] = isDuplicate;
+    }
+
+    ana.tx->setBranch<vector<float>>("t5_pt", t5_pt);
+    ana.tx->setBranch<vector<float>>("t5_eta", t5_eta);
+    ana.tx->setBranch<vector<float>>("t5_phi", t5_phi);
+    ana.tx->setBranch<vector<int>>("t5_isFake", t5_isFake);
+    ana.tx->setBranch<vector<int>>("t5_isDuplicate", t5_isDuplicate);
 
 }
 

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -1854,6 +1854,10 @@ void fillTrackCandidateOutputBranches_for_CPU(SDL::CPU::Event& event)
             hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->upperHitPtr()->idx());
             hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->idx());
             hit_idx.push_back(trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->upperHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->upperHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->idx());
+            hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->upperHitPtr()->idx());
             hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->idx());
             hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->upperHitPtr()->idx());
             hit_idx.push_back(trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->idx());
@@ -1883,41 +1887,75 @@ void fillTrackCandidateOutputBranches_for_CPU(SDL::CPU::Event& event)
             hit_types.push_back(4);
             hit_types.push_back(4);
             hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
+            hit_types.push_back(4);
 
-            const SDL::CPU::Module& module0 = trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
-            const SDL::CPU::Module& module2 = trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
-            const SDL::CPU::Module& module4 = trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
-            const SDL::CPU::Module& module6 = trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
-            const SDL::CPU::Module& module8 = trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
-            const SDL::CPU::Module& module10 = trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            // 0 -- 0
+            //      0 -- 0
+            //
+            //           0 -- 0
+            //                0 -- 0
+            // 01  23   
+            //     45   67
+            //          89   1011
+            //               1213  1415
 
-            bool isPixel0 = module0.isPixelLayerModule();
-            bool isPixel2 = module2.isPixelLayerModule();
-            bool isPixel4 = module4.isPixelLayerModule();
-            bool isPixel6 = module6.isPixelLayerModule();
-            bool isPixel8 = module8.isPixelLayerModule();
-            bool isPixel10 =module10.isPixelLayerModule();
+            // 0 -- 0
+            //      0 -- 0
+            //
+            //           0 -- 0
+            //                0 -- 0
+            // 0    2   
+            //      4    6
+            //           8   10  
+            //               1213  1415
 
-            int layer0 = module0.layer();
-            int layer2 = module2.layer();
-            int layer4 = module4.layer();
-            int layer6 = module6.layer();
-            int layer8 = module8.layer();
-            int layer10 =module10.layer();
+            const SDL::CPU::Module& module0  = trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module2  = trackCandidatePtr->innerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module4  = trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module6  = trackCandidatePtr->innerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module8  = trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module10 = trackCandidatePtr->outerTrackletBasePtr()->innerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module12 = trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->innerMiniDoubletPtr()->lowerHitPtr()->getModule();
+            const SDL::CPU::Module& module14 = trackCandidatePtr->outerTrackletBasePtr()->outerSegmentPtr()->outerMiniDoubletPtr()->lowerHitPtr()->getModule();
 
-            int subdet0 = module0.subdet();
-            int subdet2 = module2.subdet();
-            int subdet4 = module4.subdet();
-            int subdet6 = module6.subdet();
-            int subdet8 = module8.subdet();
-            int subdet10 =module10.subdet();
+            bool isPixel0  = module0.isPixelLayerModule();
+            bool isPixel2  = module2.isPixelLayerModule();
+            bool isPixel4  = module4.isPixelLayerModule();
+            bool isPixel6  = module6.isPixelLayerModule();
+            bool isPixel8  = module8.isPixelLayerModule();
+            bool isPixel10 = module10.isPixelLayerModule();
+            bool isPixel12 = module12.isPixelLayerModule();
+            bool isPixel14 = module14.isPixelLayerModule();
 
-            int logicallayer0 = isPixel0 ? 0 : layer0  + 6 * (subdet0 == 4);
-            int logicallayer2 = isPixel2 ? 0 : layer2  + 6 * (subdet2 == 4);
-            int logicallayer4 = isPixel4 ? 0 : layer4  + 6 * (subdet4 == 4);
-            int logicallayer6 = isPixel6 ? 0 : layer6  + 6 * (subdet6 == 4);
-            int logicallayer8 = isPixel8 ? 0 : layer8  + 6 * (subdet8 == 4);
-            int logicallayer10 =isPixel10 ? 0 : layer10 + 6 * (subdet10 == 4);
+            int layer0  = module0.layer();
+            int layer2  = module2.layer();
+            int layer4  = module4.layer();
+            int layer6  = module6.layer();
+            int layer8  = module8.layer();
+            int layer10 = module10.layer();
+            int layer12 = module12.layer();
+            int layer14 = module14.layer();
+
+            int subdet0  = module0.subdet();
+            int subdet2  = module2.subdet();
+            int subdet4  = module4.subdet();
+            int subdet6  = module6.subdet();
+            int subdet8  = module8.subdet();
+            int subdet10 = module10.subdet();
+            int subdet12 = module12.subdet();
+            int subdet14 = module14.subdet();
+
+            int logicallayer0  = isPixel0  ? 0 : layer0  + 6 * (subdet0  == 4);
+            int logicallayer2  = isPixel2  ? 0 : layer2  + 6 * (subdet2  == 4);
+            int logicallayer4  = isPixel4  ? 0 : layer4  + 6 * (subdet4  == 4);
+            int logicallayer6  = isPixel6  ? 0 : layer6  + 6 * (subdet6  == 4);
+            int logicallayer8  = isPixel8  ? 0 : layer8  + 6 * (subdet8  == 4);
+            int logicallayer10 = isPixel10 ? 0 : layer10 + 6 * (subdet10 == 4);
+            int logicallayer12 = isPixel12 ? 0 : layer12 + 6 * (subdet12 == 4);
+            int logicallayer14 = isPixel14 ? 0 : layer14 + 6 * (subdet14 == 4);
 
             int layer_binary = 0;
             layer_binary |= (1 << logicallayer0);
@@ -1926,6 +1964,8 @@ void fillTrackCandidateOutputBranches_for_CPU(SDL::CPU::Event& event)
             layer_binary |= (1 << logicallayer6);
             layer_binary |= (1 << logicallayer8);
             layer_binary |= (1 << logicallayer10);
+            layer_binary |= (1 << logicallayer12);
+            layer_binary |= (1 << logicallayer14);
 
             // sim track matched index
             std::vector<int> matched_sim_trk_idxs = matchedSimTrkIdxs(hit_idx, hit_types);
@@ -1945,19 +1985,32 @@ void fillTrackCandidateOutputBranches_for_CPU(SDL::CPU::Event& event)
             float phi = -999;
 
             bool isInnerTrackletTriplet = (hit_idx[2] == hit_idx[4] and hit_idx[3] == hit_idx[5] and hit_types[2] == hit_types[4] and hit_types[3] == hit_types[5]);
-            bool isOuterTrackletTriplet = (hit_idx[6] == hit_idx[8] and hit_idx[7] == hit_idx[9] and hit_types[6] == hit_types[8] and hit_types[7] == hit_types[9]);
+            bool isOuterTrackletTriplet = (hit_idx[10] == hit_idx[12] and hit_idx[11] == hit_idx[13] and hit_types[10] == hit_types[12] and hit_types[11] == hit_types[13]);
 
-            // std::cout << "here1" << std::endl;
-            // std::cout <<  " isInnerTrackletTriplet: " << isInnerTrackletTriplet <<  " isOuterTrackletTriplet: " << isOuterTrackletTriplet <<  std::endl;
-            // if (isInnerTrackletTriplet)
+            // // if (isInnerTrackletTriplet and isOuterTrackletTriplet)
+            // if (true)
             // {
+            //     std::cout << "here1" << std::endl;
+            //     std::cout <<  " isInnerTrackletTriplet: " << isInnerTrackletTriplet <<  " isOuterTrackletTriplet: " << isOuterTrackletTriplet <<  std::endl;
             //     std::cout <<  " logicallayer0: " << logicallayer0 <<  " logicallayer2: " << logicallayer2 <<  " logicallayer4: " << logicallayer4 <<  " logicallayer6: " << logicallayer6 <<  " logicallayer8: " << logicallayer8 <<  " logicallayer10: " << logicallayer10 <<  std::endl;
-            //     // std::cout << ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand;
+            //     for (unsigned int ihit = 0; ihit < hit_idx.size(); ++ihit)
+            //     {
+            //         std::cout <<  " ihit: " << ihit <<  " hit_idx[ihit]: " << hit_idx[ihit] <<  std::endl;
+            //     }
+            //     for (unsigned int ihit = 0; ihit < hit_types.size(); ++ihit)
+            //     {
+            //         std::cout <<  " ihit: " << ihit <<  " hit_types[ihit]: " << hit_types[ihit] <<  std::endl;
+            //     }
             //     std::cout << "recovar size: " << ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand.getRecoVars().size() << std::endl;
-            //     // for (auto& [k, v]: ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand.getRecoVars())
-            //     // {
-            //     //     std::cout <<  " k: " << k <<  std::endl;
-            //     // }
+            //     for (auto& [k, v]: ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand.getRecoVars())
+            //     {
+            //         std::cout <<  " k: " << k <<  std::endl;
+            //     }
+            //     std::cout << "recovar size: " << ((SDL::CPU::Triplet*) trackCandidatePtr->outerTrackletBasePtr())->tlCand.getRecoVars().size() << std::endl;
+            //     for (auto& [k, v]: ((SDL::CPU::Triplet*) trackCandidatePtr->outerTrackletBasePtr())->tlCand.getRecoVars())
+            //     {
+            //         std::cout <<  " k: " << k <<  std::endl;
+            //     }
             // }
             float pt_in  = isInnerTrackletTriplet ? ((SDL::CPU::Triplet*) trackCandidatePtr->innerTrackletBasePtr())->tlCand.getRecoVar("pt_beta") : trackCandidatePtr->innerTrackletBasePtr()->getRecoVar("pt_beta");
             // std::cout <<  " pt_in: " << pt_in <<  std::endl;
@@ -1975,14 +2028,14 @@ void fillTrackCandidateOutputBranches_for_CPU(SDL::CPU::Event& event)
             if (hit_types[0] == 4)
             {
                 SDL::CPU::Hit hitA(trk.ph2_x()[hit_idx[0]], trk.ph2_y()[hit_idx[0]], trk.ph2_z()[hit_idx[0]]);
-                SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[11]], trk.ph2_y()[hit_idx[11]], trk.ph2_z()[hit_idx[11]]);
+                SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[15]], trk.ph2_y()[hit_idx[15]], trk.ph2_z()[hit_idx[15]]);
                 eta = hitB.eta();
                 phi = hitA.phi();
             }
             else
             {
                 SDL::CPU::Hit hitA(trk.pix_x()[hit_idx[0]], trk.pix_y()[hit_idx[0]], trk.pix_z()[hit_idx[0]]);
-                SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[11]], trk.ph2_y()[hit_idx[11]], trk.ph2_z()[hit_idx[11]]);
+                SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[15]], trk.ph2_y()[hit_idx[15]], trk.ph2_z()[hit_idx[15]]);
                 eta = hitB.eta();
                 phi = hitA.phi();
             }

--- a/code/core/write_sdl_ntuple.h
+++ b/code/core/write_sdl_ntuple.h
@@ -18,7 +18,9 @@
 // Common
 void createOutputBranches();
 void createLowerLevelOutputBranches();
+#ifdef DO_QUINTUPLET
 void createQuintupletCutValueBranches();
+#endif
 void createQuadrupletCutValueBranches();
 void createTripletCutValueBranches();
 void createSegmentCutValueBranches();
@@ -33,7 +35,9 @@ void fillTrackCandidateOutputBranches(SDL::Event& event);
 void fillLowerLevelOutputBranches(SDL::Event& event);
 void fillQuadrupletOutputBranches(SDL::Event& event);
 void fillTripletOutputBranches(SDL::Event& event);
+#ifdef DO_QUINTUPLET
 void fillQuintupletOutputBranches(SDL::Event& event);
+#endif
 void fillPixelLineSegmentOutputBranches(SDL::Event& event);
 void fillOccupancyBranches(SDL::Event& event);
 void fillPixelQuadrupletOutputBranches(SDL::Event& event);
@@ -44,6 +48,9 @@ void fillLowerLevelOutputBranches_for_CPU(SDL::CPU::Event& event);
 void fillQuadrupletOutputBranches_for_CPU(SDL::CPU::Event& event);
 void fillTripletOutputBranches_for_CPU(SDL::CPU::Event& event);
 void fillPixelQuadrupletOutputBranches_for_CPU(SDL::CPU::Event& event);
+#ifdef DO_QUINTUPLET
+void fillQuintupletOutputBranches_for_CPU(SDL::CPU::Event& event);
+#endif
 
 // Timing
 void printTimingInformation(std::vector<std::vector<float>>& timing_information);

--- a/efficiency/misc/index.html
+++ b/efficiency/misc/index.html
@@ -35,6 +35,9 @@
 &nbsp;&nbsp;&nbsp;&nbsp;<a href="#10">10. Pixel Quadruplet (pT4) MTV-like Efficiency plots</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;<a href="#11">11. Pixel Quadruplet (pT4) MTV-like Fake Rate plots</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;<a href="#12">12. Pixel Quadruplet (pT4) MTV-like Duplicate Rate plots</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#13">13. Quintuplet (T5) MTV-like Efficiency plots</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#14">14. Quintuplet (T5) MTV-like Fake Rate plots</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#15">15. Quintuplet (T5) MTV-like Duplicate Rate plots</a><br />
 </p>
 <p><a href="mtv/">Full list of plots can be found here</a></p>
 <h2 data-number="1" id="track-candidate-mtv-like-efficiency-plots" data-number="1"><a name="1"></a><span class="header-section-number">1.</span> Track Candidate MTV-like Efficiency plots</h2>
@@ -64,6 +67,13 @@
 <p><img src="mtv/pT4_AllTypes_h_fakerate_numer_pt_eff.png" width="450" /> <img src="mtv/pT4_AllTypes_h_fakerate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/pT4_AllTypes_h_fakerate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/pT4_AllTypes_h_fakerate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/pT4_AllTypes_h_fakerate_numer_phi_eff.png" width="450" /></p>
 <h2 data-number="12" id="track-candidate-mtv-like-duplrate-plots" data-number="12"><a name="12"></a><span class="header-section-number">12.</span> Pixel Quadruplet (pT4) MTV-like Duplicate Rate plots</h2>
 <p><img src="mtv/pT4_AllTypes_h_duplrate_numer_pt_eff.png" width="450" /> <img src="mtv/pT4_AllTypes_h_duplrate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/pT4_AllTypes_h_duplrate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/pT4_AllTypes_h_duplrate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/pT4_AllTypes_h_duplrate_numer_phi_eff.png" width="450" /></p>
+
+<h2 data-number="13" id="track-candidate-mtv-like-efficiency-plots" data-number="13"><a name="13"></a><span class="header-section-number">13.</span> Quintuplet (T5) MTV-like Efficiency plots</h2>
+<p><img src="mtv/T5_AllTypes__pt_eff.png" width="450" /> <img src="mtv/T5_AllTypes__ptzoom_eff.png" width="450" /> <img src="mtv/T5_AllTypes__etacoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes__etazoomcoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes__dxycoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes__dz_eff.png" width="450" /> <img src="mtv/T5_AllTypes__phi_eff.png" width="450" /></p>
+<h2 data-number="14" id="track-candidate-mtv-like-fakerate-plots" data-number="14"><a name="14"></a><span class="header-section-number">14.</span> Quintuplet (T5) MTV-like Fake Rate plots</h2>
+<p><img src="mtv/T5_AllTypes_h_fakerate_numer_pt_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_fakerate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_fakerate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_fakerate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_fakerate_numer_phi_eff.png" width="450" /></p>
+<h2 data-number="15" id="track-candidate-mtv-like-duplrate-plots" data-number="15"><a name="15"></a><span class="header-section-number">15.</span> Quintuplet (T5) MTV-like Duplicate Rate plots</h2>
+<p><img src="mtv/T5_AllTypes_h_duplrate_numer_pt_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_duplrate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_duplrate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_duplrate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_duplrate_numer_phi_eff.png" width="450" /></p>
 
 </body>
 </html>

--- a/efficiency/src/SDL.cc
+++ b/efficiency/src/SDL.cc
@@ -53,10 +53,20 @@ void SDL::Init(TTree *tree) {
     tc_eta_branch = tree->GetBranch("tc_eta");
     if (tc_eta_branch) { tc_eta_branch->SetAddress(&tc_eta_); }
   }
+  t5_eta_branch = 0;
+  if (tree->GetBranch("t5_eta") != 0) {
+    t5_eta_branch = tree->GetBranch("t5_eta");
+    if (t5_eta_branch) { t5_eta_branch->SetAddress(&t5_eta_); }
+  }
   tc_phi_branch = 0;
   if (tree->GetBranch("tc_phi") != 0) {
     tc_phi_branch = tree->GetBranch("tc_phi");
     if (tc_phi_branch) { tc_phi_branch->SetAddress(&tc_phi_); }
+  }
+  t5_phi_branch = 0;
+  if (tree->GetBranch("t5_phi") != 0) {
+    t5_phi_branch = tree->GetBranch("t5_phi");
+    if (t5_phi_branch) { t5_phi_branch->SetAddress(&t5_phi_); }
   }
   sim_T5_matched_branch = 0;
   if (tree->GetBranch("sim_T5_matched") != 0) {
@@ -177,6 +187,11 @@ void SDL::Init(TTree *tree) {
   if (tree->GetBranch("tc_pt") != 0) {
     tc_pt_branch = tree->GetBranch("tc_pt");
     if (tc_pt_branch) { tc_pt_branch->SetAddress(&tc_pt_); }
+  }
+  t5_pt_branch = 0;
+  if (tree->GetBranch("t5_pt") != 0) {
+    t5_pt_branch = tree->GetBranch("t5_pt");
+    if (t5_pt_branch) { t5_pt_branch->SetAddress(&t5_pt_); }
   }
   t5_innerRadiusMax_branch = 0;
   if (tree->GetBranch("t5_innerRadiusMax") != 0) {
@@ -407,7 +422,9 @@ void SDL::GetEntry(unsigned int idx) {
   sim_q_isLoaded = false;
   sim_eta_isLoaded = false;
   tc_eta_isLoaded = false;
+  t5_eta_isLoaded = false;
   tc_phi_isLoaded = false;
+  t5_phi_isLoaded = false;
   sim_T5_matched_isLoaded = false;
   sim_T5_types_isLoaded = false;
   t4_occupancies_isLoaded = false;
@@ -432,6 +449,7 @@ void SDL::GetEntry(unsigned int idx) {
   module_subdets_isLoaded = false;
   t5_innerRadiusMax2S_isLoaded = false;
   tc_pt_isLoaded = false;
+  t5_pt_isLoaded = false;
   t5_innerRadiusMax_isLoaded = false;
   tc_isDuplicate_isLoaded = false;
   pLS_pt_isLoaded = false;
@@ -487,7 +505,9 @@ void SDL::LoadAllBranches() {
   if (sim_q_branch != 0) sim_q();
   if (sim_eta_branch != 0) sim_eta();
   if (tc_eta_branch != 0) tc_eta();
+  if (t5_eta_branch != 0) t5_eta();
   if (tc_phi_branch != 0) tc_phi();
+  if (t5_phi_branch != 0) t5_phi();
   if (sim_T5_matched_branch != 0) sim_T5_matched();
   if (sim_T5_types_branch != 0) sim_T5_types();
   if (t4_occupancies_branch != 0) t4_occupancies();
@@ -512,6 +532,7 @@ void SDL::LoadAllBranches() {
   if (module_subdets_branch != 0) module_subdets();
   if (t5_innerRadiusMax2S_branch != 0) t5_innerRadiusMax2S();
   if (tc_pt_branch != 0) tc_pt();
+  if (t5_pt_branch != 0) t5_pt();
   if (t5_innerRadiusMax_branch != 0) t5_innerRadiusMax();
   if (tc_isDuplicate_branch != 0) tc_isDuplicate();
   if (pLS_pt_branch != 0) pLS_pt();
@@ -676,6 +697,18 @@ const vector<float> &SDL::tc_eta() {
   }
   return *tc_eta_;
 }
+const vector<float> &SDL::t5_eta() {
+  if (not t5_eta_isLoaded) {
+    if (t5_eta_branch != 0) {
+      t5_eta_branch->GetEntry(index);
+    } else {
+      printf("branch t5_eta_branch does not exist!\n");
+      exit(1);
+    }
+    t5_eta_isLoaded = true;
+  }
+  return *t5_eta_;
+}
 const vector<float> &SDL::tc_phi() {
   if (not tc_phi_isLoaded) {
     if (tc_phi_branch != 0) {
@@ -687,6 +720,18 @@ const vector<float> &SDL::tc_phi() {
     tc_phi_isLoaded = true;
   }
   return *tc_phi_;
+}
+const vector<float> &SDL::t5_phi() {
+  if (not t5_phi_isLoaded) {
+    if (t5_phi_branch != 0) {
+      t5_phi_branch->GetEntry(index);
+    } else {
+      printf("branch t5_phi_branch does not exist!\n");
+      exit(1);
+    }
+    t5_phi_isLoaded = true;
+  }
+  return *t5_phi_;
 }
 const vector<int> &SDL::sim_T5_matched() {
   if (not sim_T5_matched_isLoaded) {
@@ -975,6 +1020,18 @@ const vector<float> &SDL::tc_pt() {
     tc_pt_isLoaded = true;
   }
   return *tc_pt_;
+}
+const vector<float> &SDL::t5_pt() {
+  if (not t5_pt_isLoaded) {
+    if (t5_pt_branch != 0) {
+      t5_pt_branch->GetEntry(index);
+    } else {
+      printf("branch t5_pt_branch does not exist!\n");
+      exit(1);
+    }
+    t5_pt_isLoaded = true;
+  }
+  return *t5_pt_;
 }
 const vector<float> &SDL::t5_innerRadiusMax() {
   if (not t5_innerRadiusMax_isLoaded) {
@@ -1521,6 +1578,7 @@ namespace tas {
   const vector<int> &sim_q() { return sdl.sim_q(); }
   const vector<float> &sim_eta() { return sdl.sim_eta(); }
   const vector<float> &tc_eta() { return sdl.tc_eta(); }
+  const vector<float> &t5_eta() { return sdl.t5_eta(); }
   const vector<float> &tc_phi() { return sdl.tc_phi(); }
   const vector<int> &sim_T5_matched() { return sdl.sim_T5_matched(); }
   const vector<vector<int> > &sim_T5_types() { return sdl.sim_T5_types(); }
@@ -1546,6 +1604,7 @@ namespace tas {
   const vector<int> &module_subdets() { return sdl.module_subdets(); }
   const vector<float> &t5_innerRadiusMax2S() { return sdl.t5_innerRadiusMax2S(); }
   const vector<float> &tc_pt() { return sdl.tc_pt(); }
+  const vector<float> &t5_pt() { return sdl.t5_pt(); }
   const vector<float> &t5_innerRadiusMax() { return sdl.t5_innerRadiusMax(); }
   const vector<int> &tc_isDuplicate() { return sdl.tc_isDuplicate(); }
   const vector<float> &pLS_pt() { return sdl.pLS_pt(); }

--- a/efficiency/src/SDL.h
+++ b/efficiency/src/SDL.h
@@ -50,9 +50,15 @@ protected:
   vector<float> *tc_eta_;
   TBranch *tc_eta_branch;
   bool tc_eta_isLoaded;
+  vector<float> *t5_eta_;
+  TBranch *t5_eta_branch;
+  bool t5_eta_isLoaded;
   vector<float> *tc_phi_;
   TBranch *tc_phi_branch;
   bool tc_phi_isLoaded;
+  vector<float> *t5_phi_;
+  TBranch *t5_phi_branch;
+  bool t5_phi_isLoaded;
   vector<int> *sim_T5_matched_;
   TBranch *sim_T5_matched_branch;
   bool sim_T5_matched_isLoaded;
@@ -125,6 +131,9 @@ protected:
   vector<float> *tc_pt_;
   TBranch *tc_pt_branch;
   bool tc_pt_isLoaded;
+  vector<float> *t5_pt_;
+  TBranch *t5_pt_branch;
+  bool t5_pt_isLoaded;
   vector<float> *t5_innerRadiusMax_;
   TBranch *t5_innerRadiusMax_branch;
   bool t5_innerRadiusMax_isLoaded;
@@ -268,7 +277,9 @@ public:
   const vector<int> &sim_q();
   const vector<float> &sim_eta();
   const vector<float> &tc_eta();
+  const vector<float> &t5_eta();
   const vector<float> &tc_phi();
+  const vector<float> &t5_phi();
   const vector<int> &sim_T5_matched();
   const vector<vector<int> > &sim_T5_types();
   const vector<int> &t4_occupancies();
@@ -293,6 +304,7 @@ public:
   const vector<int> &module_subdets();
   const vector<float> &t5_innerRadiusMax2S();
   const vector<float> &tc_pt();
+  const vector<float> &t5_pt();
   const vector<float> &t5_innerRadiusMax();
   const vector<int> &tc_isDuplicate();
   const vector<float> &pLS_pt();
@@ -355,7 +367,9 @@ namespace tas {
   const vector<int> &sim_q();
   const vector<float> &sim_eta();
   const vector<float> &tc_eta();
+  const vector<float> &t5_eta();
   const vector<float> &tc_phi();
+  const vector<float> &t5_phi();
   const vector<int> &sim_T5_matched();
   const vector<vector<int> > &sim_T5_types();
   const vector<int> &t4_occupancies();
@@ -380,6 +394,7 @@ namespace tas {
   const vector<int> &module_subdets();
   const vector<float> &t5_innerRadiusMax2S();
   const vector<float> &tc_pt();
+  const vector<float> &t5_pt();
   const vector<float> &t5_innerRadiusMax();
   const vector<int> &tc_isDuplicate();
   const vector<float> &pLS_pt();

--- a/efficiency/src/efficiency.cc
+++ b/efficiency/src/efficiency.cc
@@ -33,6 +33,7 @@ int main(int argc, char** argv)
     // creating a set of fake rate plots
     std::vector<FakeRateSetDefinition> list_FRSetDef;
 
+    // TODO FIXME the passing of the pt eta phi's are not implemented properly. (It's like half finished....)
     list_FRSetDef.push_back(FakeRateSetDefinition("TC_AllTypes", 13, [&](int itc) {return sdl.tc_isFake().size() > itc ? sdl.tc_isFake()[itc] > 0 : false;}, sdl.tc_pt(), sdl.tc_eta(), sdl.tc_phi()));
     if (ana.do_lower_level)
     {
@@ -40,7 +41,7 @@ int main(int argc, char** argv)
         list_FRSetDef.push_back(FakeRateSetDefinition("T3_AllTypes", 13, [&](int it3) {return sdl.t3_isFake().size() > it3 ? sdl.t3_isFake()[it3] > 0 : false;}, sdl.t3_pt(), sdl.t3_eta(), sdl.t3_phi()));
         list_FRSetDef.push_back(FakeRateSetDefinition("pT4_AllTypes", 13, [&](int ipT4) {return sdl.pT4_isFake().size() > ipT4 ? sdl.pT4_isFake()[ipT4] > 0 : false;}, sdl.pT4_pt(), sdl.pT4_eta(), sdl.pT4_phi()));
         list_FRSetDef.push_back(FakeRateSetDefinition("pLS_AllTypes", 13, [&](int itls) {return sdl.pLS_isFake().size() > itls ? sdl.pLS_isFake()[itls] > 0 : false;}, sdl.pLS_pt(), sdl.pLS_eta(), sdl.pLS_phi()));
-
+        list_FRSetDef.push_back(FakeRateSetDefinition("T5_AllTypes", 13, [&](int iT5) {return sdl.t5_isFake().size() > iT5 ? sdl.t5_isFake()[iT5] > 0 : false;}, sdl.t5_pt(), sdl.t5_eta(), sdl.t5_phi()));
     }
 
     bookFakeRateSets(list_FRSetDef);
@@ -55,6 +56,7 @@ int main(int argc, char** argv)
         list_DLSetDef.push_back(DuplicateRateSetDefinition("T3_AllTypes", 13, [&](int it3) {return sdl.t3_isDuplicate().size() > it3 ? sdl.t3_isDuplicate()[it3] > 0 : false;}, sdl.t3_pt(), sdl.t3_eta(), sdl.t3_phi()));
         list_DLSetDef.push_back(DuplicateRateSetDefinition("pT4_AllTypes", 13, [&](int ipT4) {return sdl.pT4_isDuplicate().size() > ipT4 ? sdl.pT4_isDuplicate()[ipT4] > 0 : false;}, sdl.pT4_pt(), sdl.pT4_eta(), sdl.pT4_phi()));
         list_DLSetDef.push_back(DuplicateRateSetDefinition("pLS_AllTypes", 13, [&](int itls) {return sdl.pLS_isDuplicate().size() > itls ? sdl.pLS_isDuplicate()[itls] > 0 : false;}, sdl.pLS_pt(), sdl.pLS_eta(), sdl.pLS_phi()));
+        list_DLSetDef.push_back(DuplicateRateSetDefinition("T5_AllTypes", 13, [&](int iT5) {return sdl.t5_isDuplicate().size() > iT5 ? sdl.t5_isDuplicate()[iT5] > 0 : false;}, sdl.t5_pt(), sdl.t5_eta(), sdl.t5_phi()));
     }
 
     bookDuplicateRateSets(list_DLSetDef);
@@ -267,12 +269,9 @@ void fillFakeRateSets(std::vector<FakeRateSetDefinition>& FRsets)
     {
         if (FRset.set_name.Contains("TC_"))
         {
-            for (unsigned int itc = 0; itc < FRset.pt.size(); ++itc)
+            for (unsigned int itc = 0; itc < sdl.tc_pt().size(); ++itc)
             {
-                for (unsigned int itc = 0; itc < sdl.tc_pt().size(); ++itc)
-                {
-                    fillFakeRateSet(itc, FRset);
-                }
+                fillFakeRateSet(itc, FRset);
             }
         }
         else if (FRset.set_name.Contains("T4s_"))
@@ -294,6 +293,13 @@ void fillFakeRateSets(std::vector<FakeRateSetDefinition>& FRsets)
             for (unsigned int it3 = 0; it3 < sdl.t3_pt().size(); ++it3)
             {
                 fillFakeRateSet(it3, FRset);
+            }
+        }
+        else if (FRset.set_name.Contains("T5_"))
+        {
+            for (unsigned int it5 = 0; it5 < sdl.t5_pt().size(); ++it5)
+            {
+                fillFakeRateSet(it5, FRset);
             }
         }
     }
@@ -327,6 +333,12 @@ void fillFakeRateSet(int itc, FakeRateSetDefinition& FRset)
         pt = sdl.t3_pt()[itc];
         eta = sdl.t3_eta()[itc];
         phi = sdl.t3_phi()[itc];
+    }
+    else if (FRset.set_name.Contains("T5_"))
+    {
+        pt = sdl.t5_pt()[itc];
+        eta = sdl.t5_eta()[itc];
+        phi = sdl.t5_phi()[itc];
     }
 
     TString category_name = FRset.set_name;
@@ -388,12 +400,9 @@ void fillDuplicateRateSets(std::vector<DuplicateRateSetDefinition>& DLsets)
     {
         if (DLset.set_name.Contains("TC_"))
         {
-            for (unsigned int itc = 0; itc < DLset.pt.size(); ++itc)
+            for (unsigned int itc = 0; itc < sdl.tc_pt().size(); ++itc)
             {
-                for (unsigned int itc = 0; itc < sdl.tc_pt().size(); ++itc)
-                {
-                    fillDuplicateRateSet(itc, DLset);
-                }
+                fillDuplicateRateSet(itc, DLset);
             }
         }
         else if (DLset.set_name.Contains("T4s_"))
@@ -415,6 +424,13 @@ void fillDuplicateRateSets(std::vector<DuplicateRateSetDefinition>& DLsets)
             for (unsigned int it3 = 0; it3 < sdl.t3_pt().size(); ++it3)
             {
                 fillDuplicateRateSet(it3, DLset);
+            }
+        }
+        if (DLset.set_name.Contains("T5_"))
+        {
+            for (unsigned int it5 = 0; it5 < sdl.t5_pt().size(); ++it5)
+            {
+                fillDuplicateRateSet(it5, DLset);
             }
         }
     }
@@ -448,6 +464,12 @@ void fillDuplicateRateSet(int itc, DuplicateRateSetDefinition& DLset)
         pt = sdl.t3_pt()[itc];
         eta = sdl.t3_eta()[itc];
         phi = sdl.t3_phi()[itc];
+    }
+    else if (DLset.set_name.Contains("T5_"))
+    {
+        pt = sdl.t5_pt()[itc];
+        eta = sdl.t5_eta()[itc];
+        phi = sdl.t5_phi()[itc];
     }
 
     TString category_name = DLset.set_name;

--- a/efficiency/src/efficiency.cc
+++ b/efficiency/src/efficiency.cc
@@ -19,13 +19,13 @@ int main(int argc, char** argv)
     // creating a set of efficiency plots
     std::vector<EfficiencySetDefinition> list_effSetDef;
 
-    list_effSetDef.push_back(EfficiencySetDefinition("TC_AllTypes", 13, [&](int isim) {return sdl.sim_TC_matched()[isim] > 0;}));
+    list_effSetDef.push_back(EfficiencySetDefinition("TC_AllTypes", 13, [&](int isim) {return sdl.sim_TC_matched().size() > isim ? sdl.sim_TC_matched()[isim] > 0 : false;}));
     if (ana.do_lower_level)
     {
-        list_effSetDef.push_back(EfficiencySetDefinition("T4s_AllTypes", 13, [&](int isim) {return sdl.sim_T4_matched()[isim] > 0;}));
-        list_effSetDef.push_back(EfficiencySetDefinition("T3_AllTypes", 13, [&](int isim) {return sdl.sim_T3_matched()[isim] > 0;}));
-        list_effSetDef.push_back(EfficiencySetDefinition("pT4_AllTypes", 13, [&](int isim) {return sdl.sim_pT4_matched()[isim] > 0;}));
-        list_effSetDef.push_back(EfficiencySetDefinition("T5_AllTypes", 13, [&](int isim) {return sdl.sim_T5_matched()[isim] > 0;}));
+        list_effSetDef.push_back(EfficiencySetDefinition("T4s_AllTypes", 13, [&](int isim) {return sdl.sim_T4_matched().size() > isim ? sdl.sim_T4_matched()[isim] > 0 : false;}));
+        list_effSetDef.push_back(EfficiencySetDefinition("T3_AllTypes", 13, [&](int isim) {return sdl.sim_T3_matched().size() > isim ? sdl.sim_T3_matched()[isim] > 0 : false;}));
+        list_effSetDef.push_back(EfficiencySetDefinition("pT4_AllTypes", 13, [&](int isim) {return sdl.sim_pT4_matched().size() > isim ? sdl.sim_pT4_matched()[isim] > 0 : false;}));
+        list_effSetDef.push_back(EfficiencySetDefinition("T5_AllTypes", 13, [&](int isim) {return sdl.sim_T5_matched().size() > isim ? sdl.sim_T5_matched()[isim] > 0 : false;}));
     }
 
     bookEfficiencySets(list_effSetDef);
@@ -33,13 +33,13 @@ int main(int argc, char** argv)
     // creating a set of fake rate plots
     std::vector<FakeRateSetDefinition> list_FRSetDef;
 
-    list_FRSetDef.push_back(FakeRateSetDefinition("TC_AllTypes", 13, [&](int itc) {return sdl.tc_isFake()[itc] > 0;}, sdl.tc_pt(), sdl.tc_eta(), sdl.tc_phi()));
+    list_FRSetDef.push_back(FakeRateSetDefinition("TC_AllTypes", 13, [&](int itc) {return sdl.tc_isFake().size() > itc ? sdl.tc_isFake()[itc] > 0 : false;}, sdl.tc_pt(), sdl.tc_eta(), sdl.tc_phi()));
     if (ana.do_lower_level)
     {
-        list_FRSetDef.push_back(FakeRateSetDefinition("T4s_AllTypes", 13, [&](int it4) {return sdl.t4_isFake()[it4] > 0;}, sdl.t4_pt(), sdl.t4_eta(), sdl.t4_phi()));
-        list_FRSetDef.push_back(FakeRateSetDefinition("T3_AllTypes", 13, [&](int it3) {return sdl.t3_isFake()[it3] > 0;}, sdl.t3_pt(), sdl.t3_eta(), sdl.t3_phi()));
-        list_FRSetDef.push_back(FakeRateSetDefinition("pT4_AllTypes", 13, [&](int ipT4) {return sdl.pT4_isFake()[ipT4] > 0;}, sdl.pT4_pt(), sdl.pT4_eta(), sdl.pT4_phi()));
-        list_FRSetDef.push_back(FakeRateSetDefinition("pLS_AllTypes", 13, [&](int itls) { return sdl.pLS_isFake()[itls] > 0;}, sdl.pLS_pt(), sdl.pLS_eta(), sdl.pLS_phi()));
+        list_FRSetDef.push_back(FakeRateSetDefinition("T4s_AllTypes", 13, [&](int it4) {return sdl.t4_isFake().size() > it4 ? sdl.t4_isFake()[it4] > 0 : false;}, sdl.t4_pt(), sdl.t4_eta(), sdl.t4_phi()));
+        list_FRSetDef.push_back(FakeRateSetDefinition("T3_AllTypes", 13, [&](int it3) {return sdl.t3_isFake().size() > it3 ? sdl.t3_isFake()[it3] > 0 : false;}, sdl.t3_pt(), sdl.t3_eta(), sdl.t3_phi()));
+        list_FRSetDef.push_back(FakeRateSetDefinition("pT4_AllTypes", 13, [&](int ipT4) {return sdl.pT4_isFake().size() > ipT4 ? sdl.pT4_isFake()[ipT4] > 0 : false;}, sdl.pT4_pt(), sdl.pT4_eta(), sdl.pT4_phi()));
+        list_FRSetDef.push_back(FakeRateSetDefinition("pLS_AllTypes", 13, [&](int itls) {return sdl.pLS_isFake().size() > itls ? sdl.pLS_isFake()[itls] > 0 : false;}, sdl.pLS_pt(), sdl.pLS_eta(), sdl.pLS_phi()));
 
     }
 
@@ -48,13 +48,13 @@ int main(int argc, char** argv)
     // creating a set of fake rate plots
     std::vector<DuplicateRateSetDefinition> list_DLSetDef;
 
-    list_DLSetDef.push_back(DuplicateRateSetDefinition("TC_AllTypes", 13, [&](int itc) {return sdl.tc_isDuplicate()[itc] > 0;}, sdl.tc_pt(), sdl.tc_eta(), sdl.tc_phi()));
+    list_DLSetDef.push_back(DuplicateRateSetDefinition("TC_AllTypes", 13, [&](int itc) {return sdl.tc_isDuplicate().size() > itc ? sdl.tc_isDuplicate()[itc] > 0 : false;}, sdl.tc_pt(), sdl.tc_eta(), sdl.tc_phi()));
     if (ana.do_lower_level)
     {
-        list_DLSetDef.push_back(DuplicateRateSetDefinition("T4s_AllTypes", 13, [&](int it4) {return sdl.t4_isDuplicate()[it4] > 0;}, sdl.t4_pt(), sdl.t4_eta(), sdl.t4_phi()));
-        list_DLSetDef.push_back(DuplicateRateSetDefinition("T3_AllTypes", 13, [&](int it3) {return sdl.t3_isDuplicate()[it3] > 0;}, sdl.t3_pt(), sdl.t3_eta(), sdl.t3_phi()));
-        list_DLSetDef.push_back(DuplicateRateSetDefinition("pT4_AllTypes", 13, [&](int ipT4) {return sdl.pT4_isDuplicate()[ipT4] > 0;}, sdl.pT4_pt(), sdl.pT4_eta(), sdl.pT4_phi()));
-        list_DLSetDef.push_back(DuplicateRateSetDefinition("pLS_AllTypes", 13, [&](int itls) { return sdl.pLS_isDuplicate()[itls] > 0;}, sdl.pLS_pt(), sdl.pLS_eta(), sdl.pLS_phi()));
+        list_DLSetDef.push_back(DuplicateRateSetDefinition("T4s_AllTypes", 13, [&](int it4) {return sdl.t4_isDuplicate().size() > it4 ? sdl.t4_isDuplicate()[it4] > 0 : false;}, sdl.t4_pt(), sdl.t4_eta(), sdl.t4_phi()));
+        list_DLSetDef.push_back(DuplicateRateSetDefinition("T3_AllTypes", 13, [&](int it3) {return sdl.t3_isDuplicate().size() > it3 ? sdl.t3_isDuplicate()[it3] > 0 : false;}, sdl.t3_pt(), sdl.t3_eta(), sdl.t3_phi()));
+        list_DLSetDef.push_back(DuplicateRateSetDefinition("pT4_AllTypes", 13, [&](int ipT4) {return sdl.pT4_isDuplicate().size() > ipT4 ? sdl.pT4_isDuplicate()[ipT4] > 0 : false;}, sdl.pT4_pt(), sdl.pT4_eta(), sdl.pT4_phi()));
+        list_DLSetDef.push_back(DuplicateRateSetDefinition("pLS_AllTypes", 13, [&](int itls) {return sdl.pLS_isDuplicate().size() > itls ? sdl.pLS_isDuplicate()[itls] > 0 : false;}, sdl.pLS_pt(), sdl.pLS_eta(), sdl.pLS_phi()));
     }
 
     bookDuplicateRateSets(list_DLSetDef);


### PR DESCRIPTION
Performance for muon: http://uaf-10.t2.ucsd.edu/~phchang//analysis/sdl/code/TrackLooper__/workarea/2021_04_19_T5CPU_w_Radius/efficiencies/eff_plots__CPU_645f858_muonGun/index.html

- The track candidates for the CPU is currently = combinations with T3 and T4s but not T5.
- The future plan is to make track candidates = {T5, pT2}.
- The html for the lower level objects have been updated to include T5s as well.
- The write_sdl_ntuple.cc for the cpu's are done, but i noticed for GPU it's not done yet. Mb @bsathian can work on it?
