### PR TITLE
pT5 bug fix

### DIFF
--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -2690,7 +2690,7 @@ __global__ void removeDupPixelQuintupletsInGPUFromMap(struct SDL::modules& modul
             unsigned int pLS_jx = pixelQuintupletsInGPU.pixelIndices[jx];
             int nMatched = checkHitsT5(T5_ix,T5_jx,mdsInGPU,segmentsInGPU,tripletsInGPU,quintupletsInGPU);
             int npMatched = checkHitspT5(pLS_ix,pLS_jx,mdsInGPU,segmentsInGPU,hitsInGPU);
-            if(((nMatched + npMatched) >=10))// || (secondPass && ((nMatched + npMatched) >=1))) 
+            if(((nMatched + npMatched) >=7))// || (secondPass && ((nMatched + npMatched) >=1))) 
             {
                 dup_count++;
                 if( pixelQuintupletsInGPU.score[ix] > pixelQuintupletsInGPU.score[jx])

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -2168,7 +2168,8 @@ __global__ void createPixelQuintupletsInGPUFromMap(struct SDL::modules& modulesI
     
     unsigned int quintupletIndex = modulesInGPU.quintupletModuleIndices[quintupletLowerModuleArrayIndex] + outerQuintupletArrayIndex;
 
-    if(quintupletsInGPU.isDup[quintupletIndex]) return;
+    if(segmentsInGPU.isDup[pixelSegmentArrayIndex]) return;//skip duplicated pLS
+    if(quintupletsInGPU.isDup[quintupletIndex]) return; //skip duplicated T5s
 
     float rzChiSquared, rPhiChiSquared, rPhiChiSquaredInwards;
 


### PR DESCRIPTION
Pixel Segment duplicates were not being removed in the pT5 newgrid kernel. This bug is now fixed

Comparison plots can be found here : http://uaf-10.t2.ucsd.edu/~bsathian/SDL/eff_comparison_plots__17dcf7dDIRTY_explicit_newgrid_17dcf7d_explicit_newgrid_PU200/TC_AllTypes__pt.pdf

http://uaf-10.t2.ucsd.edu/~bsathian/SDL/eff_comparison_plots__17dcf7dDIRTY_explicit_newgrid_17dcf7d_explicit_newgrid_PU200/TC_AllTypes__etacoarse.pdf