### PR TITLE
Inclusion of pLS, pT5 and pT3 cross cleaning and duplicate removal

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1949,7 +1949,7 @@ void SDL::Event::createPixelQuintuplets()
 #endif  
     
 #ifdef DUP_pLS
-    checkHitspLS<<<64,1024>>>(*modulesInGPU,*mdsInGPU, *segmentsInGPU);
+    checkHitspLS<<<64,1024>>>(*modulesInGPU,*mdsInGPU, *segmentsInGPU, *hitsInGPU);
     cudaError_t cudaerrpix = cudaDeviceSynchronize();
     if(cudaerrpix != cudaSuccess)
     {
@@ -5477,11 +5477,14 @@ __global__ void removeDupQuintupletsInGPU(struct SDL::modules& modulesInGPU, str
           if(nMatched >=7){
             dup_count++;
             if(secondPass){
-              if( quintupletsInGPU.score_rphisum[ix] - quintupletsInGPU.score_rphisum[jx] > 0){
+              if( quintupletsInGPU.score_rphisum[ix] > quintupletsInGPU.score_rphisum[jx] ){
                 rmQuintupletToMemory(quintupletsInGPU,ix);continue; // keept shorted track
               }
             }
-              if( quintupletsInGPU.score_rphisum[ix] - quintupletsInGPU.score_rphisum[jx] > 0){
+              if( quintupletsInGPU.score_rphisum[ix] > quintupletsInGPU.score_rphisum[jx] ){
+              rmQuintupletToMemory(quintupletsInGPU,ix);continue; // keept shorted track
+            }
+              if( (quintupletsInGPU.score_rphisum[ix] == quintupletsInGPU.score_rphisum[jx]) && (ix<jx)){
               rmQuintupletToMemory(quintupletsInGPU,ix);continue; // keept shorted track
             }
           }
@@ -5532,18 +5535,18 @@ __device__ float scorepT3(struct SDL::modules& modulesInGPU,struct SDL::hits& hi
         //printf("pT3 score: %f\n",score);
         return score;
 }
-__device__ inline int* checkHitspT3(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU){
-        int phits1[6] = {-1,-1,-1,-1};
-        int phits2[6] = {-1,-1,-1,-1};
-          phits1[0] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[ix]]];
-          phits1[1] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[ix]+1]];
-          phits1[2] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[ix]]+1];
-          phits1[3] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[ix]+1]+1];
+__device__ inline int checkHitspT5(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::hits& hitsInGPU){
+        int phits1[4] = {-1,-1,-1,-1};
+        int phits2[4] = {-1,-1,-1,-1};
+          phits1[0] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*ix]]];
+          phits1[1] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*ix+1]]];
+          phits1[2] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*ix]+1]];
+          phits1[3] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*ix+1]+1]];
 
-          phits2[0] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[jx]]];
-          phits2[1] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[jx]+1]];
-          phits2[2] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[jx]]+1];
-          phits2[3] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[jx]+1]+1];
+          phits2[0] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*jx]]];
+          phits2[1] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*jx+1]]];
+          phits2[2] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*jx]+1]];
+          phits2[3] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*jx+1]+1]];
 
         int npMatched =0;
         for (int i =0; i<4;i++){
@@ -5551,6 +5554,29 @@ __device__ inline int* checkHitspT3(unsigned int ix, unsigned int jx,struct SDL:
           if(phits1[i] == -1){continue;}
           for (int j =0; j<4; j++){
             if(phits2[j] == -1){continue;}
+            if(phits1[i] == phits2[j]){pmatched = true; break;}
+          }
+          if(pmatched){npMatched++;}
+        }
+        return npMatched;
+}
+__device__ inline int* checkHitspT3(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU,struct SDL::hits& hitsInGPU){
+        int phits1[4] = {-1,-1,-1,-1};
+        int phits2[4] = {-1,-1,-1,-1};
+          phits1[0] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[ix]]]];
+          phits1[1] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[ix]+1]]];
+          phits1[2] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[ix]]+1]];
+          phits1[3] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[ix]+1]+1]];
+
+          phits2[0] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[jx]]]];
+          phits2[1] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[jx]+1]]];
+          phits2[2] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[jx]]+1]];
+          phits2[3] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*pixelTripletsInGPU.pixelSegmentIndices[jx]+1]+1]];
+
+        int npMatched =0;
+        for (int i =0; i<4;i++){
+          bool pmatched = false;
+          for (int j =0; j<4; j++){
             if(phits1[i] == phits2[j]){pmatched = true; break;}
           }
           if(pmatched){npMatched++;}
@@ -5574,9 +5600,7 @@ __device__ inline int* checkHitspT3(unsigned int ix, unsigned int jx,struct SDL:
         int nMatched =0;
         for (int i =0; i<6;i++){
           bool matched = false;
-          if(hits1[i] == -1){continue;}
           for (int j =0; j<6; j++){
-            if(hits2[j] == -1){continue;}
             if(hits1[i] == hits2[j]){matched = true; break;}
           }
           if(matched){nMatched++;}
@@ -5603,7 +5627,7 @@ __global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::modules& modulesI
       float phi1     = pixelTripletsInGPU.phi[ix];
       //float pt1     = pixelTripletsInGPU.pt[ix];
       //for (unsigned int jx=ix+1; jx<*pixelTripletsInGPU.nPixelTriplets-1; jx++){
-      for (unsigned int jx=0; jx<*pixelTripletsInGPU.nPixelTriplets-1; jx++){
+      for (unsigned int jx=0; jx<*pixelTripletsInGPU.nPixelTriplets; jx++){
        // if(pixelTripletsInGPU.isDup[jx]){continue;}
         //float pt2 = pixelTripletsInGPU.pt[jx];
         //if(abs(1./pt1 - 1./pt2) > 0.5){continue;}
@@ -5627,7 +5651,7 @@ __global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::modules& modulesI
         //if (dEta > 0.005){continue;}
         //if (dPhi > 0.005){continue;}
         float dR2 = dEta*dEta + dPhi*dPhi;
-        int* nMatched = checkHitspT3(ix,jx,mdsInGPU,segmentsInGPU,tripletsInGPU,pixelTripletsInGPU); 
+        int* nMatched = checkHitspT3(ix,jx,mdsInGPU,segmentsInGPU,tripletsInGPU,pixelTripletsInGPU,hitsInGPU); 
         //if(nMatched ==5){
         //  dup_count++;
         //  if( pixelTripletsInGPU.score[ix] - pixelTripletsInGPU.score[jx] > 2){
@@ -5659,14 +5683,23 @@ __global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::modules& modulesI
         //}
         unsigned int pLS_ix = pixelTripletsInGPU.pixelSegmentIndices[ix];
         unsigned int pLS_jx = pixelTripletsInGPU.pixelSegmentIndices[jx];
-        if((nMatched[1] >= 4) || (pLS_ix == pLS_jx))
+        //if(nMatched[0] >=1){
+        //printf("%d\n",nMatched[0]);
+        //}
+        //if((nMatched[1] >= 4) || (pLS_ix == pLS_jx))
+        if((nMatched[0] + nMatched[1]) >= 7)
         {
           dup_count++;
           //if( pixelTripletsInGPU.score[ix] - pixelTripletsInGPU.score[jx] > .2){
-          if( pixelTripletsInGPU.score[ix] - pixelTripletsInGPU.score[jx] > 0)
+          if( pixelTripletsInGPU.score[ix] > pixelTripletsInGPU.score[jx])
           {
                 rmPixelTripletToMemory(pixelTripletsInGPU,ix);
-                break; // keept shorted track
+                break;
+          }
+          if( (pixelTripletsInGPU.score[ix] == pixelTripletsInGPU.score[jx]) && (ix<jx))
+          {
+                rmPixelTripletToMemory(pixelTripletsInGPU,ix);
+                break;
           }
         }
         //if(nMatched ==8){
@@ -5753,16 +5786,33 @@ __global__ void removeDupPixelQuintupletsInGPUFromMap(struct SDL::modules& modul
         unsigned int pLS_ix = pixelQuintupletsInGPU.pixelIndices[ix];
         unsigned int pLS_jx = pixelQuintupletsInGPU.pixelIndices[jx];
         int nMatched = checkHitsT5(T5_ix,T5_jx,mdsInGPU,segmentsInGPU,tripletsInGPU,quintupletsInGPU);
-        if(nMatched >= 7 || (pLS_ix==pLS_jx))
+        int npMatched = checkHitspT5(pLS_ix,pLS_jx,mdsInGPU,segmentsInGPU,hitsInGPU);
+        //if(T5_ix==T5_jx || (pLS_ix==pLS_jx))
+        //{
+        //  dup_count++;
+        //  //if( pixelTripletsInGPU.score[ix] - pixelTripletsInGPU.score[jx] > .2){
+        //  if( pixelQuintupletsInGPU.score[ix] > pixelQuintupletsInGPU.score[jx] )
+        //  {
+        //        rmPixelQuintupletToMemory(pixelQuintupletsInGPU,ix);
+        //        break; // keept shorted track
+        //  }
+        //  if( (pixelQuintupletsInGPU.score[ix] == pixelQuintupletsInGPU.score[jx]) && (ix<jx))
+        //  {
+        //        rmPixelQuintupletToMemory(pixelQuintupletsInGPU,ix);
+        //        break; // keept shorted track
+        //  }
+        //}
+        if((nMatched + npMatched) >=10)
+        //if(nMatched >= 7 || (npMatched>=3))
         {
           dup_count++;
           //if( pixelTripletsInGPU.score[ix] - pixelTripletsInGPU.score[jx] > .2){
-          if( pixelQuintupletsInGPU.score[ix] - pixelQuintupletsInGPU.score[jx] > 0)
+          if( pixelQuintupletsInGPU.score[ix] > pixelQuintupletsInGPU.score[jx])
           {
                 rmPixelQuintupletToMemory(pixelQuintupletsInGPU,ix);
                 break; // keept shorted track
           }
-          if( (pixelQuintupletsInGPU.score[ix] = pixelQuintupletsInGPU.score[jx]) && (ix>jx))
+          if( (pixelQuintupletsInGPU.score[ix] == pixelQuintupletsInGPU.score[jx]) && (ix>jx))
           {
                 rmPixelQuintupletToMemory(pixelQuintupletsInGPU,ix);
                 break; // keept shorted track
@@ -5797,7 +5847,7 @@ __global__ void removeDupPixelQuintupletsInGPUFromMap(struct SDL::modules& modul
       }
     }
 }
-__global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU){
+__global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::hits& hitsInGPU){
      int counter=0;
      int pixelModuleIndex = *modulesInGPU.nModules - 1;
      unsigned int prefix = pixelModuleIndex*N_MAX_SEGMENTS_PER_MODULE;
@@ -5806,10 +5856,10 @@ __global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniD
      for(int ix=blockIdx.x*blockDim.x+threadIdx.x;ix<nPixelSegments;ix+=blockDim.x*gridDim.x){
        bool found=false;
        unsigned int phits1[4] ;
-       phits1[0] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+ix)]];
-       phits1[1] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+ix)+1]];
-       phits1[2] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+ix)]+1];
-       phits1[3] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+ix)+1]+1];
+       phits1[0] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+ix)]]];
+       phits1[1] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+ix)+1]]];
+       phits1[2] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+ix)]+1]];
+       phits1[3] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+ix)+1]+1]];
        float eta_pix1 = segmentsInGPU.eta[ix];
        float phi_pix1 = segmentsInGPU.phi[ix];
        float pt1 = segmentsInGPU.ptIn[ix];
@@ -5817,12 +5867,12 @@ __global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniD
          if(ix==jx){continue;}
          unsigned int phits2[4] ;
          float ptErr_diff = segmentsInGPU.ptErr[ix] - segmentsInGPU.ptErr[jx];
-         if (ptErr_diff>0){continue;}
+         if (ptErr_diff>0){continue;}// allows for exact matches to be checked
 
-         phits2[0] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+jx)]];
-         phits2[1] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+jx)+1]];
-         phits2[2] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+jx)]+1];
-         phits2[3] = mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+jx)+1]+1];
+         phits2[0] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+jx)]]];
+         phits2[1] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+jx)+1]]];
+         phits2[2] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+jx)]+1]];
+         phits2[3] = hitsInGPU.idxs[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*(prefix+jx)+1]+1]];
          float eta_pix2 = segmentsInGPU.eta[jx];
          float phi_pix2 = segmentsInGPU.phi[jx];
          float pt2 = segmentsInGPU.ptIn[jx];
@@ -5836,8 +5886,13 @@ __global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniD
            }
            if(pmatched){npMatched++;}
          }
-         if(npMatched >=1){
-           printf("pLS npMatched: %d\n",npMatched);
+         if((npMatched ==4) && (ix < jx)){ // if exact match, remove only 1
+           //printf("pLS npMatched: %d\n",npMatched);
+           found=true;break;
+         }
+         if(npMatched ==3){
+           //printf("pLS npMatched: %d\n",npMatched);
+           found=true;break;
          }
          float dEta = abs(eta_pix1-eta_pix2);
          float dPhi = abs(phi_pix1-phi_pix2);
@@ -5845,10 +5900,10 @@ __global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniD
          if(dPhi > M_PI){dPhi = dPhi - 2*M_PI;}
          //if (abs(dPhi) > 0.1){continue;}
          float dR2 = dEta*dEta + dPhi*dPhi;
-         if(dR2 < 0.0001){
-           //printf("dR: %.2f\n",dR2);
-           found=true;break;
-         }
+         //if(dR2 < 0.0001){
+         //  //printf("dR: %.2f\n",dR2);
+         //  found=true;break;
+         //}
        }
        if(found){counter++;rmPixelSegmentFromMemory(segmentsInGPU,ix);continue;}
      }

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -4509,15 +4509,15 @@ __global__ void createPixelQuintupletsInGPUFromMap(struct SDL::modules& modulesI
            addPixelQuintupletToMemory(pixelQuintupletsInGPU, pixelSegmentIndex, quintupletIndex, pixelQuintupletIndex,rzChiSquared, rPhiChiSquared, rPhiChiSquaredInwards);
 
 #else
-           addPixelQuintupletToMemory(pixelQuintupletsInGPU, pixelSegmentIndex, quintupletIndex, pixelQuintupletIndex);
+           addPixelQuintupletToMemory(pixelQuintupletsInGPU, pixelSegmentIndex, quintupletIndex, pixelQuintupletIndex,rPhiChiSquared);
 #endif
-           //mark the relevant T5 and pT3 here!
-           quintupletsInGPU.partOfPT5[quintupletIndex] = true;
-           unsigned int innerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex];
-           unsigned int outerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex + 1];
-           tripletsInGPU.partOfPT5[innerTripletIndex] = true;
-           tripletsInGPU.partOfPT5[outerTripletIndex] = true;
-           segmentsInGPU.partOfPT5[pixelSegmentArrayIndex] = true;
+//           //mark the relevant T5 and pT3 here!
+//           quintupletsInGPU.partOfPT5[quintupletIndex] = true;
+//           unsigned int innerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex];
+//           unsigned int outerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex + 1];
+//           tripletsInGPU.partOfPT5[innerTripletIndex] = true;
+//           tripletsInGPU.partOfPT5[outerTripletIndex] = true;
+//           segmentsInGPU.partOfPT5[pixelSegmentArrayIndex] = true;
        }
 
     }
@@ -4956,6 +4956,7 @@ SDL::segments* SDL::Event::getSegments()
         segmentsInCPU->ptIn = new float[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
         segmentsInCPU->eta = new float[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
         segmentsInCPU->phi = new float[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
+        segmentsInCPU->isDup = new bool[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
         cudaMemcpy(segmentsInCPU->mdIndices, segmentsInGPU->mdIndices, 2 * nMemoryLocations * sizeof(unsigned int), cudaMemcpyDeviceToHost);
         cudaMemcpy(segmentsInCPU->nSegments, segmentsInGPU->nSegments, nModules * sizeof(unsigned int), cudaMemcpyDeviceToHost);
         cudaMemcpy(segmentsInCPU->innerMiniDoubletAnchorHitIndices, segmentsInGPU->innerMiniDoubletAnchorHitIndices, nMemoryLocations * sizeof(unsigned int), cudaMemcpyDeviceToHost);
@@ -4963,6 +4964,7 @@ SDL::segments* SDL::Event::getSegments()
         cudaMemcpy(segmentsInCPU->ptIn, segmentsInGPU->ptIn, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(float), cudaMemcpyDeviceToHost);
         cudaMemcpy(segmentsInCPU->eta, segmentsInGPU->eta, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(float), cudaMemcpyDeviceToHost);
         cudaMemcpy(segmentsInCPU->phi, segmentsInGPU->phi, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(float), cudaMemcpyDeviceToHost);
+        cudaMemcpy(segmentsInCPU->isDup, segmentsInGPU->isDup, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(bool), cudaMemcpyDeviceToHost);
 
 
     }
@@ -5161,9 +5163,11 @@ SDL::pixelQuintuplets* SDL::Event::getPixelQuintuplets()
 
         pixelQuintupletsInCPU->pixelIndices = new unsigned int[nPixelQuintuplets];
         pixelQuintupletsInCPU->T5Indices = new unsigned int[nPixelQuintuplets];
+        pixelQuintupletsInCPU->isDup = new bool[nPixelQuintuplets];
 
         cudaMemcpy(pixelQuintupletsInCPU->pixelIndices, pixelQuintupletsInGPU->pixelIndices, nPixelQuintuplets * sizeof(unsigned int), cudaMemcpyDeviceToHost);
         cudaMemcpy(pixelQuintupletsInCPU->T5Indices, pixelQuintupletsInGPU->T5Indices, nPixelQuintuplets * sizeof(unsigned int), cudaMemcpyDeviceToHost);
+        cudaMemcpy(pixelQuintupletsInCPU->isDup, pixelQuintupletsInGPU->isDup, nPixelQuintuplets * sizeof(bool), cudaMemcpyDeviceToHost);
     }
     return pixelQuintupletsInCPU;
 }

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -190,7 +190,7 @@ __device__ int* checkHitspT3(unsigned int ix, unsigned int jx,struct SDL::miniDo
 __global__ void removeDupPixelQuintupletsInGPUFromMap(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::quintuplets& quintupletsInGPU);
 __global__ void markUsedObjects(struct SDL::modules& modulesInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::quintuplets& quintupletsInGPU);
 
-__global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU);
+__global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::hits& hitsInGPU);
 
 
 __device__ void scoreT5(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,unsigned int innerTrip,unsigned int outerTrip, int layer, float* scores);

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -190,6 +190,8 @@ __device__ int* checkHitspT3(unsigned int ix, unsigned int jx,struct SDL::miniDo
 __global__ void removeDupPixelQuintupletsInGPUFromMap(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::quintuplets& quintupletsInGPU);
 __global__ void markUsedObjects(struct SDL::modules& modulesInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::quintuplets& quintupletsInGPU);
 
+__global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU);
+
 
 __device__ void scoreT5(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,unsigned int innerTrip,unsigned int outerTrip, int layer, float* scores);
 __global__ void removeDupQuintupletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU, bool secondPass);
@@ -204,7 +206,7 @@ __global__ void createSegmentsInGPU(struct SDL::modules& modulesInGPU, struct SD
 
 __global__ void addpT2asTrackCandidateInGPU(struct SDL::modules& modulesInGPU,struct SDL::pixelTracklets& pixelTrackletsInGPU,struct SDL::trackCandidates& trackCandidatesInGPU);
 
-__global__ void addpT3asTrackCandidateInGPU(struct SDL::modules& modulesInGPU,struct SDL::pixelTriplets& pixelTripletsInGPU,struct SDL::trackCandidates& trackCandidatesInGPU);
+__global__ void addpT3asTrackCandidateInGPU(struct SDL::modules& modulesInGPU,struct SDL::pixelTriplets& pixelTripletsInGPU,struct SDL::trackCandidates& trackCandidatesInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU);
 
 __global__ void addT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU,struct SDL::quintuplets& quintupletsInGPU,struct SDL::trackCandidates& trackCandidatesInGPU);
 

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -187,6 +187,8 @@ namespace SDL
 __device__ float scorepT3(struct SDL::modules& modulesInGPU,struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, unsigned int innerPix,unsigned int outerTrip,float pt, float pz);
 __global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::triplets& tripletsInGPU);
 __device__ int* checkHitspT3(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU);
+__global__ void removeDupPixelQuintupletsInGPUFromMap(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::quintuplets& quintupletsInGPU);
+__global__ void markUsedObjects(struct SDL::modules& modulesInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::quintuplets& quintupletsInGPU);
 
 
 __device__ void scoreT5(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,unsigned int innerTrip,unsigned int outerTrip, int layer, float* scores);

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -23,7 +23,7 @@ LD                   = nvcc
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
 FINALSTATE           = -DFINAL_pT3 -DFINAL_T5 -DFINAL_pT5
-DUPLICATES           = -DDUP_T5 -DDUP_pT3
+DUPLICATES           = -DDUP_T5 -DDUP_pT3 #-DDUP_pT5
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = -DNESTED_PARA 

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -23,7 +23,7 @@ LD                   = nvcc
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
 FINALSTATE           = -DFINAL_pT3 -DFINAL_T5 -DFINAL_pT5
-DUPLICATES           = -DDUP_T5 -DDUP_pT5 -DDUP_pT3 -DDUP_pLS
+DUPLICATES           = -DDUP_pLS -DDUP_T5 -DDUP_pT5 -DDUP_pT3
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = -DNESTED_PARA 

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -23,7 +23,7 @@ LD                   = nvcc
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
 FINALSTATE           = -DFINAL_pT3 -DFINAL_T5 -DFINAL_pT5
-DUPLICATES           = -DDUP_T5 -DDUP_pT3 #-DDUP_pT5
+DUPLICATES           = -DDUP_T5 -DDUP_pT5 -DDUP_pT3 -DDUP_pLS
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = -DNESTED_PARA 

--- a/SDL/PixelQuintuplet.cuh
+++ b/SDL/PixelQuintuplet.cuh
@@ -31,6 +31,8 @@ namespace SDL
         unsigned int* pixelIndices;
         unsigned int* T5Indices;
         unsigned int* nPixelQuintuplets;
+        bool* isDup;
+        float* score;
 #ifdef CUT_VALUE_DEBUG
         float* rzChiSquared;
         float* rPhiChiSquared;
@@ -47,11 +49,12 @@ namespace SDL
     void createPixelQuintupletsInUnifiedMemory(struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int maxPixelQuintuplets);
     void createPixelQuintupletsInExplicitMemory(struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int maxPixelQuintuplets);
 
+    CUDA_DEV void rmPixelQuintupletToMemory(struct pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pixelQuintupletIndex);
 #ifdef CUT_VALUE_DEBUG
     CUDA_DEV void addPixelQuintupletToMemory(struct pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pixelIndex, unsigned int T5Index, unsigned int pixelQuintupletIndex, float& rzChiSquared, float& rPhiChiSquared, float& rPhiChiSquaredInwards);
 
 #else
-    CUDA_DEV void addPixelQuintupletToMemory(struct pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pixelIndex, unsigned int T5Index, unsigned int pixelQuintupletIndex);
+    CUDA_DEV void addPixelQuintupletToMemory(struct pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pixelIndex, unsigned int T5Index, unsigned int pixelQuintupletIndex, float score);
 #endif
 
     CUDA_DEV bool runPixelQuintupletDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, struct triplets& tripletsInGPU, struct quintuplets& quintupletsInGPU, unsigned int& pixelSegmentIndex, unsigned int& quintupletIndex, float& rzChiSquared, float& rPhiChiSquared, float& rPhiChiSquaredInwards);

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -17,6 +17,7 @@ void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned
     segmentsInGPU.dPhis = (float*)cms::cuda::allocate_managed((nMemoryLocations*6 + maxPixelSegments * 8) *sizeof(float),stream);
     segmentsInGPU.superbin = (int*)cms::cuda::allocate_managed((maxPixelSegments) *sizeof(int),stream);
     segmentsInGPU.pixelType = (int*)cms::cuda::allocate_managed((maxPixelSegments) *sizeof(int),stream);
+    segmentsInGPU.isDup = (bool*)cms::cuda::allocate_managed((maxPixelSegments) *sizeof(bool),stream);
     segmentsInGPU.circleCenterX = (float*)cms::cuda::allocate_managed((maxPixelSegments) * sizeof(float), stream);
     segmentsInGPU.circleCenterY = (float*)cms::cuda::allocate_managed((maxPixelSegments) * sizeof(float), stream);
     segmentsInGPU.circleRadius = (float*)cms::cuda::allocate_managed((maxPixelSegments) * sizeof(float), stream);
@@ -27,6 +28,7 @@ void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned
     cudaMallocManaged(&segmentsInGPU.dPhis, (nMemoryLocations * 6 + maxPixelSegments * 8)*sizeof(float));
     cudaMallocManaged(&segmentsInGPU.superbin, (maxPixelSegments )*sizeof(int));
     cudaMallocManaged(&segmentsInGPU.pixelType, (maxPixelSegments )*sizeof(int));
+    cudaMallocManaged(&segmentsInGPU.isDup, (maxPixelSegments )*sizeof(bool));
     cudaMallocManaged(&segmentsInGPU.circleCenterX, maxPixelSegments * sizeof(float));
     cudaMallocManaged(&segmentsInGPU.circleCenterY, maxPixelSegments * sizeof(float));
     cudaMallocManaged(&segmentsInGPU.circleRadius, maxPixelSegments * sizeof(float));
@@ -94,6 +96,7 @@ void SDL::createSegmentsInExplicitMemory(struct segments& segmentsInGPU, unsigne
     segmentsInGPU.dPhis = (float*)cms::cuda::allocate_device(dev,(nMemoryLocations*6 + maxPixelSegments * 8) *sizeof(float),stream);
     segmentsInGPU.superbin = (int*)cms::cuda::allocate_device(dev,(maxPixelSegments) *sizeof(int),stream);
     segmentsInGPU.pixelType = (int*)cms::cuda::allocate_device(dev,(maxPixelSegments) *sizeof(int),stream);
+    segmentsInGPU.isDup = (bool*)cms::cuda::allocate_device(dev,(maxPixelSegments) *sizeof(bool),stream);
     segmentsInGPU.circleCenterX = (float*)cms::cuda::allocate_device(dev, maxPixelSegments * sizeof(float), stream);
     segmentsInGPU.circleCenterY = (float*)cms::cuda::allocate_device(dev, maxPixelSegments * sizeof(float), stream);
     segmentsInGPU.circleRadius = (float*)cms::cuda::allocate_device(dev, maxPixelSegments * sizeof(float), stream);
@@ -105,6 +108,7 @@ void SDL::createSegmentsInExplicitMemory(struct segments& segmentsInGPU, unsigne
     cudaMalloc(&segmentsInGPU.dPhis, (nMemoryLocations * 6 + maxPixelSegments * 8)*sizeof(float));
     cudaMalloc(&segmentsInGPU.superbin, (maxPixelSegments )*sizeof(int));
     cudaMalloc(&segmentsInGPU.pixelType, (maxPixelSegments )*sizeof(int));
+    cudaMalloc(&segmentsInGPU.isDup, (maxPixelSegments )*sizeof(bool));
     cudaMalloc(&segmentsInGPU.circleCenterX, maxPixelSegments * sizeof(float));
     cudaMalloc(&segmentsInGPU.circleCenterY, maxPixelSegments * sizeof(float));
     cudaMalloc(&segmentsInGPU.circleRadius, maxPixelSegments * sizeof(float));
@@ -140,6 +144,7 @@ SDL::segments::segments()
 {
     superbin = nullptr;
     pixelType = nullptr;
+    isDup = nullptr;
     circleRadius = nullptr;
     circleCenterX = nullptr;
     circleCenterY = nullptr;
@@ -192,6 +197,7 @@ void SDL::segments::freeMemoryCache()
     cms::cuda::free_device(dev,nSegments);
     cms::cuda::free_device(dev,superbin);
     cms::cuda::free_device(dev,pixelType);
+    cms::cuda::free_device(dev,isDup);
     cms::cuda::free_device(dev, circleCenterX);
     cms::cuda::free_device(dev, circleCenterY);
     cms::cuda::free_device(dev, circleRadius);
@@ -202,6 +208,7 @@ void SDL::segments::freeMemoryCache()
     cms::cuda::free_managed(nSegments);
     cms::cuda::free_managed(superbin);
     cms::cuda::free_managed(pixelType);
+    cms::cuda::free_managed(isDup);
     cms::cuda::free_managed(circleCenterX);
     cms::cuda::free_managed(circleCenterY);
     cms::cuda::free_managed(circleRadius);
@@ -215,6 +222,7 @@ void SDL::segments::freeMemory()
     cudaFree(dPhis);
     cudaFree(superbin);
     cudaFree(pixelType);
+    cudaFree(isDup);
     cudaFree(circleCenterX);
     cudaFree(circleCenterY);
     cudaFree(circleRadius);
@@ -278,6 +286,9 @@ __device__ void SDL::addSegmentToMemory(struct segments& segmentsInGPU, unsigned
 #endif
 }
 
+__device__ void SDL::rmPixelSegmentFromMemory(struct segments& segmentsInGPU,unsigned int pixelSegmentArrayIndex){
+    segmentsInGPU.isDup[pixelSegmentArrayIndex] = 1;
+}
 __device__ void SDL::addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, unsigned int pixelModuleIndex, unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, float eta, float phi, unsigned int idx, unsigned int pixelSegmentArrayIndex, int superbin, int
         pixelType)
 
@@ -300,6 +311,7 @@ __device__ void SDL::addPixelSegmentToMemory(struct segments& segmentsInGPU, str
 
     segmentsInGPU.superbin[pixelSegmentArrayIndex] = superbin;
     segmentsInGPU.pixelType[pixelSegmentArrayIndex] = pixelType;
+    segmentsInGPU.isDup[pixelSegmentArrayIndex] = 0;
 
     //computing circle parameters
     /*

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -50,6 +50,7 @@ namespace SDL
         float* phi;
         int* superbin;
         int* pixelType;
+        bool* isDup;
         float* circleCenterX;
         float* circleCenterY;
         float* circleRadius;
@@ -91,6 +92,7 @@ namespace SDL
     CUDA_DEV void addSegmentToMemory(struct segments& segmentsInGPU, unsigned int lowerMDIndex, unsigned int upperMDIndex, unsigned int innerLowerModuleIndex, unsigned int outerLowerModuleIndex, unsigned int innerMDAnchorHitIndex, unsigned int outerMDAnchorHitIndex, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, unsigned int idx);
 #endif
 
+    CUDA_DEV void rmPixelSegmentFromMemory(struct segments& segmentsInGPU, unsigned int pixelSegmentArrayIndex);
     CUDA_DEV void addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, unsigned int pixelModuleIndex, unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, float eta, float phi, unsigned int idx, unsigned int pixelSegmentArrayIndex, int superbin, int
             pixelType);
 

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -2361,6 +2361,7 @@ void fillPixelLineSegmentOutputBranches(SDL::Event& event)
     unsigned int nPixelSegments = std::min(segmentsInGPU.nSegments[pixelModuleIndex], N_MAX_PIXEL_SEGMENTS_PER_MODULE);
     for(unsigned int jdx = 0; jdx < nPixelSegments; jdx++)
     {
+        if(segmentsInGPU.isDup[jdx]) {continue;}
         unsigned int pixelSegmentIndex = pixelModuleIndex * N_MAX_SEGMENTS_PER_MODULE + jdx;
         unsigned int innerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex];
         unsigned int outerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex + 1];

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -2123,6 +2123,7 @@ void fillPixelQuintupletOutputBranches(SDL::Event& event)
     for(unsigned int jdx = 0; jdx < nPixelQuintuplets; jdx++)
     {
         //obtain the hits
+        if(pixelQuintupletsInGPU.isDup[jdx]) {continue;};
         unsigned int T5Index = pixelQuintupletsInGPU.T5Indices[jdx];
     
         unsigned int T5InnerTripletIndex = quintupletsInGPU.tripletIndices[2 * T5Index];

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -105,11 +105,11 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified" ]]; t
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
-    run_gpu unified_cache ${SAMPLE} ${NEVENTS} -c
+    #run_gpu unified_cache ${SAMPLE} ${NEVENTS} -c
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache_newgrid" ]]; then
-    run_gpu unified_cache_newgrid ${SAMPLE} ${NEVENTS} -c -g
+    #run_gpu unified_cache_newgrid ${SAMPLE} ${NEVENTS} -c -g
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_newgrid" ]]; then
@@ -121,11 +121,11 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; 
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
-     run_gpu explicit_cache ${SAMPLE} ${NEVENTS} -x -c # Does not run on phi3
+    # run_gpu explicit_cache ${SAMPLE} ${NEVENTS} -x -c # Does not run on phi3
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache_newgrid" ]]; then
-     run_gpu explicit_cache_newgrid ${SAMPLE} ${NEVENTS} -x -c -g # Does not run on phi3
+    # run_gpu explicit_cache_newgrid ${SAMPLE} ${NEVENTS} -x -c -g # Does not run on phi3
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_newgrid" ]]; then

--- a/efficiency/misc/index.html
+++ b/efficiency/misc/index.html
@@ -35,6 +35,12 @@
 &nbsp;&nbsp;&nbsp;&nbsp;<a href="#10">10. Quintuplet (T5) MTV-like Efficiency plots</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;<a href="#11">11. Quintuplet (T5) MTV-like Fake Rate plots</a><br />
 &nbsp;&nbsp;&nbsp;&nbsp;<a href="#12">12. Quintuplet (T5) MTV-like Duplicate Rate plots</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#13">13. Pixel Quintuplet (pT5) MTV-like Efficiency plots</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#14">14. Pixel Quintuplet (pT5) MTV-like Fake Rate plots</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#15">15. Pixel Quintuplet (pT5) MTV-like Duplicate Rate plots</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#16">16. Pixel Line Segment (pLS) MTV-like Efficiency plots</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#17">17. Pixel Line Segment (pLS) MTV-like Fake Rate plots</a><br />
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="#18">18. Pixel Line Segment (pLS) MTV-like Duplicate Rate plots</a><br />
 </p>
 <p><a href="mtv/">Full list of plots can be found here</a></p>
 <h2 data-number="1" id="track-candidate-mtv-like-efficiency-plots" data-number="1"><a name="1"></a><span class="header-section-number">1.</span> Track Candidate MTV-like Efficiency plots</h2>
@@ -64,6 +70,20 @@
 <p><img src="mtv/T5_AllTypes_h_fakerate_numer_pt_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_fakerate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_fakerate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_fakerate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_fakerate_numer_phi_eff.png" width="450" /></p>
 <h2 data-number="12" id="track-candidate-mtv-like-duplrate-plots" data-number="12"><a name="12"></a><span class="header-section-number">12.</span> Quintuplet (T5) MTV-like Duplicate Rate plots</h2>
 <p><img src="mtv/T5_AllTypes_h_duplrate_numer_pt_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_duplrate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_duplrate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_duplrate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/T5_AllTypes_h_duplrate_numer_phi_eff.png" width="450" /></p>
+
+<h2 data-number="13" id="track-candidate-mtv-like-efficiency-plots" data-number="13"><a name="13"></a><span class="header-section-number">13.</span> Pixel Quintuplet (pT5) MTV-like Efficiency plots</h2>
+<p><img src="mtv/pT5_AllTypes__pt_eff.png" width="450" /> <img src="mtv/pT5_AllTypes__ptzoom_eff.png" width="450" /> <img src="mtv/pT5_AllTypes__etacoarse_eff.png" width="450" /> <img src="mtv/pT5_AllTypes__etazoomcoarse_eff.png" width="450" /> <img src="mtv/pT5_AllTypes__dxycoarse_eff.png" width="450" /> <img src="mtv/pT5_AllTypes__dz_eff.png" width="450" /> <img src="mtv/pT5_AllTypes__phi_eff.png" width="450" /></p>
+<h2 data-number="14" id="track-candidate-mtv-like-fakerate-plots" data-number="14"><a name="14"></a><span class="header-section-number">14.</span> Pixel Quintuplet (pT5) MTV-like Fake Rate plots</h2>
+<p><img src="mtv/pT5_AllTypes_h_fakerate_numer_pt_eff.png" width="450" /> <img src="mtv/pT5_AllTypes_h_fakerate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/pT5_AllTypes_h_fakerate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/pT5_AllTypes_h_fakerate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/pT5_AllTypes_h_fakerate_numer_phi_eff.png" width="450" /></p>
+<h2 data-number="15" id="track-candidate-mtv-like-duplrate-plots" data-number="15"><a name="15"></a><span class="header-section-number">15.</span> Pixel Quintuplet (pT5) MTV-like Duplicate Rate plots</h2>
+<p><img src="mtv/pT5_AllTypes_h_duplrate_numer_pt_eff.png" width="450" /> <img src="mtv/pT5_AllTypes_h_duplrate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/pT5_AllTypes_h_duplrate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/pT5_AllTypes_h_duplrate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/pT5_AllTypes_h_duplrate_numer_phi_eff.png" width="450" /></p>
+
+<h2 data-number="16" id="track-candidate-mtv-like-efficiency-plots" data-number="16"><a name="16"></a><span class="header-section-number">13.</span> Pixel Line Segment (pLS) MTV-like Efficiency plots</h2>
+<p><img src="mtv/pLS_AllTypes__pt_eff.png" width="450" /> <img src="mtv/pLS_AllTypes__ptzoom_eff.png" width="450" /> <img src="mtv/pLS_AllTypes__etacoarse_eff.png" width="450" /> <img src="mtv/pLS_AllTypes__etazoomcoarse_eff.png" width="450" /> <img src="mtv/pLS_AllTypes__dxycoarse_eff.png" width="450" /> <img src="mtv/pLS_AllTypes__dz_eff.png" width="450" /> <img src="mtv/pLS_AllTypes__phi_eff.png" width="450" /></p>
+<h2 data-number="17" id="track-candidate-mtv-like-fakerate-plots" data-number="17"><a name="17"></a><span class="header-section-number">14.</span> Pixel Line Segment (pLS) MTV-like Fake Rate plots</h2>
+<p><img src="mtv/pLS_AllTypes_h_fakerate_numer_pt_eff.png" width="450" /> <img src="mtv/pLS_AllTypes_h_fakerate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/pLS_AllTypes_h_fakerate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/pLS_AllTypes_h_fakerate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/pLS_AllTypes_h_fakerate_numer_phi_eff.png" width="450" /></p>
+<h2 data-number="18" id="track-candidate-mtv-like-duplrate-plots" data-number="18"><a name="18"></a><span class="header-section-number">15.</span> Pixel Line Segment (pLS) MTV-like Duplicate Rate plots</h2>
+<p><img src="mtv/pLS_AllTypes_h_duplrate_numer_pt_eff.png" width="450" /> <img src="mtv/pLS_AllTypes_h_duplrate_numer_ptzoom_eff.png" width="450" /> <img src="mtv/pLS_AllTypes_h_duplrate_numer_etacoarse_eff.png" width="450" /> <img src="mtv/pLS_AllTypes_h_duplrate_numer_etazoomcoarse_eff.png" width="450" /> <img src="mtv/pLS_AllTypes_h_duplrate_numer_phi_eff.png" width="450" /></p>
 
 </body>
 </html>

--- a/efficiency/src/efficiency.cc
+++ b/efficiency/src/efficiency.cc
@@ -25,6 +25,7 @@ int main(int argc, char** argv)
         list_effSetDef.push_back(EfficiencySetDefinition("T4s_AllTypes", 13, [&](int isim) {return sdl.sim_T4_matched().size() > isim ? sdl.sim_T4_matched()[isim] > 0 : false;}));
         list_effSetDef.push_back(EfficiencySetDefinition("T3_AllTypes", 13, [&](int isim) {return sdl.sim_T3_matched().size() > isim ? sdl.sim_T3_matched()[isim] > 0 : false;}));
         list_effSetDef.push_back(EfficiencySetDefinition("pT4_AllTypes", 13, [&](int isim) {return sdl.sim_pT4_matched().size() > isim ? sdl.sim_pT4_matched()[isim] > 0 : false;}));
+        list_effSetDef.push_back(EfficiencySetDefinition("pLS_AllTypes", 13, [&](int isim) {return sdl.sim_pLS_matched().size() > isim ? sdl.sim_pLS_matched()[isim] > 0 : false;}));
         list_effSetDef.push_back(EfficiencySetDefinition("T5_AllTypes", 13, [&](int isim) {return sdl.sim_T5_matched().size() > isim ? sdl.sim_T5_matched()[isim] > 0 : false;}));
         list_effSetDef.push_back(EfficiencySetDefinition("pT3_AllTypes", 13, [&](int isim) {return sdl.sim_pT3_matched().size() > isim ? sdl.sim_pT3_matched()[isim] > 0 : false;}));
         list_effSetDef.push_back(EfficiencySetDefinition("pT5_AllTypes", 13, [&](int isim) {return sdl.sim_pT5_matched().size() > isim ? sdl.sim_pT5_matched()[isim] > 0 : false;}));
@@ -170,14 +171,15 @@ void fillEfficiencySets(std::vector<EfficiencySetDefinition>& effsets)
 {
     for (auto& effset : effsets)
     {
+        bool excludepT5FoundSim = effset.set_name.Contains("pT3_");
         for (unsigned int isimtrk = 0; isimtrk < sdl.sim_pt().size(); ++isimtrk)
         {
-            fillEfficiencySet(isimtrk, effset);
+            fillEfficiencySet(isimtrk, effset,excludepT5FoundSim);
         }
     }
 }
 
-void fillEfficiencySet(int isimtrk, EfficiencySetDefinition& effset)
+void fillEfficiencySet(int isimtrk, EfficiencySetDefinition& effset, bool excludepT5Found)
 {
     const float& pt = sdl.sim_pt()[isimtrk];
     const float& eta = sdl.sim_eta()[isimtrk];
@@ -194,6 +196,8 @@ void fillEfficiencySet(int isimtrk, EfficiencySetDefinition& effset)
     const float& vtx_z = sdl.simvtx_z()[vtxIdx];
     const float& vtx_perp = sqrt(vtx_x * vtx_x + vtx_y * vtx_y);
 
+    const float& pT5Found = sdl.sim_pT5_matched()[isimtrk];
+
     if (bunch != 0)
         return;
 
@@ -205,6 +209,9 @@ void fillEfficiencySet(int isimtrk, EfficiencySetDefinition& effset)
 
     if (ana.pdgid == 0 and q == 0)
         return;
+
+    if(pT5Found !=0 and excludepT5Found)
+      return;
 
     TString category_name = effset.set_name;
 
@@ -297,6 +304,13 @@ void fillFakeRateSets(std::vector<FakeRateSetDefinition>& FRsets)
                 fillFakeRateSet(ipt3, FRset);
             }
         }
+        else if (FRset.set_name.Contains("pLS_"))
+        {
+            for (unsigned int ipls = 0; ipls < sdl.pLS_pt().size(); ++ipls)
+            {
+                fillFakeRateSet(ipls, FRset);
+            }
+        }
         else if (FRset.set_name.Contains("pT5_"))
         {
             for (unsigned int ipt5 = 0; ipt5 < sdl.pT5_pt().size(); ++ipt5)
@@ -351,6 +365,12 @@ void fillFakeRateSet(int itc, FakeRateSetDefinition& FRset)
         pt = sdl.pT3_pt()[itc];
         eta = sdl.pT3_eta()[itc];
         phi = sdl.pT3_phi()[itc];
+    }
+    else if (FRset.set_name.Contains("pLS_"))
+    {
+        pt = sdl.pLS_pt()[itc];
+        eta = sdl.pLS_eta()[itc];
+        phi = sdl.pLS_phi()[itc];
     }
     else if (FRset.set_name.Contains("pT5_"))
     {
@@ -455,6 +475,13 @@ void fillDuplicateRateSets(std::vector<DuplicateRateSetDefinition>& DLsets)
                 fillDuplicateRateSet(ipt3, DLset);
             }
         }
+        else if (DLset.set_name.Contains("pLS_"))
+        {
+            for (unsigned int ipls = 0; ipls < sdl.pLS_pt().size(); ++ipls)
+            {
+                fillDuplicateRateSet(ipls, DLset);
+            }
+        }
         else if (DLset.set_name.Contains("pT5_"))
         {
             for (unsigned int ipt5 = 0; ipt5 < sdl.pT5_pt().size(); ++ipt5)
@@ -508,6 +535,12 @@ void fillDuplicateRateSet(int itc, DuplicateRateSetDefinition& DLset)
         pt = sdl.pT3_pt()[itc];
         eta = sdl.pT3_eta()[itc];
         phi = sdl.pT3_phi()[itc];
+    }
+    else if (DLset.set_name.Contains("pLS_"))
+    {
+        pt = sdl.pLS_pt()[itc];
+        eta = sdl.pLS_eta()[itc];
+        phi = sdl.pLS_phi()[itc];
     }
     else if (DLset.set_name.Contains("pT5_"))
     {

--- a/efficiency/src/efficiency.h
+++ b/efficiency/src/efficiency.h
@@ -11,7 +11,7 @@
 void bookEfficiencySets(std::vector<EfficiencySetDefinition>& effset);
 void bookEfficiencySet(EfficiencySetDefinition& effset);
 void fillEfficiencySets(std::vector<EfficiencySetDefinition>& effset);
-void fillEfficiencySet(int isimtrk, EfficiencySetDefinition& effset);
+void fillEfficiencySet(int isimtrk, EfficiencySetDefinition& effset, bool excludepT5Found);
 void bookFakeRateSets(std::vector<FakeRateSetDefinition>& FRset);
 void bookFakeRateSet(FakeRateSetDefinition& FRset);
 void fillFakeRateSets(std::vector<FakeRateSetDefinition>& FRset);


### PR DESCRIPTION
This cleans duplicate pLS (using dR), pT5 (using hit matching in outer tracker and pLS ID matching) and pT3 (using 4+ outer hits and pLS ID matching) to remove duplicates. Also removes pT3 cross cleaning. 
Produces ~20% duplicate rate  for all TCs
Note that none of these methods are optimized for physics performance or time. 
Validation plots: https://www.classe.cornell.edu/~mgr85/www/SegmentLinking_keep/PR74/