### PR TITLE
preliminary pT3 duplicate cleaning

### DIFF
--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -186,7 +186,7 @@ namespace SDL
 }
 __device__ float scorepT3(struct SDL::modules& modulesInGPU,struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, unsigned int innerPix,unsigned int outerTrip,float pt, float pz);
 __global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::triplets& tripletsInGPU);
-__device__ int checkHitspT3(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU);
+__device__ int* checkHitspT3(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU);
 
 
 __device__ void scoreT5(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,unsigned int innerTrip,unsigned int outerTrip, int layer, float* scores);

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -22,8 +22,8 @@ CXXFLAGS             =  -g --compiler-options -Wall --compiler-options -Wshadow 
 LD                   = nvcc 
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
-FINALSTATE           = -DFINAL_T5 #-DFINAL_pT3 #-DFINAL_T3T4 
-DUPLICATES           = -DDUP_T5
+FINALSTATE           = -DFINAL_pT3 -DFINAL_T5
+DUPLICATES           = -DDUP_T5 -DDUP_pT3
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = -DNESTED_PARA 

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -1894,6 +1894,7 @@ void fillPixelTripletOutputBranches(SDL::Event& event)
         unsigned int pixelSegmentIndex = pixelTripletsInGPU.pixelSegmentIndices[jdx];
         unsigned int tripletIndex = pixelTripletsInGPU.tripletIndices[jdx];
 
+        if(pixelTripletsInGPU.isDup[jdx]==1){continue;}
         pT3_eta_2.emplace_back(pixelTripletsInGPU.eta[jdx]);
         pT3_phi_2.emplace_back(pixelTripletsInGPU.phi[jdx]);
         pT3_score.emplace_back(pixelTripletsInGPU.score[jdx]);


### PR DESCRIPTION
This is not the final pT3 duplicate removal. It is intended to help with understanding the effect on pT5 creation when pT3s are cleaned.
pT3 multiplicity: 24028 - > 7220
track candidate final state in validation plots: T5 + pT3
Validation plots: https://www.classe.cornell.edu/~mgr85/www/SegmentLinking_keep/PR71/
Requirements: 4 matched pixel hits and 4+ matched triplet hits. No eta, phi requirement. Save smaller r-phi track score only. 