### PR TITLE
Hit matching

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1527,15 +1527,15 @@ void SDL::Event::createTrackCandidates()
     }
 #endif // final state pT2 and pT3
 
-#ifdef FINAL_T5
+#ifdef FINAL_pT5
     printf("Adding pT5s to TC collection\n");
     unsigned int nThreadsx_pT5 = 1;
-    unsigned int nBlocksx_pT5 = (N_MAX_PIXEL_QUINTUPLETS) % nThreadsx == 0 ? N_MAX_PIXEL_QUINTUPLETS / nThreadsx : N_MAX_PIXEL_QUINTUPLETS / nThreadsx + 1;
+    unsigned int nBlocksx_pT5 = (N_MAX_PIXEL_QUINTUPLETS) % nThreadsx_pT5 == 0 ? N_MAX_PIXEL_QUINTUPLETS / nThreadsx_pT5 : N_MAX_PIXEL_QUINTUPLETS / nThreadsx_pT5 + 1;
     addpT5asTrackCandidateInGPU<<<nBlocksx_pT5, nThreadsx_pT5>>>(*modulesInGPU, *pixelQuintupletsInGPU, *trackCandidatesInGPU);
     cudaError_t cudaerr_pT5 = cudaDeviceSynchronize();
     if(cudaerr_pT5 != cudaSuccess)
     {
-        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr_pT3)<<std::endl;
+        std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr_pT5)<<std::endl;
     }
 #endif
 
@@ -3308,7 +3308,7 @@ __global__ void addpT3asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, s
 }
 
 
-__global__ void addPT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU)
+__global__ void addpT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU)
 {
   int pixelQuintupletArrayIndex = blockIdx.x * blockDim.x + threadIdx.x;
   unsigned int pixelLowerModuleArrayIndex = *modulesInGPU.nLowerModules;

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -5158,22 +5158,17 @@ __device__ int inline checkHitsT5(unsigned int ix, unsigned int jx,struct SDL::m
         int nMatched =0;
         for (int i =0; i<10;i++){
           bool matched = false;
-          //if(hits1[i] == -1){continue;}
           for (int j =0; j<10; j++){
-            //if(hits2[j] == -1){continue;}
             if(hits1[i] == hits2[j]){matched = true; break;}
           }
           if(matched){nMatched++;}
         }
-        //if(nMatched==9){printf("%u %u %u %u %u %u %u %u %u XXX %u %u %u %u %u %u %u %u %u %u\n",hits1[1],hits1[2],hits1[3],hits1[4],hits1[5],hits1[6],hits1[7],hits1[8],hits1[9],hits2[0],hits2[1],hits2[2],hits2[3],hits2[4],hits2[5],hits2[6],hits2[7],hits2[8],hits2[9]);}
-        //if(nMatched ==9){printf("%u %u %u %u %u %u %u %u %u %u || %u %u %u %u %u %u %u %u %u %u\n",hits1[0],hits1[1],hits1[2],hits1[3],hits1[4],hits1[5],hits1[6],hits1[7],hits1[8],hits1[9],hits2[0],hits2[1],hits2[2],hits2[3],hits2[4],hits2[5],hits2[6],hits2[7],hits2[8],hits2[9]);}
         return nMatched;
 }
 __device__ int duplicateCounter;
 __global__ void removeDupQuintupletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU,bool secondPass)
 {
       int dup_count=0;
-      //for(int q=0;q<2;q++){
       for(unsigned int lowmod1=blockIdx.x*blockDim.x+threadIdx.x; lowmod1<*modulesInGPU.nLowerModules;lowmod1+=blockDim.x*gridDim.x){
       for(unsigned int ix1=blockIdx.y*blockDim.y+threadIdx.y; ix1<quintupletsInGPU.nQuintuplets[lowmod1]; ix1+=blockDim.y*gridDim.y){
         unsigned int ix = modulesInGPU.quintupletModuleIndices[lowmod1] + ix1;
@@ -5200,7 +5195,6 @@ __global__ void removeDupQuintupletsInGPU(struct SDL::modules& modulesInGPU, str
           if(nMatched >=7){
             dup_count++;
             if(secondPass){
-              //printf("second\n");
               if( quintupletsInGPU.score_rphisum[ix] - quintupletsInGPU.score_rphisum[jx] > 0){
                 rmQuintupletToMemory(quintupletsInGPU,ix);continue; // keept shorted track
               }
@@ -5211,10 +5205,6 @@ __global__ void removeDupQuintupletsInGPU(struct SDL::modules& modulesInGPU, str
           }
         }}
       }}
-      //__syncthreads();
-      //secondPass=true;
-      //}
-     // printf("dups: %d\n",dup_count);
 }
 
 __device__ float scorepT3(struct SDL::modules& modulesInGPU,struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU,struct SDL::segments& segmentsInGPU,struct SDL::triplets& tripletsInGPU, unsigned int innerPix, unsigned int outerTrip, float pt, float pz)

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -185,6 +185,10 @@ namespace SDL
 
 }
 
+__device__ float scoreT5(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,unsigned int innerTrip,unsigned int outerTrip, int layer);
+__global__ void removeDupQuintupletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU);
+__device__ int checkHitsT5(unsigned int hit1, unsigned int hit2,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU,struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU);
+
 __global__ void testMiniDoublets(struct SDL::miniDoublets& mdsInGPU);
 __global__ void createMiniDoubletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU);
 

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -184,6 +184,10 @@ namespace SDL
     extern struct pixelMap* pixelMapping;
 
 }
+__device__ float scorepT3(struct SDL::modules& modulesInGPU,struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, unsigned int innerPix,unsigned int outerTrip,float pt, float pz);
+__global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::triplets& tripletsInGPU);
+__device__ int checkHitspT3(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU);
+
 
 __device__ float scoreT5(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,unsigned int innerTrip,unsigned int outerTrip, int layer);
 __global__ void removeDupQuintupletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU);

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -206,6 +206,7 @@ __global__ void addpT3asTrackCandidateInGPU(struct SDL::modules& modulesInGPU,st
 
 __global__ void addT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU,struct SDL::quintuplets& quintupletsInGPU,struct SDL::trackCandidates& trackCandidatesInGPU);
 
+__global__ void addpT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU);
 #ifndef NESTED_PARA
 #ifdef NEWGRID_Tracklet
 __global__ void createTrackletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::tracklets& trackletsInGPU, unsigned int *index_gpu);

--- a/SDL/Hit.cu
+++ b/SDL/Hit.cu
@@ -14,6 +14,7 @@ SDL::hits::hits()
     moduleIndices = nullptr;
     rts = nullptr;
     phis = nullptr;
+    etas = nullptr;
 //    edge2SMap = nullptr;
     highEdgeXs = nullptr;
     highEdgeYs = nullptr;
@@ -35,6 +36,7 @@ void SDL::createHitsInUnifiedMemory(struct hits& hitsInGPU,unsigned int nMaxHits
 
     hitsInGPU.rts = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
     hitsInGPU.phis = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
+    hitsInGPU.etas = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
 
     hitsInGPU.moduleIndices = (unsigned int*)cms::cuda::allocate_managed(nMaxHits*sizeof(unsigned int),stream);
     hitsInGPU.idxs = (unsigned int*)cms::cuda::allocate_managed(nMaxHits*sizeof(unsigned int),stream);
@@ -57,6 +59,7 @@ void SDL::createHitsInUnifiedMemory(struct hits& hitsInGPU,unsigned int nMaxHits
 
     cudaMallocManaged(&hitsInGPU.rts, nMaxHits * sizeof(float));
     cudaMallocManaged(&hitsInGPU.phis, nMaxHits * sizeof(float));
+    cudaMallocManaged(&hitsInGPU.etas, nMaxHits * sizeof(float));
 
 //    cudaMallocManaged(&hitsInGPU.edge2SMap, nMaxHits * sizeof(int)); //hits to edge hits map. Signed int
     //cudaMallocManaged(&hitsInGPU.highEdgeXs, nMax2SHits * sizeof(float)); // due to changes made for the explicit version
@@ -87,6 +90,7 @@ void SDL::createHitsInExplicitMemory(struct hits& hitsInGPU, unsigned int nMaxHi
 
     hitsInGPU.rts = (float*)cms::cuda::allocate_device(dev,nMaxHits*sizeof(float),stream);
     hitsInGPU.phis = (float*)cms::cuda::allocate_device(dev,nMaxHits*sizeof(float),stream);
+    hitsInGPU.etas = (float*)cms::cuda::allocate_device(dev,nMaxHits*sizeof(float),stream);
 
     hitsInGPU.moduleIndices = (unsigned int*)cms::cuda::allocate_device(dev,nMaxHits*sizeof(unsigned int),stream);
     hitsInGPU.idxs = (unsigned int*)cms::cuda::allocate_device(dev,nMaxHits*sizeof(unsigned int),stream);
@@ -107,6 +111,7 @@ void SDL::createHitsInExplicitMemory(struct hits& hitsInGPU, unsigned int nMaxHi
 
     cudaMalloc(&hitsInGPU.rts, nMaxHits * sizeof(float));
     cudaMalloc(&hitsInGPU.phis, nMaxHits * sizeof(float));
+    cudaMalloc(&hitsInGPU.etas, nMaxHits * sizeof(float));
 
     cudaMalloc(&hitsInGPU.highEdgeXs, nMaxHits * sizeof(float));
     cudaMalloc(&hitsInGPU.highEdgeYs, nMaxHits * sizeof(float));
@@ -355,6 +360,7 @@ void SDL::hits::freeMemory()
     cudaFree(rts);
     cudaFree(idxs);
     cudaFree(phis);
+    cudaFree(etas);
 
 //    cudaFree(edge2SMap);
     cudaFree(highEdgeXs);

--- a/SDL/Hit.cuh
+++ b/SDL/Hit.cuh
@@ -35,6 +35,7 @@ namespace SDL
         
         float *rts;
         float* phis;
+        float* etas;
 
 //        int *edge2SMap;
         float *highEdgeXs;

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -23,7 +23,7 @@ LD                   = nvcc
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
 FINALSTATE           = -DFINAL_T5 #-DFINAL_pT3 #-DFINAL_T3T4 
-DUPLICATES           = #-DDUP_T5
+DUPLICATES           = -DDUP_T5
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = -DNESTED_PARA 

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -22,7 +22,8 @@ CXXFLAGS             =  -g --compiler-options -Wall --compiler-options -Wshadow 
 LD                   = nvcc 
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
-FINALSTATE           = -DFINAL_T5 -DFINAL_pT3 #-DFINAL_pT2 #-DFINAL_T3T4 
+FINALSTATE           = -DFINAL_T5 #-DFINAL_pT3 #-DFINAL_pT2 #-DFINAL_T3T4 
+DUPLICATES           = #-DDUP_T5
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = -DNESTED_PARA 
@@ -36,10 +37,10 @@ CUDALAUNCHFLAG_FLAGS = -DNEWGRID_MD -DNEWGRID_Seg -DNEWGRID_Trips -DNEWGRID_Trac
 CUTVALUEFLAG = 
 CUTVALUEFLAG_FLAGS = -DCUT_VALUE_DEBUG
 %_cuda.o : %.cu %.cuh
-	$(LD) -x cu $(CXXFLAGS) $(LDFLAGS) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUDALAUNCHFLAG) $(CUTVALUEFLAG) $(FINALSTATE) $< -o $@
+	$(LD) -x cu $(CXXFLAGS) $(LDFLAGS) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUDALAUNCHFLAG) $(CUTVALUEFLAG) $(FINALSTATE) $(DUPLICATES) $< -o $@
 
 %_cpu.o : %.cc %.h
-	$(LD) -O2 $(CXXFLAGS) $(LDFLAGS) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUDALAUNCHFLAG) $(FINALSTATE) $< -o $@
+	$(LD) -O2 $(CXXFLAGS) $(LDFLAGS) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUDALAUNCHFLAG) $(FINALSTATE) $(DUPLICATES) $< -o $@
 
 $(LIB):$(CCOBJECTS) $(CUOBJECTS)
 	$(LD)  $(SOFLAGS) $^ -o $@

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -22,8 +22,8 @@ CXXFLAGS             =  -g --compiler-options -Wall --compiler-options -Wshadow 
 LD                   = nvcc 
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
-FINALSTATE           = -DFINAL_T5 #-DFINAL_pT3 #-DFINAL_pT2 #-DFINAL_T3T4 
-DUPLICATES           = #-DDUP_T5
+FINALSTATE           = -DFINAL_pT3 #-DFINAL_pT3 #-DFINAL_pT2 #-DFINAL_T3T4 
+DUPLICATES           = -#DDUP_pT3#-DDUP_T5
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = -DNESTED_PARA 

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -23,7 +23,7 @@ LD                   = nvcc
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
 FINALSTATE           = -DFINAL_T5 #-DFINAL_pT3 #-DFINAL_T3T4 
-DUPLICATES           = -DDUP_T5
+DUPLICATES           = #-DDUP_T5
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = -DNESTED_PARA 

--- a/SDL/PixelQuintuplet.cu
+++ b/SDL/PixelQuintuplet.cu
@@ -92,7 +92,6 @@ __device__ bool SDL::runPixelQuintupletDefaultAlgo(struct modules& modulesInGPU,
     pass = pass & (pT3OuterT3Index == T5InnerT3Index);
 
     rzChiSquared = computePT5ChiSquared(modulesInGPU, hitsInGPU, pixelAnchorHitIndex1, pixelAnchorHitIndex2, anchorHitIndex1, anchorHitIndex2, anchorHitIndex3, anchorHitIndex4, anchorHitIndex5, lowerModuleIndex1, lowerModuleIndex2, lowerModuleIndex3, lowerModuleIndex4, lowerModuleIndex5);
-    
     //other cuts will be filled here!
     return pass;
 }

--- a/SDL/PixelTriplet.cu
+++ b/SDL/PixelTriplet.cu
@@ -8,6 +8,8 @@ SDL::pixelTriplets::pixelTriplets()
     nPixelTriplets = nullptr;
     pixelRadius = nullptr;
     tripletRadius = nullptr;
+    pt = nullptr;
+    isDup = nullptr;
 #ifdef CUT_VALUE_DEBUG
     pixelRadiusError = nullptr;
 #endif
@@ -20,6 +22,8 @@ void SDL::pixelTriplets::freeMemory()
     cudaFree(nPixelTriplets);
     cudaFree(pixelRadius);
     cudaFree(tripletRadius);
+    cudaFree(pt);
+    cudaFree(isDup);
 #ifdef CUT_VALUE_DEBUG
     cudaFree(pixelRadiusError);
 #endif
@@ -36,9 +40,16 @@ void SDL::createPixelTripletsInUnifiedMemory(struct pixelTriplets& pixelTriplets
     cudaMallocManaged(&pixelTripletsInGPU.nPixelTriplets, sizeof(unsigned int));
     cudaMallocManaged(&pixelTripletsInGPU.pixelRadius, maxPixelTriplets * sizeof(float));
     cudaMallocManaged(&pixelTripletsInGPU.tripletRadius, maxPixelTriplets * sizeof(float));
+    cudaMallocManaged(&pixelTripletsInGPU.pt, maxPixelTriplets * 6*sizeof(float));
+    cudaMallocManaged(&pixelTripletsInGPU.isDup, maxPixelTriplets * sizeof(bool));
 #ifdef CUT_VALUE_DEBUG
     cudaMallocManaged(&pixelTripletsInGPU.pixelRadiusError, maxPixelTriplets * sizeof(float));
 #endif
+    pixelTripletsInGPU.eta = pixelTripletsInGPU.pt + maxPixelTriplets;
+    pixelTripletsInGPU.phi = pixelTripletsInGPU.pt + maxPixelTriplets * 2;
+    pixelTripletsInGPU.eta_pix = pixelTripletsInGPU.pt + maxPixelTriplets *3;
+    pixelTripletsInGPU.phi_pix = pixelTripletsInGPU.pt + maxPixelTriplets * 4;
+    pixelTripletsInGPU.score = pixelTripletsInGPU.pt + maxPixelTriplets * 5;
     cudaMemset(pixelTripletsInGPU.nPixelTriplets, 0, sizeof(unsigned int));
 }
 
@@ -49,7 +60,14 @@ void SDL::createPixelTripletsInExplicitMemory(struct pixelTriplets& pixelTriplet
     cudaMalloc(&pixelTripletsInGPU.nPixelTriplets, sizeof(unsigned int));
     cudaMalloc(&pixelTripletsInGPU.pixelRadius, maxPixelTriplets * sizeof(float));
     cudaMalloc(&pixelTripletsInGPU.tripletRadius, maxPixelTriplets * sizeof(float));
+    cudaMalloc(&pixelTripletsInGPU.pt, maxPixelTriplets * 6*sizeof(float));
+    cudaMalloc(&pixelTripletsInGPU.isDup, maxPixelTriplets * sizeof(bool));
 
+    pixelTripletsInGPU.eta = pixelTripletsInGPU.pt + maxPixelTriplets;
+    pixelTripletsInGPU.phi = pixelTripletsInGPU.pt + maxPixelTriplets * 2;
+    pixelTripletsInGPU.eta_pix = pixelTripletsInGPU.pt + maxPixelTriplets *3;
+    pixelTripletsInGPU.phi_pix = pixelTripletsInGPU.pt + maxPixelTriplets * 4;
+    pixelTripletsInGPU.score = pixelTripletsInGPU.pt + maxPixelTriplets * 5;
     cudaMemset(pixelTripletsInGPU.nPixelTriplets, 0, sizeof(unsigned int));
 
 }
@@ -57,17 +75,28 @@ void SDL::createPixelTripletsInExplicitMemory(struct pixelTriplets& pixelTriplet
 #ifdef CUT_VALUE_DEBUG
 __device__ void SDL::addPixelTripletToMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int pixelSegmentIndex, unsigned int tripletIndex, float pixelRadius, float pixelRadiusError, float tripletRadius, unsigned int pixelTripletIndex)
 #else
-__device__ void SDL::addPixelTripletToMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int pixelSegmentIndex, unsigned int tripletIndex, float pixelRadius, float tripletRadius, unsigned int pixelTripletIndex)
+__device__ void SDL::addPixelTripletToMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int pixelSegmentIndex, unsigned int tripletIndex, float pixelRadius, float tripletRadius, unsigned int pixelTripletIndex, float pt, float eta, float phi, float eta_pix, float phi_pix,float score)
 #endif
 {
     pixelTripletsInGPU.pixelSegmentIndices[pixelTripletIndex] = pixelSegmentIndex;
     pixelTripletsInGPU.tripletIndices[pixelTripletIndex] = tripletIndex;
     pixelTripletsInGPU.pixelRadius[pixelTripletIndex] = pixelRadius;
     pixelTripletsInGPU.tripletRadius[pixelTripletIndex] = tripletRadius;
+    pixelTripletsInGPU.pt[pixelTripletIndex] = pt;
+    pixelTripletsInGPU.eta[pixelTripletIndex] = eta;
+    pixelTripletsInGPU.phi[pixelTripletIndex] = phi;
+    pixelTripletsInGPU.eta_pix[pixelTripletIndex] = eta_pix;
+    pixelTripletsInGPU.phi_pix[pixelTripletIndex] = phi_pix;
+    pixelTripletsInGPU.isDup[pixelTripletIndex] = 0;
+    pixelTripletsInGPU.score[pixelTripletIndex] = score;
 
 #ifdef CUT_VALUE_DEBUG
     pixelTripletsInGPU.pixelRadiusError[pixelTripletIndex] = pixelRadiusError;
 #endif
+}
+__device__ void SDL::rmPixelTripletToMemory(struct pixelTriplets& pixelTripletsInGPU,unsigned int pixelTripletIndex)
+{
+    pixelTripletsInGPU.isDup[pixelTripletIndex] = 1;
 }
 
 __device__ bool SDL::runPixelTripletDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, struct triplets& tripletsInGPU, unsigned int& pixelSegmentIndex, unsigned int tripletIndex, float& pixelRadius, float& pixelRadiusError, float& tripletRadius)

--- a/SDL/PixelTriplet.cuh
+++ b/SDL/PixelTriplet.cuh
@@ -33,6 +33,13 @@ namespace SDL
         float* pixelRadius;
         float* pixelRadiusError;
         float* tripletRadius;
+        float* pt;
+        float* eta;
+        float* phi;
+        float* eta_pix;
+        float* phi_pix;
+        float* score;
+        bool* isDup;
 
         pixelTriplets();
         ~pixelTriplets();
@@ -47,9 +54,9 @@ namespace SDL
 #ifdef CUT_VALUE_DEBUG
     CUDA_DEV void addPixelTripletToMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int pixelSegmentIndex, unsigned int tripletIndex, float pixelRadius, float pixelRadiusError, float tripletRadius, unsigned int pixelTripletIndex);
 #else
-    CUDA_DEV void addPixelTripletToMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int pixelSegmentIndex, unsigned int tripletIndex, float pixelRadius, float tripletRadius, unsigned int pixelTripletIndex);
+    CUDA_DEV void addPixelTripletToMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int pixelSegmentIndex, unsigned int tripletIndex, float pixelRadius, float tripletRadius, unsigned int pixelTripletIndex,float pt, float eta, float phi, float eta_pix, float phi_pix, float score);
 #endif
-
+    CUDA_DEV void rmPixelTripletToMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int pixelTripletIndex);
     CUDA_DEV bool runPixelTripletDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, struct triplets& tripletsInGPU, unsigned int& pixelSegmentIndex, unsigned int tripletIndex, float& pixelRadius, float& pixelRadiusError, float& tripletRadius);
 
     CUDA_DEV bool passRadiusCriterion(struct modules& modulesInGPU, float& pixelRadius, float& pixelRadiusError, float& tripletRadius, unsigned int lowerModuleIndex, unsigned int middleModuleIndex, unsigned int upperModuleIndex);

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -17,7 +17,6 @@ SDL::quintuplets::quintuplets()
     layer = nullptr;
     regressionG = nullptr;
     regressionF = nullptr;
->>>>>>> 1d2412a1282dcafa609ef131e539b760af83898f
 
 #ifdef CUT_VALUE_DEBUG
     innerRadiusMin = nullptr;

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -166,7 +166,7 @@ void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsI
     cudaMallocManaged(&quintupletsInGPU.innerRadius, nMemoryLocations * sizeof(float));
     cudaMallocManaged(&quintupletsInGPU.outerRadius, nMemoryLocations * sizeof(float));
     cudaMallocManaged(&quintupletsInGPU.regressionRadius, nMemoryLocations * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.pt, nMemoryLocations *6* sizeof(float));
+    cudaMallocManaged(&quintupletsInGPU.pt, nMemoryLocations *7* sizeof(float));
     cudaMallocManaged(&quintupletsInGPU.layer, nMemoryLocations * sizeof(int));
     cudaMallocManaged(&quintupletsInGPU.isDup, nMemoryLocations * sizeof(bool));
 
@@ -193,6 +193,7 @@ void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsI
     quintupletsInGPU.score_rphi = quintupletsInGPU.pt + 3*nMemoryLocations;
     quintupletsInGPU.score_rz = quintupletsInGPU.pt + 4*nMemoryLocations;
     quintupletsInGPU.score_rphiz = quintupletsInGPU.pt + 5*nMemoryLocations;
+    quintupletsInGPU.score_rzlsq = quintupletsInGPU.pt + 6*nMemoryLocations;
 #pragma omp parallel for
     for(size_t i = 0; i<nLowerModules;i++)
     {
@@ -259,6 +260,7 @@ __device__ void SDL::addQuintupletToMemory(struct SDL::quintuplets& quintupletsI
     quintupletsInGPU.phi[quintupletIndex] = phi;
     quintupletsInGPU.score_rphi[quintupletIndex] = scores[0];
     quintupletsInGPU.score_rz[quintupletIndex] = scores[1];
+    quintupletsInGPU.score_rzlsq[quintupletIndex] = scores[3];
     quintupletsInGPU.score_rphiz[quintupletIndex] = scores[2];
     quintupletsInGPU.layer[quintupletIndex] = layer;
     quintupletsInGPU.isDup[quintupletIndex] = 0;

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -32,6 +32,14 @@ namespace SDL
         float* innerRadius;
         float* outerRadius;
         float* regressionRadius;
+        float* pt;
+        float* eta;
+        float* phi;
+        float* score_rphi;
+        float* score_rz;
+        float* score_rphiz;
+        int* layer;
+        bool* isDup;
 
 #ifdef CUT_VALUE_DEBUG
         float* innerRadiusMin;
@@ -63,11 +71,13 @@ namespace SDL
 
     void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, unsigned int& nEligibleModules, unsigned int* indicesOfEligibleModules, unsigned int maxQuintuplets, unsigned int& maxTriplets);
 
+  CUDA_DEV void rmQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int quintupletIndex);
+
 #ifdef CUT_VALUE_DEBUG
     CUDA_DEV void addQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int innerTripletIndex, unsigned int outerTripletIndex, unsigned int lowerModule1, unsigned int lowerModule2, unsigned int lowerModule3, unsigned int lowerModule4, unsigned int lowerModule5, float innerRadius, float innerRadiusMin, float innerRadiusMax, float outerRadius, float outerRadiusMin, float outerRadiusMax, float bridgeRadius, float bridgeRadiusMin, float bridgeRadiusMax,
         float innerRadiusMin2S, float innerRadiusMax2S, float bridgeRadiusMin2S, float bridgeRadiusMax2S, float outerRadiusMin2S, float outerRadiusMax2S, float regressionRadius, float chiSquared, unsigned int quintupletIndex);
 #else
-    CUDA_DEV void addQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int innerTripletIndex, unsigned int outerTripletIndex, unsigned int lowerModule1, unsigned int lowerModule2, unsigned int lowerModule3, unsigned int lowerModule4, unsigned int lowerModule5, float innerRadius, float outerRadius, float regressionRadius, unsigned int quintupletIndex); 
+    CUDA_DEV void addQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int innerTripletIndex, unsigned int outerTripletIndex, unsigned int lowerModule1, unsigned int lowerModule2, unsigned int lowerModule3, unsigned int lowerModule4, unsigned int lowerModule5, float innerRadius, float outerRadius, float regressionRadius, unsigned int quintupletIndex, float pt, float eta, float phi, float* scores, int layer); 
 #endif
 
 

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -37,6 +37,7 @@ namespace SDL
         float* phi;
         float* score_rphi;
         float* score_rz;
+        float* score_rzlsq;
         float* score_rphiz;
         int* layer;
         bool* isDup;

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -38,7 +38,7 @@ namespace SDL
         float* score_rphi;
         float* score_rz;
         float* score_rzlsq;
-        float* score_rphiz;
+        float* score_rphisum;
         int* layer;
         bool* isDup;
 

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -106,9 +106,19 @@ void createLowerLevelOutputBranches()
     ana.tx->createBranch<vector<vector<int>>>("sim_T5_types");
     ana.tx->createBranch<vector<int>>("t5_isFake");
     ana.tx->createBranch<vector<int>>("t5_isDuplicate");
+    ana.tx->createBranch<vector<int>>("t5_foundDuplicate");
     ana.tx->createBranch<vector<float>>("t5_pt");
     ana.tx->createBranch<vector<float>>("t5_eta");
     ana.tx->createBranch<vector<float>>("t5_phi");
+    ana.tx->createBranch<vector<float>>("t5_eta_2");
+    ana.tx->createBranch<vector<float>>("t5_phi_2");
+
+    ana.tx->createBranch<vector<float>>("t5_score_rphi");
+    ana.tx->createBranch<vector<float>>("t5_score_rz");
+    ana.tx->createBranch<vector<float>>("t5_score_rphiz");
+    ana.tx->createBranch<vector<vector<int>>>("t5_hitIdxs");
+    ana.tx->createBranch<vector<vector<int>>>("t5_matched_simIdx");
+
 //#endif
     //pLS
     ana.tx->createBranch<vector<int>>("sim_pLS_matched");
@@ -1447,6 +1457,13 @@ void fillQuintupletOutputBranches(SDL::Event& event)
     std::vector<float> t5_pt;
     std::vector<float> t5_eta;
     std::vector<float> t5_phi;
+    std::vector<float> t5_eta_2;
+    std::vector<float> t5_phi_2;
+    std::vector<float> t5_score_rphi;
+    std::vector<float> t5_score_rz;
+    std::vector<float> t5_score_rphiz;
+    std::vector<vector<int>> t5_hitIdxs;
+    std::vector<int> t5_foundDuplicate;
 
 #ifdef CUT_VALUE_DEBUG
     std::vector<float> t5_innerRadius;
@@ -1496,7 +1513,12 @@ void fillQuintupletOutputBranches(SDL::Event& event)
             unsigned int innerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex];
             unsigned int outerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex + 1];
 
-
+            t5_foundDuplicate.emplace_back(quintupletsInGPU.isDup[quintupletIndex]);
+            t5_score_rphi.emplace_back(quintupletsInGPU.score_rphi[quintupletIndex]);
+            t5_score_rz.emplace_back(quintupletsInGPU.score_rz[quintupletIndex]);
+            t5_score_rphiz.emplace_back(quintupletsInGPU.score_rphiz[quintupletIndex]);
+            t5_eta_2.emplace_back(quintupletsInGPU.eta[quintupletIndex]);
+            t5_phi_2.emplace_back(quintupletsInGPU.phi[quintupletIndex]);
 
 #ifdef CUT_VALUE_DEBUG
             t5_innerRadius.push_back(quintupletsInGPU.innerRadius[quintupletIndex]);
@@ -1548,7 +1570,7 @@ void fillQuintupletOutputBranches(SDL::Event& event)
             unsigned int innerTripletInnerSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.hitIndices[2 * innerTripletInnerSegmentOuterMiniDoubletIndex + 1];
 
             unsigned int innerTripletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.hitIndices[2 * innerTripletOuterSegmentOuterMiniDoubletIndex];
-            unsigned int innerTripletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.hitIndices[2 * innerTripletInnerSegmentOuterMiniDoubletIndex + 1];
+            unsigned int innerTripletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.hitIndices[2 * innerTripletOuterSegmentOuterMiniDoubletIndex + 1];//fixed bug previously inner trip INNER Segment
 
             unsigned int outerTripletInnerSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.hitIndices[2 * outerTripletInnerSegmentOuterMiniDoubletIndex];
             unsigned int outerTripletInnerSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.hitIndices[2 * outerTripletInnerSegmentOuterMiniDoubletIndex + 1];
@@ -1568,6 +1590,7 @@ void fillQuintupletOutputBranches(SDL::Event& event)
                 (int) hitsInGPU.idxs[outerTripletOuterSegmentOuterMiniDoubletLowerHitIndex],
                 (int) hitsInGPU.idxs[outerTripletOuterSegmentOuterMiniDoubletUpperHitIndex]
             };
+            t5_hitIdxs.emplace_back(hit_idxs);
 
             std::vector<int> hit_types(hit_idxs.size(), 4);
             std::vector<int> module_idxs = {
@@ -1688,9 +1711,19 @@ void fillQuintupletOutputBranches(SDL::Event& event)
     ana.tx->setBranch<vector<vector<int>>>("sim_T5_types", sim_T5_types);
     ana.tx->setBranch<vector<int>>("t5_isFake", t5_isFake);
     ana.tx->setBranch<vector<int>>("t5_isDuplicate", t5_isDuplicate);
+    ana.tx->setBranch<vector<int>>("t5_foundDuplicate", t5_foundDuplicate);
     ana.tx->setBranch<vector<float>>("t5_pt", t5_pt);
     ana.tx->setBranch<vector<float>>("t5_eta", t5_eta);
     ana.tx->setBranch<vector<float>>("t5_phi", t5_phi);
+    ana.tx->setBranch<vector<float>>("t5_eta_2", t5_eta_2);
+    ana.tx->setBranch<vector<float>>("t5_phi_2", t5_phi_2);
+
+
+    ana.tx->setBranch<vector<vector<int>>>("t5_matched_simIdx", t5_matched_simIdx);
+    ana.tx->setBranch<vector<vector<int>>>("t5_hitIdxs", t5_hitIdxs);
+    ana.tx->setBranch<vector<float>>("t5_score_rphi", t5_score_rphi);
+    ana.tx->setBranch<vector<float>>("t5_score_rz", t5_score_rz);
+    ana.tx->setBranch<vector<float>>("t5_score_rphiz", t5_score_rphiz);
 #ifdef CUT_VALUE_DEBUG
     ana.tx->setBranch<vector<vector<float>>>("t5_matched_pt",t5_simpt);
 

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -129,7 +129,7 @@ void createLowerLevelOutputBranches()
     ana.tx->createBranch<vector<float>>("pLS_eta");
     ana.tx->createBranch<vector<float>>("pLS_phi");
 
-
+    //pT3
     ana.tx->createBranch<vector<int>>("sim_pT3_matched");
     ana.tx->createBranch<vector<vector<int>>>("sim_pT3_types");
     ana.tx->createBranch<vector<float>>("pT3_pt");
@@ -137,7 +137,14 @@ void createLowerLevelOutputBranches()
     ana.tx->createBranch<vector<float>>("pT3_phi");
     ana.tx->createBranch<vector<int>>("pT3_isFake");
     ana.tx->createBranch<vector<int>>("pT3_isDuplicate");
+    ana.tx->createBranch<vector<float>>("pT3_eta_2");
+    ana.tx->createBranch<vector<float>>("pT3_phi_2");
+    ana.tx->createBranch<vector<float>>("pT3_score");
+    ana.tx->createBranch<vector<int>>("pT3_foundDuplicate");
+    ana.tx->createBranch<vector<vector<int>>>("pT3_matched_simIdx");
+    ana.tx->createBranch<vector<vector<int>>>("pT3_hitIdxs");
 
+    //pT5
     ana.tx->createBranch<vector<int>>("sim_pT5_matched");
     ana.tx->createBranch<vector<vector<int>>>("sim_pT5_types");
     ana.tx->createBranch<vector<float>>("pT5_pt");
@@ -1769,6 +1776,11 @@ void fillPixelTripletOutputBranches(SDL::Event& event)
     std::vector<float> pT3_pt;
     std::vector<float> pT3_eta;
     std::vector<float> pT3_phi;
+    std::vector<float> pT3_eta_2;
+    std::vector<float> pT3_phi_2;
+    std::vector<float> pT3_score;
+    std::vector<int> pT3_foundDuplicate;
+    std::vector<vector<int>> pT3_hitIdxs;
 
 #ifdef CUT_VALUE_DEBUG
     std::vector<float> pT3_pixelRadius;
@@ -1786,6 +1798,11 @@ void fillPixelTripletOutputBranches(SDL::Event& event)
     {
         unsigned int pixelSegmentIndex = pixelTripletsInGPU.pixelSegmentIndices[jdx];
         unsigned int tripletIndex = pixelTripletsInGPU.tripletIndices[jdx];
+
+        pT3_eta_2.emplace_back(pixelTripletsInGPU.eta[jdx];
+        pT3_phi_2.emplace_back(pixelTripletsInGPU.phi[jdx];
+        pT3_score.emplace_back(pixelTripletsInGPU.score[jdx];
+        pT3_foundDuplicate.emplace_back(pixelTripletsInGPU.isDup[jdx];
         
         unsigned int pixelInnerMDIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex];
         unsigned int pixelOuterMDIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex + 1];
@@ -1819,6 +1836,8 @@ void fillPixelTripletOutputBranches(SDL::Event& event)
             (int) hitsInGPU.idxs[tripletOuterMDLowerHitIndex],
             (int) hitsInGPU.idxs[tripletOuterMDUpperHitIndex]
         };
+
+        pT3_hitIdxs.emplace_back(hit_idxs);
 
         std::vector<int> hit_types;
         hit_types.push_back(0);
@@ -1943,6 +1962,12 @@ void fillPixelTripletOutputBranches(SDL::Event& event)
     ana.tx->setBranch<vector<float>>("pT3_pt", pT3_pt);
     ana.tx->setBranch<vector<float>>("pT3_eta", pT3_eta);
     ana.tx->setBranch<vector<float>>("pT3_phi", pT3_phi);
+    ana.tx->setBranch<vector<float>>("pT3_eta_2", pT3_eta_2);
+    ana.tx->setBranch<vector<float>>("pT3_phi_2", pT3_phi_2);
+    ana.tx->setBranch<vector<float>>("pT3_score", pT3_score);
+    ana.tx->setBranch<vector<int>>("pT3_foundDuplicate", pT3_foundDuplicate);
+    ana.tx->setBranch<vector<vector<int>>>("pT3_matched_simIdx", pT3_matched_simIdx);
+    ana.tx->setBranch<vector<vector<int>>>("pT3_hitIdxs", pT3_hitIdxs);
 #ifdef CUT_VALUE_DEBUG
     ana.tx->setBranch<vector<vector<float>>>("pT3_matched_pt", pT3_simpt);
     ana.tx->setBranch<vector<float>>("pT3_pixelRadius", pT3_pixelRadius);

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -115,6 +115,7 @@ void createLowerLevelOutputBranches()
 
     ana.tx->createBranch<vector<float>>("t5_score_rphi");
     ana.tx->createBranch<vector<float>>("t5_score_rz");
+    ana.tx->createBranch<vector<float>>("t5_score_rzlsq");
     ana.tx->createBranch<vector<float>>("t5_score_rphiz");
     ana.tx->createBranch<vector<vector<int>>>("t5_hitIdxs");
     ana.tx->createBranch<vector<vector<int>>>("t5_matched_simIdx");
@@ -1468,6 +1469,7 @@ void fillQuintupletOutputBranches(SDL::Event& event)
     std::vector<float> t5_phi_2;
     std::vector<float> t5_score_rphi;
     std::vector<float> t5_score_rz;
+    std::vector<float> t5_score_rzlsq;
     std::vector<float> t5_score_rphiz;
     std::vector<vector<int>> t5_hitIdxs;
     std::vector<int> t5_foundDuplicate;
@@ -1520,9 +1522,11 @@ void fillQuintupletOutputBranches(SDL::Event& event)
             unsigned int innerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex];
             unsigned int outerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex + 1];
 
+            if(quintupletsInGPU.isDup[quintupletIndex]==1){continue;}
             t5_foundDuplicate.emplace_back(quintupletsInGPU.isDup[quintupletIndex]);
             t5_score_rphi.emplace_back(quintupletsInGPU.score_rphi[quintupletIndex]);
             t5_score_rz.emplace_back(quintupletsInGPU.score_rz[quintupletIndex]);
+            t5_score_rzlsq.emplace_back(quintupletsInGPU.score_rzlsq[quintupletIndex]);
             t5_score_rphiz.emplace_back(quintupletsInGPU.score_rphiz[quintupletIndex]);
             t5_eta_2.emplace_back(quintupletsInGPU.eta[quintupletIndex]);
             t5_phi_2.emplace_back(quintupletsInGPU.phi[quintupletIndex]);
@@ -1730,6 +1734,7 @@ void fillQuintupletOutputBranches(SDL::Event& event)
     ana.tx->setBranch<vector<vector<int>>>("t5_hitIdxs", t5_hitIdxs);
     ana.tx->setBranch<vector<float>>("t5_score_rphi", t5_score_rphi);
     ana.tx->setBranch<vector<float>>("t5_score_rz", t5_score_rz);
+    ana.tx->setBranch<vector<float>>("t5_score_rzlsq", t5_score_rzlsq);
     ana.tx->setBranch<vector<float>>("t5_score_rphiz", t5_score_rphiz);
 #ifdef CUT_VALUE_DEBUG
     ana.tx->setBranch<vector<vector<float>>>("t5_matched_pt",t5_simpt);
@@ -1799,10 +1804,10 @@ void fillPixelTripletOutputBranches(SDL::Event& event)
         unsigned int pixelSegmentIndex = pixelTripletsInGPU.pixelSegmentIndices[jdx];
         unsigned int tripletIndex = pixelTripletsInGPU.tripletIndices[jdx];
 
-        pT3_eta_2.emplace_back(pixelTripletsInGPU.eta[jdx];
-        pT3_phi_2.emplace_back(pixelTripletsInGPU.phi[jdx];
-        pT3_score.emplace_back(pixelTripletsInGPU.score[jdx];
-        pT3_foundDuplicate.emplace_back(pixelTripletsInGPU.isDup[jdx];
+        pT3_eta_2.emplace_back(pixelTripletsInGPU.eta[jdx]);
+        pT3_phi_2.emplace_back(pixelTripletsInGPU.phi[jdx]);
+        pT3_score.emplace_back(pixelTripletsInGPU.score[jdx]);
+        pT3_foundDuplicate.emplace_back(pixelTripletsInGPU.isDup[jdx]);
         
         unsigned int pixelInnerMDIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex];
         unsigned int pixelOuterMDIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex + 1];

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -853,10 +853,10 @@ void fillTrackCandidateOutputBranches_v1(SDL::Event& event)
                 //outerTrackletIndex = T5
                 innerTrackletInnerSegmentIndex = pixelTripletsInGPU.pixelSegmentIndices[innerTrackletIdx];
                 innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * pixelTripletsInGPU.tripletIndices[innerTrackletIdx]];
-                outerTrackletInnerSegmentIndex = tripletsInGPU.segmentIndices[2 * pixelTripletsInGPU.tripletIndices[innerTrackletIndex] + 1];
+                outerTrackletInnerSegmentIndex = tripletsInGPU.segmentIndices[2 * pixelTripletsInGPU.tripletIndices[innerTrackletIdx] + 1];
 
-                outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIndex + 1]];
-                outermostSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIndex + 1] + 1];
+                outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]];
+                outermostSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1] + 1];
 
                 //betaIn only has the beta values of the T5s. Use the TC type = 7 criterion to then get the pixel pT value to add together with these later!!!!!!
                 betaIn_in = tripletsInGPU.betaIn[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]];
@@ -934,7 +934,7 @@ void fillTrackCandidateOutputBranches_v1(SDL::Event& event)
             if(trackCandidateType == 7)
             {
                outermostSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outermostSegmentIndex];
-                outermostSegmentOuterMiniDoubletIndex; = segmentsInGPU.mdIndices[2 * outermostSegmentIndex + 1];
+               outermostSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outermostSegmentIndex + 1];
 
 
             }
@@ -952,13 +952,13 @@ void fillTrackCandidateOutputBranches_v1(SDL::Event& event)
             unsigned int outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.hitIndices[2 * outerTrackletOuterSegmentOuterMiniDoubletIndex];
             unsigned int outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.hitIndices[2 * outerTrackletOuterSegmentOuterMiniDoubletIndex + 1];
 
-            unsigned int outermostOuterMiniDoubletLowerHitIndex;
-            unsigned int outermostOuterMiniDoubletUpperHitIndex;
+            unsigned int outermostSegmentOuterMiniDoubletLowerHitIndex;
+            unsigned int outermostSegmentOuterMiniDoubletUpperHitIndex;
 
             if(trackCandidateType == 7)
             {
-                outermostOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.hitIndices[2 * outermostOuterMiniDoubletIndex];
-                outermostOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.hitIndices[2 * outermostOuterMiniDoubletIndex + 1];
+                outermostSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.hitIndices[2 * outermostSegmentOuterMiniDoubletIndex];
+                outermostSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.hitIndices[2 * outermostSegmentOuterMiniDoubletIndex + 1];
             }
 
             std::vector<int> hit_idx = {
@@ -978,8 +978,8 @@ void fillTrackCandidateOutputBranches_v1(SDL::Event& event)
 
             if(trackCandidateType == 7)
             {
-                hit_idxs.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletLowerHitIndex]);
-                hit_idxs.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletUpperHitIndex]);
+                hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletLowerHitIndex]);
+                hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletUpperHitIndex]);
             }
 
             unsigned int iiia_idx = -1;
@@ -1067,8 +1067,8 @@ void fillTrackCandidateOutputBranches_v1(SDL::Event& event)
                 (int) hitsInGPU.moduleIndices[outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex],
             };
 
-            module_idxs.push_back((int) hitsInGPU.moduleIndices[outermostOuterMiniDoubletLowerHitIndex]);
-            moduls_idxs.push_back((int) hitsInGPU.moduleIndices[outermostOuterMiniDoubletUpperHitIndex]);
+            module_idxs.push_back((int) hitsInGPU.moduleIndices[outermostSegmentOuterMiniDoubletLowerHitIndex]);
+            module_idxs.push_back((int) hitsInGPU.moduleIndices[outermostSegmentOuterMiniDoubletUpperHitIndex]);
 
             bool isPixel0 = (idx == *(modulesInGPU.nLowerModules));
             // bool isPixel1 = (idx == *(modulesInGPU.nLowerModules));

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -116,7 +116,7 @@ void createLowerLevelOutputBranches()
     ana.tx->createBranch<vector<float>>("t5_score_rphi");
     ana.tx->createBranch<vector<float>>("t5_score_rz");
     ana.tx->createBranch<vector<float>>("t5_score_rzlsq");
-    ana.tx->createBranch<vector<float>>("t5_score_rphiz");
+    ana.tx->createBranch<vector<float>>("t5_score_rphisum");
     ana.tx->createBranch<vector<vector<int>>>("t5_hitIdxs");
     ana.tx->createBranch<vector<vector<int>>>("t5_matched_simIdx");
 
@@ -1558,7 +1558,7 @@ void fillQuintupletOutputBranches(SDL::Event& event)
     std::vector<float> t5_score_rphi;
     std::vector<float> t5_score_rz;
     std::vector<float> t5_score_rzlsq;
-    std::vector<float> t5_score_rphiz;
+    std::vector<float> t5_score_rphisum;
     std::vector<vector<int>> t5_hitIdxs;
     std::vector<int> t5_foundDuplicate;
 
@@ -1615,7 +1615,7 @@ void fillQuintupletOutputBranches(SDL::Event& event)
             t5_score_rphi.emplace_back(quintupletsInGPU.score_rphi[quintupletIndex]);
             t5_score_rz.emplace_back(quintupletsInGPU.score_rz[quintupletIndex]);
             t5_score_rzlsq.emplace_back(quintupletsInGPU.score_rzlsq[quintupletIndex]);
-            t5_score_rphiz.emplace_back(quintupletsInGPU.score_rphiz[quintupletIndex]);
+            t5_score_rphisum.emplace_back(quintupletsInGPU.score_rphisum[quintupletIndex]);
             t5_eta_2.emplace_back(quintupletsInGPU.eta[quintupletIndex]);
             t5_phi_2.emplace_back(quintupletsInGPU.phi[quintupletIndex]);
 
@@ -1823,7 +1823,7 @@ void fillQuintupletOutputBranches(SDL::Event& event)
     ana.tx->setBranch<vector<float>>("t5_score_rphi", t5_score_rphi);
     ana.tx->setBranch<vector<float>>("t5_score_rz", t5_score_rz);
     ana.tx->setBranch<vector<float>>("t5_score_rzlsq", t5_score_rzlsq);
-    ana.tx->setBranch<vector<float>>("t5_score_rphiz", t5_score_rphiz);
+    ana.tx->setBranch<vector<float>>("t5_score_rphisum", t5_score_rphisum);
 #ifdef CUT_VALUE_DEBUG
     ana.tx->setBranch<vector<vector<float>>>("t5_matched_pt",t5_simpt);
 

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -133,5 +133,5 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_newgr
 fi
 
 echo "Total Timing Summary"
-echo "Evt     Hits         MD       LS      T4      T4x       pT4        T3       TC       T5       pT3      Total"
+echo "Evt     Hits         MD       LS      T4      T4x       pT4       T3       TC       T5      pT3     pT5     Total"
 grep -hr "avg " timing_temp.txt # space is needed to not get certain bad lines 

--- a/efficiency/python/plot_compare_arbitrary.py
+++ b/efficiency/python/plot_compare_arbitrary.py
@@ -39,7 +39,7 @@ def parse_plot_name(output_name):
         rtnstr.append("Quadruplet w/ gap")
     elif "pT3_" in output_name:
         rtnstr.append("Pixel Triplet")
-    elif "pT3_" in output_name:
+    elif "pT5_" in output_name:
         rtnstr.append("Pixel Quintuplet")
     elif "T3_" in output_name:
         rtnstr.append("Triplet")


### PR DESCRIPTION
Fixes errors from pT5 
adds T5 duplicate removal
only keeps T5s from first 2 layers. 

Validation plots (T5 only in final state) https://www.classe.cornell.edu/~mgr85/www/SegmentLinking_keep/PR70/
For PU200 first event: T5 multiplicity 4337 -> 706
For muonGun first event: T5 multiplicity 108-> 33
It pretty consistently takes 10 extra ms for the duplicate removal but cuts the current pT5 creation time in half. 