### PR TITLE
single precision

### DIFF
--- a/SDL/Constants.h
+++ b/SDL/Constants.h
@@ -12,17 +12,17 @@ namespace SDL
             // Luminous region fiducial region. +- 15 cm
             const float deltaZLum = 15.f;
 
-            const float kRinv1GeVf = (2.99792458e-3 * 3.8);
+            const float kRinv1GeVf = (2.99792458e-3f * 3.8f);
 
-            const float k2Rinv1GeVf = (2.99792458e-3 * 3.8) / 2.;
+            const float k2Rinv1GeVf = 0.5f*(2.99792458e-3f * 3.8f);
 
             const float ptCut = PTCUT;
 
-            const float sinAlphaMax = 0.95;  // arcsin (0.95) ~= 1.25 rad ~= 72 degrees (1/5th circle)
+            const float sinAlphaMax = 0.95f;  // arcsin (0.95) ~= 1.25 rad ~= 72 degrees (1/5th circle)
 
-            const float pixelPSZpitch = 0.15;
+            const float pixelPSZpitch = 0.15f;
 
-            const float strip2SZpitch = 5.0;
+            const float strip2SZpitch = 5.0f;
 
         }
     }

--- a/SDL/Hit.cuh
+++ b/SDL/Hit.cuh
@@ -79,8 +79,8 @@ namespace SDL
       return test;
     }
     if (y == 0) return  0;
-    if (y >  0) return  M_PI / 2;
-    else        return -M_PI / 2;
+    if (y >  0) return  float(M_PI) / 2.f;
+    else        return -float(M_PI) / 2.f;
     }
     CUDA_HOSTDEV inline float phi_mpi_pi(float x) {
     if (isnan(x))
@@ -89,21 +89,21 @@ namespace SDL
         return x;
     }
 
-    //while (x >= M_PI)
-    //    x -= 2. * M_PI;
+    //while (x >= float(M_PI))
+    //    x -= 2.f * float(M_PI);
 
-    //while (x < -M_PI)
-    //    x += 2. * M_PI;
+    //while (x < -float(M_PI))
+    //    x += 2.f * float(M_PI);
 
     //return x;
-    if (std::abs(x) <= float(M_PI))
+    if (fabsf(x) <= float(M_PI))
       return x;
-    constexpr float o2pi = 1. / (2. * M_PI);
+    constexpr float o2pi = 1.f / (2.f * float(M_PI));
     float n = std::round(x * o2pi);
-    return x - n * float(2. * M_PI);
+    return x - n * float(2.f * float(M_PI));
     }
     CUDA_HOSTDEV inline float phi(float x, float y, float z) {
-        return phi_mpi_pi(M_PI + ATan2(-y, -x));
+        return phi_mpi_pi(float(M_PI) + ATan2(-y, -x));
     }
     CUDA_HOSTDEV inline float deltaPhi(float x1, float y1, float z1, float x2, float y2, float z2) {
     float phi1 = phi(x1,y1,z1);

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -251,9 +251,9 @@ __global__ void addpT3asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, S
         float phi2 = segmentsInGPU.phi[pLS_jx - prefix];
         float dEta = abs(eta1-eta2);
         float dPhi = abs(phi1-phi2);
-        if(dPhi > M_PI){dPhi = dPhi - 2*M_PI;}
+        if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
         float dR2 = dEta*dEta + dPhi*dPhi;
-        if(dR2 < 1e-5) return;
+        if(dR2 < 1e-5f) return;
     }
 #endif
 
@@ -301,10 +301,10 @@ __global__ void addT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, st
             float phi2 = pixelQuintupletsInGPU.phi[jx];
             float dEta = abs(eta1-eta2);
             float dPhi = abs(phi1-phi2);
-            if(dPhi > M_PI){dPhi = dPhi - 2*M_PI;}
+            if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
             float dR2 = dEta*dEta + dPhi*dPhi;
             //printf("dR2: %f\n",dR2);
-            if(dR2 < 1e-3) return;
+            if(dR2 < 1e-3f) return;
         }
         if(jx < *pixelTripletsInGPU.nPixelTriplets)
         {
@@ -312,9 +312,9 @@ __global__ void addT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, st
             float phi2 = pixelTripletsInGPU.phi[jx]; 
             float dEta = abs(eta1-eta2);
             float dPhi = abs(phi1-phi2);
-            if(dPhi > M_PI){dPhi = dPhi - 2*M_PI;}
+            if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
             float dR2 = dEta*dEta + dPhi*dPhi;
-            if(dR2 < 1e-3) return;
+            if(dR2 < 1e-3f) return;
         }
     }
 #endif
@@ -362,9 +362,9 @@ __global__ void addpLSasTrackCandidateInGPU(struct SDL::modules& modulesInGPU, s
             float phi2 = quintupletsInGPU.phi[quintupletIndex];
             float dEta = abs(eta1-eta2);
             float dPhi = abs(phi1-phi2);
-            if(dPhi > M_PI){dPhi = dPhi - 2*M_PI;}
+            if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
             float dR2 = dEta*dEta + dPhi*dPhi;
-            if(dR2 < 1e-3) return;
+            if(dR2 < 1e-3f) return;
         }
     }
 
@@ -384,9 +384,9 @@ __global__ void addpLSasTrackCandidateInGPU(struct SDL::modules& modulesInGPU, s
             float phi2 = segmentsInGPU.phi[pLS_jx - prefix];
             float dEta = abs(eta1-eta2);
             float dPhi = abs(phi1-phi2);
-            if(dPhi > M_PI){dPhi = dPhi - 2*M_PI;}
+            if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
             float dR2 = dEta*dEta + dPhi*dPhi;
-            if(dR2 < 0.000001) return;
+            if(dR2 < 0.000001f) return;
             }
         }
         if(jx < *pixelTripletsInGPU.nPixelTriplets)
@@ -402,9 +402,9 @@ __global__ void addpLSasTrackCandidateInGPU(struct SDL::modules& modulesInGPU, s
             float phi2 = pixelTripletsInGPU.phi_pix[jx];
             float dEta = abs(eta1-eta2);
             float dPhi = abs(phi1-phi2);
-            if(dPhi > M_PI){dPhi = dPhi - 2*M_PI;}
+            if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
             float dR2 = dEta*dEta + dPhi*dPhi;
-            if(dR2 < 0.000001) return;
+            if(dR2 < 0.000001f) return;
             }
         }
     }
@@ -735,11 +735,11 @@ __device__ void scoreT5(struct SDL::modules& modulesInGPU, struct SDL::hits& hit
         float err;
         if(modulesInGPU.moduleLayerType[hitsInGPU.moduleIndices[hits1[i]]]==0)
         {
-            err=0.15*cos(atan(drdz));//(1.5mm)^2
+            err=0.15f*cosf(atanf(drdz));//(1.5mm)^2
         }
         else
         {
-            err=5.0*cos(atan(drdz));
+            err=5.0f*cosf(atanf(drdz));
         }//(5cm)^2
         score += (var*var) / (err*err);
         score_lsq += (var_lsq*var_lsq) / (err*err);
@@ -835,15 +835,15 @@ __global__ void removeDupQuintupletsInGPU(struct SDL::modules& modulesInGPU, str
                     float dEta = fabsf(eta1-eta2);
                     float dPhi = fabsf(phi1-phi2);
 		    float score_rphisum2 = quintupletsInGPU.score_rphisum[jx];
-                    if (dEta > 0.1)
+                    if (dEta > 0.1f)
                     {
                         continue;
                     }
-                    if(dPhi > M_PI){dPhi = dPhi - 2*M_PI;}
-                    if (abs(dPhi) > 0.1){continue;}
+                    if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
+                    if (abs(dPhi) > 0.1f){continue;}
                     float dR2 = dEta*dEta + dPhi*dPhi;
                     int nMatched = checkHitsT5(ix,jx,mdsInGPU,segmentsInGPU,tripletsInGPU,quintupletsInGPU);
-                    if(secondPass && (dR2 < 0.001 || nMatched >= 5))
+                    if(secondPass && (dR2 < 0.001f || nMatched >= 5))
                     {
                         if(score_rphisum1 > score_rphisum2 )
                         {
@@ -903,7 +903,7 @@ __device__ float scorepT3(struct SDL::modules& modulesInGPU,struct SDL::hits& hi
         float r = hitsInGPU.rts[hits1[i]]; // cm
         float subdet = modulesInGPU.subdets[hitsInGPU.moduleIndices[hits1[i]]];
         float drdz = modulesInGPU.drdzs[hitsInGPU.moduleIndices[hits1[i]]];
-        float var=0;
+        float var=0.f;
         if(subdet == 5)
         {// 5== barrel
             var = slope_barrel*(r-r1) - (z-z1);
@@ -915,11 +915,11 @@ __device__ float scorepT3(struct SDL::modules& modulesInGPU,struct SDL::hits& hi
         float err;
         if(modulesInGPU.moduleLayerType[hitsInGPU.moduleIndices[hits1[i]]]==0)
         {
-            err=0.15*cos(atan(drdz));//(1.5mm)^2
+            err=0.15f*cosf(atanf(drdz));//(1.5mm)^2
         }
         else
         {
-            err=5.0*cos(atan(drdz));
+            err=5.0f*cosf(atanf(drdz));
         }//(5cm)^2
         score += (var*var) / (err*err);
     }
@@ -1189,12 +1189,12 @@ __global__ void checkHitspLS(struct SDL::modules& modulesInGPU,struct SDL::miniD
               }
               float dEta = abs(eta_pix1-eta_pix2);
               float dPhi = abs(phi_pix1-phi_pix2);
-              if(dPhi > M_PI){dPhi = dPhi - 2*M_PI;}
+              if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
               //if(abs(dPhi) > 0.03){continue;}
               //if(abs(1./pt1 - 1./pt2) > 0.5){continue;}
               float dR2 = dEta*dEta + dPhi*dPhi;
               //if(dR2 <0.0003)
-              if(dR2 <0.00075)
+              if(dR2 <0.00075f)
               {
                   found=true;
                   break;

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -567,7 +567,7 @@ __global__ void createQuintupletsInGPU(struct SDL::modules& modulesInGPU, struct
                     unsigned int quintupletIndex = modulesInGPU.quintupletModuleIndices[lowerModuleArray1] +  quintupletModuleIndex;
                     float phi = hitsInGPU.phis[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*tripletsInGPU.segmentIndices[2*innerTripletIndex+layer2_adjustment]]]];
                     float eta = hitsInGPU.etas[mdsInGPU.hitIndices[2*segmentsInGPU.mdIndices[2*tripletsInGPU.segmentIndices[2*innerTripletIndex+layer2_adjustment]]]];
-                    float pt = (innerRadius+outerRadius)*3.8*1.602/(2*100*5.39);
+                    float pt = (innerRadius+outerRadius)*3.8f*1.602f/(2*100*5.39f);
                     float scores = chiSquared + nonAnchorChiSquared;
 #ifdef CUT_VALUE_DEBUG
                     addQuintupletToMemory(quintupletsInGPU, innerTripletIndex, outerTripletIndex, lowerModule1, lowerModule2, lowerModule3, lowerModule4, lowerModule5, innerRadius, innerRadiusMin, innerRadiusMax, outerRadius, outerRadiusMin, outerRadiusMax, bridgeRadius, bridgeRadiusMin, bridgeRadiusMax, innerRadiusMin2S, innerRadiusMax2S, bridgeRadiusMin2S, bridgeRadiusMax2S, outerRadiusMin2S, outerRadiusMax2S, regressionG, regressionF, regressionRadius, chiSquared, nonAnchorChiSquared,

--- a/SDL/Kernels.cuh
+++ b/SDL/Kernels.cuh
@@ -73,7 +73,7 @@ __global__ void addpLSasTrackCandidateInGPU(struct SDL::modules& modulesInGPU,st
 
 __global__ void addT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU,struct SDL::quintuplets& quintupletsInGPU,struct SDL::trackCandidates& trackCandidatesInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU,struct SDL::pixelTriplets& pixelTripletsInGPU);
 
-__global__ void addpT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU);
+__global__ void addpT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU,struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,struct SDL::quintuplets& quintupletsInGPU);
 
 
 __global__ void createTripletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, unsigned int *index_gpu);

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -49,11 +49,12 @@ void SDL::createMDsInUnifiedMemory(struct miniDoublets& mdsInGPU, unsigned int m
     mdsInGPU.noShiftedDzs  = mdsInGPU.dphichanges + 6*nMemoryLocations;
     mdsInGPU.noShiftedDphis  = mdsInGPU.dphichanges + 7*nMemoryLocations;
     mdsInGPU.noShiftedDphiChanges  = mdsInGPU.dphichanges + 8*nMemoryLocations;
-#pragma omp parallel for default(shared)
-    for(size_t i = 0; i< nModules; i++)
-    {
-        mdsInGPU.nMDs[i] = 0;
-    }
+//#pragma omp parallel for default(shared)
+//    for(size_t i = 0; i< nModules; i++)
+//    {
+//        mdsInGPU.nMDs[i] = 0;
+//    }
+    cudaMemset(mdsInGPU.nMDs,0,nModules *sizeof(unsigned int));
 }
 
 
@@ -185,7 +186,7 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoBarrel(struct modules& modulesInGP
     bool pass = true; 
     dz = zLower - zUpper;     
     dzCut = modulesInGPU.moduleType[lowerModuleIndex] == PS ? 2.f : 10.f;
-    drtCut = 0;
+    drtCut = 0.f;
     drt = hitsInGPU.rts[upperHitIndex] - hitsInGPU.rts[lowerHitIndex];
 
     const float sign = ((dz > 0) - (dz < 0)) * ((hitsInGPU.zs[lowerHitIndex] > 0) - (hitsInGPU.zs[lowerHitIndex] < 0));
@@ -201,7 +202,7 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoBarrel(struct modules& modulesInGP
         pass = false;
     }
 
-    miniCut = 0;
+    miniCut = 0.f;
 
     if (modulesInGPU.moduleLayerType[lowerModuleIndex] == Pixel)
     {
@@ -215,7 +216,7 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoBarrel(struct modules& modulesInGP
 
     // Cut #2: dphi difference
     // Ref to original code: https://github.com/slava77/cms-tkph2-ntuple/blob/184d2325147e6930030d3d1f780136bc2dd29ce6/doubletAnalysis.C#L3085
-    float xn = 0, yn = 0;// , zn = 0;
+    float xn = 0.f, yn = 0.f;// , zn = 0;
     float shiftedRt;
     if (modulesInGPU.sides[lowerModuleIndex] != Center) // If barrel and not center it is tilted
     {
@@ -338,7 +339,7 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoEndcap(struct modules& modulesInGP
     }
 
     // The new scheme shifts strip hits to be "aligned" along the line of sight from interaction point to the pixel hit (if it is PS modules)
-    float xn = 0, yn = 0, zn = 0;
+    float xn = 0.f, yn = 0.f, zn = 0.f;
 
     float shiftedCoords[3];
     shiftStripHits(modulesInGPU, hitsInGPU, lowerModuleIndex, lowerHitIndex, upperHitIndex, shiftedCoords);
@@ -391,7 +392,7 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoEndcap(struct modules& modulesInGP
         }
     }
 
-    miniCut = 0;
+    miniCut = 0.f;
     if(modulesInGPU.moduleLayerType[lowerModuleIndex] == Pixel)
     {
         miniCut = dPhiThreshold(hitsInGPU, modulesInGPU, lowerHitIndex, lowerModuleIndex,dPhi, dz);
@@ -424,8 +425,8 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoEndcap(struct modules& modulesInGP
 __device__ bool SDL::runMiniDoubletDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, unsigned int lowerModuleIndex, unsigned int lowerHitIndex, unsigned int upperHitIndex, float& dz, float& drt, float& dPhi, float& dPhiChange, float& shiftedX, float& shiftedY, float& shiftedZ, float& noShiftedDz, float& noShiftedDphi, float& noShiftedDphiChange, float& dzCut, float& drtCut, float& miniCut)
 {
     bool pass;
-    dzCut = -999;
-    drtCut = -999;
+    dzCut = -999.f;
+    drtCut = -999.f;
    
     if(modulesInGPU.subdets[lowerModuleIndex] == Barrel)
     {
@@ -480,7 +481,7 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoBarrel(struct modules& modulesInGP
 
     // Cut #2: dphi difference
     // Ref to original code: https://github.com/slava77/cms-tkph2-ntuple/blob/184d2325147e6930030d3d1f780136bc2dd29ce6/doubletAnalysis.C#L3085
-    float xn = 0, yn = 0;// , zn = 0;
+    float xn = 0.f, yn = 0.f;// , zn = 0;
     float shiftedRt;
     if (modulesInGPU.sides[lowerModuleIndex] != Center) // If barrel and not center it is tilted
     {
@@ -800,9 +801,9 @@ __device__ inline float SDL::isTighterTiltedModules(struct modules& modulesInGPU
 
 __device__ float SDL::moduleGapSize(struct modules& modulesInGPU, unsigned int moduleIndex)
 {
-    float miniDeltaTilted[3] = {0.26, 0.26, 0.26};
-    float miniDeltaFlat[6] ={0.26, 0.16, 0.16, 0.18, 0.18, 0.18};
-    float miniDeltaLooseTilted[3] = {0.4,0.4,0.4};
+    float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
+    float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
+    float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
     float miniDeltaEndcap[5][15];
 
     for (size_t i = 0; i < 5; i++)
@@ -813,33 +814,33 @@ __device__ float SDL::moduleGapSize(struct modules& modulesInGPU, unsigned int m
             {
                 if (j < 10)
                 {
-                    miniDeltaEndcap[i][j] = 0.4;
+                    miniDeltaEndcap[i][j] = 0.4f;
                 }
                 else
                 {
-                    miniDeltaEndcap[i][j] = 0.18;
+                    miniDeltaEndcap[i][j] = 0.18f;
                 }
             }
             else if (i == 2 || i == 3)
             {
                 if (j < 8)
                 {
-                    miniDeltaEndcap[i][j] = 0.4;
+                    miniDeltaEndcap[i][j] = 0.4f;
                 }
                 else
                 {
-                    miniDeltaEndcap[i][j]  = 0.18;
+                    miniDeltaEndcap[i][j]  = 0.18f;
                 }
             }
             else
             {
                 if (j < 9)
                 {
-                    miniDeltaEndcap[i][j] = 0.4;
+                    miniDeltaEndcap[i][j] = 0.4f;
                 }
                 else
                 {
-                    miniDeltaEndcap[i][j] = 0.18;
+                    miniDeltaEndcap[i][j] = 0.18f;
                 }
             }
         }
@@ -957,7 +958,7 @@ __device__ void SDL::shiftStripHits(struct modules& modulesInGPU, struct hits& h
         drdz_ = modulesInGPU.drdzs[lowerModuleIndex];
         slope = modulesInGPU.slopes[lowerModuleIndex];
     }
-    angleB = ((isEndcap) ? M_PI / 2. : atan(drdz_)); // The tilt module on the postive z-axis has negative drdz slope in r-z plane and vice versa
+    angleB = ((isEndcap) ? float(M_PI) / 2.f : atanf(drdz_)); // The tilt module on the postive z-axis has negative drdz slope in r-z plane and vice versa
 
 
     moduleSeparation = moduleGapSize(modulesInGPU, lowerModuleIndex);
@@ -968,10 +969,10 @@ __device__ void SDL::shiftStripHits(struct modules& modulesInGPU, struct hits& h
         moduleSeparation *= -1;
     }
 
-    drprime = (moduleSeparation / std::sin(angleA + angleB)) * std::sin(angleA);
+    drprime = (moduleSeparation / sinf(angleA + angleB)) * sinf(angleA);
     
     // Compute arctan of the slope and take care of the slope = infinity case
-    absArctanSlope = ((slope != SDL_INF) ? fabs(atanf(slope)) : M_PI / 2); // Since C++ can't represent infinity, SDL_INF = 123456789 was used to represent infinity in the data table
+    absArctanSlope = ((slope != SDL_INF) ? fabs(atanf(slope)) : float(M_PI) / 2.f); // Since C++ can't represent infinity, SDL_INF = 123456789 was used to represent infinity in the data table
 
     // The pixel hit position
     xp = hitsInGPU.xs[pixelHitIndex];
@@ -984,20 +985,20 @@ __device__ void SDL::shiftStripHits(struct modules& modulesInGPU, struct hits& h
     }
     else if (xp > 0 and yp < 0)
     {
-        angleM = M_PI - absArctanSlope;
+        angleM = float(M_PI) - absArctanSlope;
     }
     else if (xp < 0 and yp < 0)
     {
-        angleM = M_PI + absArctanSlope;
+        angleM = float(M_PI) + absArctanSlope;
     }
     else // if (xp < 0 and yp > 0)
     {
-        angleM = 2 * M_PI - absArctanSlope;
+        angleM = 2.f * float(M_PI) - absArctanSlope;
     }
 
     // Then since the angleM sign is taken care of properly
-    drprime_x = drprime * std::sin(angleM);
-    drprime_y = drprime * std::cos(angleM);
+    drprime_x = drprime * sinf(angleM);
+    drprime_y = drprime * cosf(angleM);
 
     // The new anchor position is
     xa = xp + drprime_x;
@@ -1025,7 +1026,7 @@ __device__ void SDL::shiftStripHits(struct modules& modulesInGPU, struct hits& h
     }
 
     // Computing new Z position
-    absdzprime = fabsf(moduleSeparation / std::sin(angleA + angleB) * std::cos(angleA)); // module separation sign is for shifting in radial direction for z-axis direction take care of the sign later
+    absdzprime = fabsf(moduleSeparation / sinf(angleA + angleB) * cosf(angleA)); // module separation sign is for shifting in radial direction for z-axis direction take care of the sign later
 
     // Depending on which one as closer to the interactin point compute the new z wrt to the pixel properly
     if (modulesInGPU.moduleLayerType[lowerModuleIndex] == Pixel)

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -725,7 +725,7 @@ __device__ float SDL::dPhiThreshold(struct hits& hitsInGPU, struct modules& modu
     unsigned int iL = modulesInGPU.layers[moduleIndex] - 1;
     const float miniSlope = asinf(min(rt * k2Rinv1GeVf / ptCut, sinAlphaMax));
     const float rLayNominal = ((modulesInGPU.subdets[moduleIndex]== Barrel) ? miniRminMeanBarrel[iL] : miniRminMeanEndcap[iL]);
-    const float miniPVoff = 0.1 / rLayNominal;
+    const float miniPVoff = 0.1f / rLayNominal;
     const float miniMuls = ((modulesInGPU.subdets[moduleIndex] == Barrel) ? miniMulsPtScaleBarrel[iL] * 3.f / ptCut : miniMulsPtScaleEndcap[iL] * 3.f / ptCut);
     const bool isTilted = modulesInGPU.subdets[moduleIndex] == Barrel and modulesInGPU.sides[moduleIndex] != Center;
     //the lower module is sent in irrespective of its layer type. We need to fetch the drdz properly

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -36,7 +36,7 @@ namespace SDL
         float* dphichanges;
 
         float* dzs; //will store drt if the module is endcap
-        float*dphis;
+        float* dphis;
 
         float* shiftedXs;
         float* shiftedYs;
@@ -121,6 +121,81 @@ namespace SDL
     extern CUDA_CONST_VAR float miniDeltaEndcap[5][15];
     extern CUDA_CONST_VAR float pixelPSZpitch;
     extern CUDA_CONST_VAR float strip2SZpitch;
+
+//CUDA_DEV float inline moduleGapSize(struct modules& modulesInGPU, unsigned int moduleIndex)
+//{
+//    float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
+//    float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
+//    float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
+//    float miniDeltaEndcap[5][15];
+//
+//    for (size_t i = 0; i < 5; i++)
+//    {
+//        for (size_t j = 0; j < 15; j++)
+//        {
+//            if (i == 0 || i == 1)
+//            {
+//                if (j < 10)
+//                {
+//                    miniDeltaEndcap[i][j] = 0.4f;
+//                }
+//                else
+//                {
+//                    miniDeltaEndcap[i][j] = 0.18f;
+//                }
+//            }
+//            else if (i == 2 || i == 3)
+//            {
+//                if (j < 8)
+//                {
+//                    miniDeltaEndcap[i][j] = 0.4f;
+//                }
+//                else
+//                {
+//                    miniDeltaEndcap[i][j]  = 0.18f;
+//                }
+//            }
+//            else
+//            {
+//                if (j < 9)
+//                {
+//                    miniDeltaEndcap[i][j] = 0.4f;
+//                }
+//                else
+//                {
+//                    miniDeltaEndcap[i][j] = 0.18f;
+//                }
+//            }
+//        }
+//    }
+//
+//
+//    unsigned int iL = modulesInGPU.layers[moduleIndex]-1;
+//    unsigned int iR = modulesInGPU.rings[moduleIndex] - 1;
+//    short subdet = modulesInGPU.subdets[moduleIndex];
+//    short side = modulesInGPU.sides[moduleIndex];
+//
+//    float moduleSeparation = 0;
+//
+//    if (subdet == Barrel and side == Center)
+//    {
+//        moduleSeparation = miniDeltaFlat[iL];
+//    }
+//    else if (isTighterTiltedModules(modulesInGPU, moduleIndex))
+//    {
+//        moduleSeparation = miniDeltaTilted[iL];
+//    }
+//    else if (subdet == Endcap)
+//    {
+//        moduleSeparation = miniDeltaEndcap[iL][iR];
+//    }
+//    else //Loose tilted modules
+//    {
+//        moduleSeparation = miniDeltaLooseTilted[iL];
+//    }
+//
+//    return moduleSeparation;
+//}
 
 }
 

--- a/SDL/PixelQuintuplet.cu
+++ b/SDL/PixelQuintuplet.cu
@@ -186,14 +186,14 @@ __device__ bool SDL::runPixelQuintupletDefaultAlgo(struct modules& modulesInGPU,
 
     rPhiChiSquaredInwards = computePT5RPhiChiSquaredInwards(modulesInGPU, hitsInGPU, quintupletsInGPU, quintupletIndex, pixelHits);
 
-    if(segmentsInGPU.circleRadius[pixelSegmentArrayIndex] < 5.0/(2 * k2Rinv1GeVf))
+    if(segmentsInGPU.circleRadius[pixelSegmentArrayIndex] < 5.0f/(2.f * k2Rinv1GeVf))
     {
         pass = pass & passPT5RZChiSquaredCuts(modulesInGPU, lowerModuleIndex1, lowerModuleIndex2, lowerModuleIndex3, lowerModuleIndex4, lowerModuleIndex5, rzChiSquared);
 
         pass = pass & passPT5RPhiChiSquaredCuts(modulesInGPU, lowerModuleIndex1, lowerModuleIndex2, lowerModuleIndex3, lowerModuleIndex4, lowerModuleIndex5, rPhiChiSquared);
     }
     
-    if(quintupletsInGPU.regressionRadius[quintupletIndex] < 5.0/(2 * k2Rinv1GeVf))
+    if(quintupletsInGPU.regressionRadius[quintupletIndex] < 5.0f/(2.f * k2Rinv1GeVf))
     {
         pass = pass & passPT5RPhiChiSquaredInwardsCuts(modulesInGPU, lowerModuleIndex1, lowerModuleIndex2, lowerModuleIndex3, lowerModuleIndex4, lowerModuleIndex5, rPhiChiSquaredInwards);
     }
@@ -215,109 +215,109 @@ __device__ bool SDL::passPT5RPhiChiSquaredCuts(struct modules& modulesInGPU, uns
     {
         if(layer4 == 12 and layer5 == 13)
         {
-            return rPhiChiSquared < 48.921;
+            return rPhiChiSquared < 48.921f;
         }
         else if(layer4 == 4 and layer5 == 12)
         {
-            return rPhiChiSquared < 97.948;
+            return rPhiChiSquared < 97.948f;
         }
         else if(layer4 == 4 and layer5 == 5)
         {
-            return rPhiChiSquared < 129.3;
+            return rPhiChiSquared < 129.3f;
         }
         else if(layer4 == 7 and layer5 == 13)
         {
-            return rPhiChiSquared < 56.21;
+            return rPhiChiSquared < 56.21f;
         }
         else if(layer4 == 7 and layer5 == 8)
         {
-            return rPhiChiSquared < 74.198;
+            return rPhiChiSquared < 74.198f;
         }
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 7)
     {
         if(layer4 == 13 and layer5 == 14)
         {
-            return rPhiChiSquared < 21.265;
+            return rPhiChiSquared < 21.265f;
         }
         else if(layer4 == 8 and layer5 == 14)
         {
-            return rPhiChiSquared < 37.058;
+            return rPhiChiSquared < 37.058f;
         }
         else if(layer4 == 8 and layer5 == 9)
         {
-            return rPhiChiSquared < 42.578;
+            return rPhiChiSquared < 42.578f;
         }
     }
     else if(layer1 == 1 and layer2 == 7 and layer3 == 8)
     {
         if(layer4 == 9 and layer5 == 10)
         {
-            return rPhiChiSquared < 32.253;
+            return rPhiChiSquared < 32.253f;
         }
         else if(layer4 == 9 and layer5 == 15)
         {
-            return rPhiChiSquared < 37.058;
+            return rPhiChiSquared < 37.058f;
         }
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 4)
     {
         if(layer4 == 12 and layer5 == 13)
         {
-            return rPhiChiSquared < 97.947;
+            return rPhiChiSquared < 97.947f;
         }
         else if(layer4 == 5 and layer5 == 12)
         {
-            return rPhiChiSquared < 129.3;
+            return rPhiChiSquared < 129.3f;
         }
         else if(layer4 == 5 and layer5 == 6)
         {
-            return rPhiChiSquared < 170.68;
+            return rPhiChiSquared < 170.68f;
         }
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 7)
     {
         if(layer4 == 13 and layer5 == 14)
         {   
-            return rPhiChiSquared < 48.92;
+            return rPhiChiSquared < 48.92f;
         }
         else if(layer4 == 8 and layer5 == 14)
         {
-            return rPhiChiSquared < 74.2;
+            return rPhiChiSquared < 74.2f;
         }
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 8)
     {
         if(layer4 == 14 and layer5 == 15)
         {
-            return rPhiChiSquared < 42.58;
+            return rPhiChiSquared < 42.58f;
         }
         else if(layer4 == 9 and layer5 == 10)
         {
-            return rPhiChiSquared < 37.06;
+            return rPhiChiSquared < 37.06f;
         }
         else if(layer4 == 9 and layer5 == 15)
         {
-            return rPhiChiSquared < 48.92;
+            return rPhiChiSquared < 48.92f;
         }
     }
     else if(layer1 == 3 and layer2 == 7 and layer3 == 8 and layer4 == 14 and layer5 == 15)
     {
-        return rPhiChiSquared < 85.25;
+        return rPhiChiSquared < 85.25f;
     }
     else if(layer1 == 7 and layer2 == 8 and layer3 == 9)
     {
         if(layer4 == 10 and layer5 == 11)
         {
-            return rPhiChiSquared < 42.58;
+            return rPhiChiSquared < 42.58f;
         }
         else if(layer4 == 10 and layer5 == 16)
         {
-            return rPhiChiSquared < 37.06;
+            return rPhiChiSquared < 37.06f;
         }
         else if(layer4 == 15 and layer5 == 16)
         {
-            return rPhiChiSquared < 37.06;
+            return rPhiChiSquared < 37.06f;
         }
     }
     return true;
@@ -337,109 +337,109 @@ __device__ bool SDL::passPT5RPhiChiSquaredInwardsCuts(struct modules& modulesInG
     {
         if(layer4 == 12 and layer5 == 13)
         {
-            return rPhiChiSquared < 451.141;
+            return rPhiChiSquared < 451.141f;
         }
         else if(layer4 == 4 and layer5 == 12)
         {
-            return rPhiChiSquared < 786.173;
+            return rPhiChiSquared < 786.173f;
         }
         else if(layer4 == 4 and layer5 == 5)
         {
-            return rPhiChiSquared < 595.545;
+            return rPhiChiSquared < 595.545f;
         }
         else if(layer4 == 7 and layer5 == 13)
         {
-            return rPhiChiSquared < 581.339;
+            return rPhiChiSquared < 581.339f;
         }
         else if(layer4 == 7 and layer5 == 8)
         {
-            return rPhiChiSquared < 112.537;
+            return rPhiChiSquared < 112.537f;
         }
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 7)
     {
         if(layer4 == 13 and layer5 == 14)
         {
-            return rPhiChiSquared < 225.322;
+            return rPhiChiSquared < 225.322f;
         }
         else if(layer4 == 8 and layer5 == 14)
         {
-            return rPhiChiSquared < 1192.402;
+            return rPhiChiSquared < 1192.402f;
         }
         else if(layer4 == 8 and layer5 == 9)
         {
-            return rPhiChiSquared < 786.173;
+            return rPhiChiSquared < 786.173f;
         }
     }
     else if(layer1 == 1 and layer2 == 7 and layer3 == 8)
     {
         if(layer4 == 9 and layer5 == 10)
         {
-            return rPhiChiSquared < 1037.817;
+            return rPhiChiSquared < 1037.817f;
         }
         else if(layer4 == 9 and layer5 == 15)
         {
-            return rPhiChiSquared < 1808.536;
+            return rPhiChiSquared < 1808.536f;
         }
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 4)
     {
         if(layer4 == 12 and layer5 == 13)
         {
-            return rPhiChiSquared < 684.253;
+            return rPhiChiSquared < 684.253f;
         }
         else if(layer4 == 5 and layer5 == 12)
         {
-            return rPhiChiSquared < 684.253;
+            return rPhiChiSquared < 684.253f;
         }
         else if(layer4 == 5 and layer5 == 6)
         {
-            return rPhiChiSquared < 684.253;
+            return rPhiChiSquared < 684.253f;
         }
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 7)
     {
         if(layer4 == 13 and layer5 == 14)
         {   
-            return rPhiChiSquared < 451.141;
+            return rPhiChiSquared < 451.141f;
         }
         else if(layer4 == 8 and layer5 == 14)
         {
-            return rPhiChiSquared < 518.34;
+            return rPhiChiSquared < 518.34f;
         }
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 8)
     {
         if(layer4 == 14 and layer5 == 15)
         {
-            return rPhiChiSquared < 2077.92;
+            return rPhiChiSquared < 2077.92f;
         }
         else if(layer4 == 9 and layer5 == 10)
         {
-            return rPhiChiSquared < 74.20;
+            return rPhiChiSquared < 74.20f;
         }
         else if(layer4 == 9 and layer5 == 15)
         {
-            return rPhiChiSquared < 1808.536;
+            return rPhiChiSquared < 1808.536f;
         }
     }
     else if(layer1 == 3 and layer2 == 7 and layer3 == 8 and layer4 == 14 and layer5 == 15)
     {
-        return rPhiChiSquared < 786.173;
+        return rPhiChiSquared < 786.173f;
     }
     else if(layer1 == 7 and layer2 == 8 and layer3 == 9)
     {
         if(layer4 == 10 and layer5 == 11)
         {
-            return rPhiChiSquared < 1574.076;
+            return rPhiChiSquared < 1574.076f;
         }
         else if(layer4 == 10 and layer5 == 16)
         {
-            return rPhiChiSquared < 5492.11;
+            return rPhiChiSquared < 5492.11f;
         }
         else if(layer4 == 15 and layer5 == 16)
         {
-            return rPhiChiSquared < 2743.037;
+            return rPhiChiSquared < 2743.037f;
         }
     }
     return true;
@@ -484,109 +484,109 @@ __device__ bool SDL::passPT5RZChiSquaredCuts(struct modules& modulesInGPU, unsig
     {
         if(layer4 == 12 and layer5 == 13)
         {
-            return rzChiSquared < 451.141;
+            return rzChiSquared < 451.141f;
         }
         else if(layer4 == 4 and layer5 == 12)
         {
-            return rzChiSquared < 392.654;
+            return rzChiSquared < 392.654f;
         }
         else if(layer4 == 4 and layer5 == 5)
         {
-            return rzChiSquared < 225.322;
+            return rzChiSquared < 225.322f;
         }
         else if(layer4 == 7 and layer5 == 13)
         {
-            return rzChiSquared < 595.546;
+            return rzChiSquared < 595.546f;
         }
         else if(layer4 == 7 and layer5 == 8)
         {
-            return rzChiSquared < 196.111;
+            return rzChiSquared < 196.111f;
         }
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 7)
     {
         if(layer4 == 13 and layer5 == 14)
         {
-            return rzChiSquared < 297.446;
+            return rzChiSquared < 297.446f;
         }
         else if(layer4 == 8 and layer5 == 14)
         {   
-            return rzChiSquared < 451.141;
+            return rzChiSquared < 451.141f;
         }
         else if(layer4 == 8 and layer5 == 9)
         {
-            return rzChiSquared < 518.339;
+            return rzChiSquared < 518.339f;
         }
     }
     else if(layer1 == 1 and layer2 == 7 and layer3 == 8)
     {
         if(layer4 == 9 and layer5 == 10)
         {
-            return rzChiSquared < 341.75;
+            return rzChiSquared < 341.75f;
         }
         else if(layer4 == 9 and layer5 == 15)
         {
-            return rzChiSquared < 341.75;
+            return rzChiSquared < 341.75f;
         }
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 4)
     {
         if(layer4 == 12 and layer5 == 13)
         {
-            return rzChiSquared < 392.655;
+            return rzChiSquared < 392.655f;
         }
         else if(layer4 == 5 and layer5 == 12)
         {
-            return rzChiSquared < 341.75;
+            return rzChiSquared < 341.75f;
         }
         else if(layer4 == 5 and layer5 == 6)
         {
-            return rzChiSquared < 112.537;
+            return rzChiSquared < 112.537f;
         }
     }
     else if(layer1 == 2 and layer2 == 3 and layer4 == 7)
     {
         if(layer4 == 13 and layer5 == 14)
         {
-            return rzChiSquared < 595.545;
+            return rzChiSquared < 595.545f;
         }
         else if(layer4 == 8 and layer5 == 14)
         {
-            return rzChiSquared < 74.198;
+            return rzChiSquared < 74.198f;
         }
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 8)
     {
         if(layer4 == 14 and layer5 == 15)
         {
-            return rzChiSquared < 518.339;
+            return rzChiSquared < 518.339f;
         }
         else if(layer4 == 9 and layer5 == 10)
         {
-            return rzChiSquared < 8.046;
+            return rzChiSquared < 8.046f;
         }
         else if(layer4 == 9 and layer5 == 15)
         {
-            return rzChiSquared < 451.141;
+            return rzChiSquared < 451.141f;
         }
     }
     else if(layer1 == 3 and layer2 == 7 and layer3 == 8 and layer4 == 14 and layer5 == 15)
     {
-        return rzChiSquared < 56.207;
+        return rzChiSquared < 56.207f;
     }
     else if(layer1 == 7 and layer2 == 8 and layer3 == 9)
     {
         if(layer4 == 10 and layer5 == 11)
         {
-            return rzChiSquared < 64.578;
+            return rzChiSquared < 64.578f;
         }
         else if(layer4 == 10 and layer5 == 16)
         {
-            return rzChiSquared < 85.250;
+            return rzChiSquared < 85.250f;
         }
         else if(layer4 == 15 and layer5 == 16)
         {
-            return rzChiSquared < 85.250;
+            return rzChiSquared < 85.250f;
         }
     }
     return true;
@@ -607,7 +607,8 @@ __device__ float SDL::computePT5RPhiChiSquaredInwards(struct modules& modulesInG
         float residual = (x - g) * (x -g) + (y - f) * (y - f) - r * r;
         chiSquared += residual * residual;
     }
-    chiSquared /= 2;
+    //chiSquared /= 2;
+    chiSquared *= 0.5f;
     return chiSquared;
 }
 
@@ -644,11 +645,11 @@ __device__ float SDL::computePT5RZChiSquared(struct modules& modulesInGPU, struc
         //PS Modules
         if(moduleType == 0)
         {
-            error = 0.15;
+            error = 0.15f;
         }
         else //2S modules
         {
-            error = 5.0;
+            error = 5.0f;
         }
 
         //special dispensation to tilted PS modules!
@@ -663,12 +664,13 @@ __device__ float SDL::computePT5RZChiSquared(struct modules& modulesInGPU, struc
                 drdz = modulesInGPU.drdzs[modulesInGPU.partnerModuleIndex(lowerModuleIndex)];
             }
 
-            error *= 1/sqrtf(1 + drdz * drdz);
+            //error *= 1.f/sqrtf(1.f + drdz * drdz);
+            error /= sqrtf(1.f + drdz * drdz);
         }
         RMSE += (residual * residual)/(error * error);
     }
 
-    RMSE = sqrtf(0.2 * RMSE);
+    RMSE = sqrtf(0.2f * RMSE);
     return RMSE;
 }
 

--- a/SDL/PixelQuintuplet.cuh
+++ b/SDL/PixelQuintuplet.cuh
@@ -73,7 +73,7 @@ namespace SDL
     CUDA_DEV bool passPT5RPhiChiSquaredInwardsCuts(struct modules& modulesInGPU, unsigned int lowerModuleIndex1, unsigned int lowerModuleIndex2, unsigned int lowerModuleIndex3, unsigned int lowerModuleIndex4, unsigned int lowerModuleIndex5, float rPhiChiSquared);
 
     CUDA_DEV bool passPT5RPhiChiSquaredCuts(struct modules& modulesInGPU, unsigned int lowerModuleIndex1, unsigned int lowerModuleIndex2, unsigned int lowerModuleIndex3, unsigned int lowerModuleIndex4, unsigned int lowerModuleIndex5, float rPhiChiSquared);
-
+    CUDA_DEV void computeSigmasForRegression_pT5(SDL::modules& modulesInGPU, const unsigned int* lowerModuleIndices, float* delta1, float* delta2, float* slopes, bool* isFlat, int nPoints = 5, bool anchorHits = true);
 
 
 }

--- a/SDL/PixelTracklet.cuh
+++ b/SDL/PixelTracklet.cuh
@@ -94,7 +94,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
 
     unsigned int innerOuterAnchorHitIndex = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerSegmentIndex];
     unsigned int outerOuterAnchorHitIndex= segmentsInGPU.outerMiniDoubletAnchorHitIndices[outerSegmentIndex];
-    if(fabsf(deltaPhi(hitsInGPU.xs[innerOuterAnchorHitIndex], hitsInGPU.ys[innerOuterAnchorHitIndex], hitsInGPU.zs[innerOuterAnchorHitIndex], hitsInGPU.xs[outerInnerAnchorHitIndex], hitsInGPU.ys[outerInnerAnchorHitIndex], hitsInGPU.zs[outerInnerAnchorHitIndex])) > M_PI/2.)
+    if(fabsf(deltaPhi(hitsInGPU.xs[innerOuterAnchorHitIndex], hitsInGPU.ys[innerOuterAnchorHitIndex], hitsInGPU.zs[innerOuterAnchorHitIndex], hitsInGPU.xs[outerInnerAnchorHitIndex], hitsInGPU.ys[outerInnerAnchorHitIndex], hitsInGPU.zs[outerInnerAnchorHitIndex])) > 0.5f*float(M_PI))
     {
         pass = false;
     }
@@ -139,14 +139,14 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     const float coshEta = sqrtf(ptIn * ptIn + pz * pz) / ptIn;
     // const float drt_OutLo_InLo = (rt_OutLo - rt_InLo);
     const float drt_OutLo_InUp = (rt_OutLo - rt_InUp);
-    const float invRt_InLo = 1. / rt_InLo;
+    const float invRt_InLo = 1.f / rt_InLo;
     const float r3_InLo = sqrtf(z_InLo * z_InLo + rt_InLo * rt_InLo);
     const float r3_InUp = sqrtf(z_InUp * z_InUp + rt_InUp * rt_InUp);
     float drt_InSeg = hitsInGPU.rts[innerOuterAnchorHitIndex] - hitsInGPU.rts[innerInnerAnchorHitIndex];
     float dz_InSeg = hitsInGPU.zs[innerOuterAnchorHitIndex] - hitsInGPU.zs[innerInnerAnchorHitIndex];
 
     float dr3_InSeg = sqrtf(hitsInGPU.rts[innerOuterAnchorHitIndex] * hitsInGPU.rts[innerOuterAnchorHitIndex] + hitsInGPU.zs[innerOuterAnchorHitIndex] * hitsInGPU.zs[innerOuterAnchorHitIndex]) - sqrtf(hitsInGPU.rts[innerInnerAnchorHitIndex] * hitsInGPU.rts[innerInnerAnchorHitIndex] + hitsInGPU.zs[innerInnerAnchorHitIndex] * hitsInGPU.zs[innerInnerAnchorHitIndex]);
-    const float sdlThetaMulsF = 0.015f * sqrt(0.1f + 0.2 * (rt_OutLo - rt_InUp) / 50.f) * sqrt(r3_InUp / rt_InUp);
+    const float sdlThetaMulsF = 0.015f * sqrt(0.1f + 0.2f * (rt_OutLo - rt_InUp) / 50.f) * sqrt(r3_InUp / rt_InUp);
     const float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; // will need a better guess than x4?
 
     float dzErr = drt_OutLo_InUp*etaErr*coshEta; //FIXME: check with the calc in the endcap
@@ -308,7 +308,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     const float pt_betaOut = drt_tl_axis * k2Rinv1GeVf / sin(betaOut);
     const float dBetaRes = 0.02f / fminf(sdOut_d, drt_InSeg);
     const float dBetaCut2 = (dBetaRes*dBetaRes * 2.0f + dBetaMuls * dBetaMuls + dBetaLum2 + dBetaRIn2 + dBetaROut2
-            + 0.25 * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
+            + 0.25f * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
     float dBeta = betaIn - betaOut;
     deltaBetaCut = sqrtf(dBetaCut2);
     if (not (dBeta * dBeta <= dBetaCut2))
@@ -390,7 +390,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
     const float coshEta = hypotf(ptIn, pz) / ptIn;
     const float multDzDr = dzOutInAbs*coshEta/(coshEta*coshEta - 1.f);
     const float r3_InUp = sqrtf(z_InUp * z_InUp + rt_InUp * rt_InUp);
-    const float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2 * (rt_OutLo - rtIn) / 50.f) * sqrtf(r3_InUp / rtIn);
+    const float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2f * (rt_OutLo - rtIn) / 50.f) * sqrtf(r3_InUp / rtIn);
     const float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; // will need a better guess than x4?
 
     float drtErr = etaErr*multDzDr;
@@ -556,7 +556,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
 
     const float dBetaRes = 0.02f / fminf(sdOut_d, drt_InSeg);
     const float dBetaCut2 = (dBetaRes*dBetaRes * 2.0f + dBetaMuls * dBetaMuls + dBetaLum2 + dBetaRIn2 + dBetaROut2
-            + 0.25 * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
+            + 0.25f * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
     float dBeta = betaIn - betaOut;
     deltaBetaCut = sqrtf(dBetaCut2);
     if (not (dBeta * dBeta <= dBetaCut2))

--- a/SDL/PixelTriplet.cu
+++ b/SDL/PixelTriplet.cu
@@ -184,7 +184,7 @@ __device__ float SDL::computeRadiusFromThreeAnchorHitspT3(float x1, float y1, fl
     }
     */
 
-    float denomInv = 1.0/((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3));
+    float denomInv = 1.f/((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3));
 
     float xy1sqr = x1 * x1 + y1 * y1;
 
@@ -192,9 +192,9 @@ __device__ float SDL::computeRadiusFromThreeAnchorHitspT3(float x1, float y1, fl
 
     float xy3sqr = x3 * x3 + y3 * y3;
 
-    g = 0.5 * ((y3 - y2) * xy1sqr + (y1 - y3) * xy2sqr + (y2 - y1) * xy3sqr) * denomInv;
+    g = 0.5f * ((y3 - y2) * xy1sqr + (y1 - y3) * xy2sqr + (y2 - y1) * xy3sqr) * denomInv;
 
-    f = 0.5 * ((x2 - x3) * xy1sqr + (x3 - x1) * xy2sqr + (x1 - x2) * xy3sqr) * denomInv;
+    f = 0.5f * ((x2 - x3) * xy1sqr + (x3 - x1) * xy2sqr + (x1 - x2) * xy3sqr) * denomInv;
 
     float c = ((x2 * y3 - x3 * y2) * xy1sqr + (x3 * y1 - x1 * y3) * xy2sqr + (x1 * y2 - x2 * y1) * xy3sqr) * denomInv;
 
@@ -246,8 +246,8 @@ __device__ bool SDL::runPixelTripletDefaultAlgo(struct modules& modulesInGPU, st
     unsigned int pixelAnchorHitIndex2 = mdsInGPU.hitIndices[2 * pixelOuterMDIndex];
     unsigned int pixelNonAnchorHitIndex2 = mdsInGPU.hitIndices[2 * pixelOuterMDIndex + 1];
 
-    pixelRadius = pixelSegmentPt/(2 * k2Rinv1GeVf);
-    pixelRadiusError = pixelSegmentPtError/(2 * k2Rinv1GeVf);
+    pixelRadius = pixelSegmentPt/(2.f * k2Rinv1GeVf);
+    pixelRadiusError = pixelSegmentPtError/(2.f * k2Rinv1GeVf);
     unsigned int tripletInnerSegmentIndex = tripletsInGPU.segmentIndices[2 * tripletIndex];
     unsigned int tripletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * tripletIndex + 1];
 
@@ -278,7 +278,7 @@ __device__ bool SDL::runPixelTripletDefaultAlgo(struct modules& modulesInGPU, st
 
     rPhiChiSquaredInwards = computePT3RPhiChiSquaredInwards(modulesInGPU, hitsInGPU, tripletRadius, g, f, pixelAnchorHits);
 
-    if(runChiSquaredCuts and pixelSegmentPt < 5.0)
+    if(runChiSquaredCuts and pixelSegmentPt < 5.0f)
     {
         pass = pass & passPT3RZChiSquaredCuts(modulesInGPU, lowerModuleIndex, middleModuleIndex, upperModuleIndex, rzChiSquared);
         pass = pass & passPT3RPhiChiSquaredCuts(modulesInGPU, lowerModuleIndex, middleModuleIndex, upperModuleIndex, rPhiChiSquared);
@@ -299,51 +299,51 @@ __device__ bool SDL::passPT3RPhiChiSquaredInwardsCuts(struct modules& modulesInG
     
     if(layer1 == 7 and layer2 == 8 and layer3 == 9)
     {
-        return chiSquared < 22016.8055;
+        return chiSquared < 22016.8055f;
     }
     else if(layer1 == 7 and layer2 == 8 and layer3 == 14)
     {
-        return chiSquared < 935179.56807;
+        return chiSquared < 935179.56807f;
     }
     else if(layer1 == 8 and layer2 == 9 and layer3 == 10)
     {
-        return chiSquared < 29064.12959;
+        return chiSquared < 29064.12959f;
     }
     else if(layer1 == 8 and layer2 == 9 and layer3 == 15)
     {
-        return chiSquared < 935179.5681;
+        return chiSquared < 935179.5681f;
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 3)
     {
-        return chiSquared < 1370.0113195101474;
+        return chiSquared < 1370.0113195101474f;
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 7)
     {
-        return chiSquared < 5492.110048314815;
+        return chiSquared < 5492.110048314815f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 4)
     {
-        return chiSquared < 4160.410806470067;
+        return chiSquared < 4160.410806470067f;
     }
     else if(layer1 == 1 and layer2 == 7 and layer3 == 8)
     {
-        return chiSquared < 29064.129591225726;
+        return chiSquared < 29064.129591225726f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 7)
     {
-        return chiSquared < 12634.215376250893;
+        return chiSquared < 12634.215376250893f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 12)
     {
-        return chiSquared < 353821.69361145404;
+        return chiSquared < 353821.69361145404f;
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 8)
     {
-        return chiSquared < 33393.26076341235;
+        return chiSquared < 33393.26076341235f;
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 13)
     {
-        return chiSquared < 935179.5680742573;
+        return chiSquared < 935179.5680742573f;
     }
 
     return true;
@@ -360,7 +360,8 @@ __device__ float SDL::computePT3RPhiChiSquaredInwards(struct modules& modulesInG
         float residual = (x - g) * (x -g) + (y - f) * (y - f) - r * r;
         chiSquared += residual * residual;
     }
-    chiSquared /= 2;
+    //chiSquared /= 2;
+    chiSquared *= 0.5f;
     return chiSquared;
 }
 
@@ -372,56 +373,56 @@ __device__ bool SDL::passPT3RZChiSquaredCuts(struct modules& modulesInGPU, unsig
 
     if(layer1 == 8 and layer2 == 9 and layer3 == 10)
     {
-        return rzChiSquared < 85.2499;
+        return rzChiSquared < 85.2499f;
     }
     else if(layer1 == 8 and layer2 == 9 and layer3 == 15)
     {
-        return rzChiSquared < 85.2499;
+        return rzChiSquared < 85.2499f;
     }
 
     else if(layer1 == 7 and layer2 == 8 and layer3 == 9)
     {
-        return rzChiSquared < 74.19805;
+        return rzChiSquared < 74.19805f;
     }
     else if(layer1 == 7 and layer2 == 8 and layer3 == 14)
     {
-        return rzChiSquared < 97.9479;
+        return rzChiSquared < 97.9479f;
     }
 
     else if(layer1 == 1 and layer2 == 2 and layer3 == 3)
     {
-        return rzChiSquared < 451.1407;;
+        return rzChiSquared < 451.1407f;
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 7)
     {
-        return rzChiSquared < 595.546;
+        return rzChiSquared < 595.546f;
     }
 
     else if(layer1 == 1 and layer2 == 7 and layer3 == 8)
     {
-        return rzChiSquared < 518.339;
+        return rzChiSquared < 518.339f;
     }
 
     else if(layer1 == 2 and layer2 == 3 and layer3 == 7)
     {
-        return rzChiSquared < 684.253;
+        return rzChiSquared < 684.253f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 12)
     {
-        return rzChiSquared < 684.253;
+        return rzChiSquared < 684.253f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 4)
     {
-        return rzChiSquared  < 392.654;
+        return rzChiSquared  < 392.654f;
     }
 
     else if(layer1 == 2 and layer2 == 7 and layer3 == 8)
     {
-        return rzChiSquared < 518.339;
+        return rzChiSquared < 518.339f;
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 13)
     {
-        return rzChiSquared < 518.339;
+        return rzChiSquared < 518.339f;
     }
 
     //default - category not found!
@@ -458,11 +459,11 @@ __device__ float SDL::computePT3RZChiSquared(struct modules& modulesInGPU, struc
         //PS Modules
         if(moduleType == 0)
         {
-            error = 0.15;
+            error = 0.15f;
         }
         else //2S modules
         {
-            error = 5.0;
+            error = 5.0f;
         }
 
         //special dispensation to tilted PS modules!
@@ -477,12 +478,12 @@ __device__ float SDL::computePT3RZChiSquared(struct modules& modulesInGPU, struc
                 drdz = modulesInGPU.drdzs[modulesInGPU.partnerModuleIndex(lowerModuleIndex)];
             }
 
-            error *= 1/sqrtf(1 + drdz * drdz);
+            error /= sqrtf(1 + drdz * drdz);
         }
         RMSE += (residual * residual)/(error * error);
     }
 
-    RMSE = sqrtf(0.2 * RMSE); //the constant doesn't really matter....
+    RMSE = sqrtf(0.2f * RMSE); //the constant doesn't really matter....
     return RMSE;
 }
 
@@ -501,9 +502,9 @@ __device__ float SDL::computePT3RPhiChiSquared(struct modules& modulesInGPU, str
     short moduleSubdet, moduleSide;
     ModuleLayerType moduleLayerType;
     float drdz;
-    float inv1 = 0.01/0.009;
-    float inv2 = 0.15/0.009;
-    float inv3 = 2.4/0.009;
+    float inv1 = 0.01f/0.009f;
+    float inv2 = 0.15f/0.009f;
+    float inv3 = 2.4f/0.009f;
     for(size_t i = 0; i < 3; i++)
     {
         xs[i] = hitsInGPU.xs[anchorHits[i]];
@@ -610,8 +611,8 @@ __device__ float SDL::computePT3RPhiChiSquared(struct modules& modulesInGPU, str
     // this for loop is kept to keep the physics results the same but I think this is a bug in the original code. This was kept at 5 and not nPoints
     for(size_t i = 3; i < 5; i++)
     {
-        delta1[i] /= 0.009;
-        delta2[i] /= 0.009;
+        delta1[i] /= 0.009f;
+        delta2[i] /= 0.009f;
     }
     chiSquared = computeChiSquared(3, xs, ys, delta1, delta2, slopes, isFlat, g, f, radius);
     
@@ -629,54 +630,54 @@ __device__ bool SDL::passPT3RPhiChiSquaredCuts(struct modules& modulesInGPU, uns
 
     if(layer1 == 8 and layer2 == 9 and layer3 == 10)
     {
-        return chiSquared < 7.003;
+        return chiSquared < 7.003f;
     }
     else if(layer1 == 8 and layer2 == 9 and layer3 == 15)
     {
-        return chiSquared < 0.5;
+        return chiSquared < 0.5f;
     }
 
     else if(layer1 == 7 and layer2 == 8 and layer3 == 9)
     {
-        return chiSquared < 8.046;
+        return chiSquared < 8.046f;
     }
     else if(layer1 == 7 and layer2 == 8 and layer3 == 14)
     {
-        return chiSquared < 0.575;
+        return chiSquared < 0.575f;
     }
 
     else if(layer1 == 1 and layer2 == 2 and layer3 == 7)
     {
-        return chiSquared < 5.304;
+        return chiSquared < 5.304f;
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 3)
     {
-        return chiSquared < 10.6211;
+        return chiSquared < 10.6211f;
     }
     else if(layer1 == 1 and layer2 == 7 and layer3 == 8)
     {
-        return chiSquared < 4.617;
+        return chiSquared < 4.617f;
     }
 
     else if(layer1 == 2 and layer2 == 7 and layer3 == 8)
     {
-        return chiSquared < 8.046;
+        return chiSquared < 8.046f;
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 13)
     {
-        return chiSquared < 0.435;
+        return chiSquared < 0.435f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 7)
     {
-        return chiSquared < 9.244;
+        return chiSquared < 9.244f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 12)
     {
-        return chiSquared < 0.287;
+        return chiSquared < 0.287f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 4)
     {
-        return chiSquared < 18.509;
+        return chiSquared < 18.509f;
     }
 
     return true;
@@ -708,13 +709,13 @@ __device__ bool SDL::passRadiusCriterion(struct modules& modulesInGPU, float& pi
 /*bounds for high Pt taken from : http://uaf-10.t2.ucsd.edu/~bsathian/SDL/T5_efficiency/efficiencies/new_efficiencies/efficiencies_20210513_T5_recovering_high_Pt_efficiencies/highE_radius_matching/highE_bounds.txt */
 __device__ bool SDL::passRadiusCriterionBBB(float& pixelRadius, float& pixelRadiusError, float& tripletRadius)
 {
-    float tripletInvRadiusErrorBound = 0.15624;
-    float pixelInvRadiusErrorBound = 0.17235;
+    float tripletInvRadiusErrorBound = 0.15624f;
+    float pixelInvRadiusErrorBound = 0.17235f;
 
-    if(pixelRadius > 2.0/(2 * k2Rinv1GeVf))
+    if(pixelRadius > 2.0f/(2.f * k2Rinv1GeVf))
     {
-        pixelInvRadiusErrorBound = 0.6375;
-        tripletInvRadiusErrorBound = 0.6588;
+        pixelInvRadiusErrorBound = 0.6375f;
+        tripletInvRadiusErrorBound = 0.6588f;
     }
 
     float tripletRadiusInvMax = (1 + tripletInvRadiusErrorBound)/tripletRadius;
@@ -728,13 +729,13 @@ __device__ bool SDL::passRadiusCriterionBBB(float& pixelRadius, float& pixelRadi
 
 __device__ bool SDL::passRadiusCriterionBBE(float& pixelRadius, float& pixelRadiusError, float& tripletRadius)
 {
-    float tripletInvRadiusErrorBound = 0.45972;
-    float pixelInvRadiusErrorBound = 0.19644;
+    float tripletInvRadiusErrorBound = 0.45972f;
+    float pixelInvRadiusErrorBound = 0.19644f;
 
-    if(pixelRadius > 2.0/(2 * k2Rinv1GeVf))
+    if(pixelRadius > 2.0f/(2 * k2Rinv1GeVf))
     {
-        pixelInvRadiusErrorBound = 0.6805;
-        tripletInvRadiusErrorBound = 0.8557;
+        pixelInvRadiusErrorBound = 0.6805f;
+        tripletInvRadiusErrorBound = 0.8557f;
     }
 
     float tripletRadiusInvMax = (1 + tripletInvRadiusErrorBound)/tripletRadius;
@@ -749,13 +750,13 @@ __device__ bool SDL::passRadiusCriterionBBE(float& pixelRadius, float& pixelRadi
 
 __device__ bool SDL::passRadiusCriterionBEE(float& pixelRadius, float& pixelRadiusError, float& tripletRadius)
 {
-    float tripletInvRadiusErrorBound = 1.59294;
-    float pixelInvRadiusErrorBound = 0.255181;
+    float tripletInvRadiusErrorBound = 1.59294f;
+    float pixelInvRadiusErrorBound = 0.255181f;
 
-    if(pixelRadius > 2.0/(2 * k2Rinv1GeVf)) //as good as not having selections
+    if(pixelRadius > 2.0f/(2 * k2Rinv1GeVf)) //as good as not having selections
     {
-        pixelInvRadiusErrorBound = 2.2091;
-        tripletInvRadiusErrorBound = 2.3548;
+        pixelInvRadiusErrorBound = 2.2091f;
+        tripletInvRadiusErrorBound = 2.3548f;
     }
 
     float tripletRadiusInvMax = (1 + tripletInvRadiusErrorBound)/tripletRadius;
@@ -771,13 +772,13 @@ __device__ bool SDL::passRadiusCriterionBEE(float& pixelRadius, float& pixelRadi
 
 __device__ bool SDL::passRadiusCriterionEEE(float& pixelRadius, float& pixelRadiusError, float& tripletRadius)
 {
-    float tripletInvRadiusErrorBound = 1.7006;
-    float pixelInvRadiusErrorBound = 0.26367;
+    float tripletInvRadiusErrorBound = 1.7006f;
+    float pixelInvRadiusErrorBound = 0.26367f;
 
-    if(pixelRadius > 2.0/(2 * k2Rinv1GeVf)) //as good as not having selections
+    if(pixelRadius > 2.0f/(2 * k2Rinv1GeVf)) //as good as not having selections
     {
-        pixelInvRadiusErrorBound = 2.286;
-        tripletInvRadiusErrorBound = 2.436;
+        pixelInvRadiusErrorBound = 2.286f;
+        tripletInvRadiusErrorBound = 2.436f;
     }
 
     float tripletRadiusInvMax = (1 + tripletInvRadiusErrorBound)/tripletRadius;

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -725,8 +725,8 @@ __device__ bool SDL::passT5RZConstraint(struct SDL::modules& modulesInGPU, struc
 
     // creating a chi squared type quantity
     // 0-> PS, 1->2S
-    residual4 = (moduleLayer4 == 0) ? residual4/2.4 : residual4/5.0;
-    residual5 = (moduleLayer5 == 0) ? residual5/2.4 : residual5/5.0;
+    residual4 = (moduleLayer4 == 0) ? residual4/2.4f : residual4/5.0f;
+    residual5 = (moduleLayer5 == 0) ? residual5/2.4f : residual5/5.0f;
 
     const float RMSE = sqrtf(0.5 * (residual4 * residual4 + residual5 * residual5));
 
@@ -735,106 +735,106 @@ __device__ bool SDL::passT5RZConstraint(struct SDL::modules& modulesInGPU, struc
     {
         if(layer4 == 4 and layer5 == 5)
         {
-            return RMSE < 0.545; 
+            return RMSE < 0.545f; 
         }
         else if(layer4 == 4 and layer5 == 12)
         {
-            return RMSE < 1.105;
+            return RMSE < 1.105f;
         }
         else if(layer4 == 7 and layer5 == 13)
         {
-            return RMSE < 0.775;
+            return RMSE < 0.775f;
         }
         else if(layer4 == 12 and layer5 == 13)
         {
-            return RMSE < 0.625;
+            return RMSE < 0.625f;
         }
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 7)
     {
         if(layer4 == 8 and layer5 == 14)
         {
-            return RMSE < 0.835;
+            return RMSE < 0.835f;
         }
         else if(layer4 == 13 and layer5 == 14)
         {
-            return RMSE < 0.575;
+            return RMSE < 0.575f;
         }
     }
     else if(layer1 == 1 and layer2 == 7 and layer3 == 8 and layer4 == 9 and layer5 == 15)
     {
-        return RMSE < 0.825;
+        return RMSE < 0.825f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 4)
     {
         if(layer4 == 5 and layer5 == 6)
         {
-            return RMSE < 0.845;
+            return RMSE < 0.845f;
         }
         else if(layer4 == 5 and layer5 == 12)
         {
-            return RMSE < 1.365;
+            return RMSE < 1.365f;
         }
 
         else if(layer4 == 12 and layer5 == 13)
         {
-            return RMSE < 0.675;
+            return RMSE < 0.675f;
         }
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 7 and layer4 == 13 and layer5 == 14)
     {
-            return RMSE < 0.495;
+            return RMSE < 0.495f;
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 12 and layer4 == 13 and layer5 == 14)
     {
-        return RMSE < 0.695; 
+        return RMSE < 0.695f; 
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 8)
     {
         if(layer4 == 9 and layer5 == 15)
         {
-            return RMSE < 0.735;
+            return RMSE < 0.735f;
         }
         else if(layer4 == 14 and layer5 == 15)
         {
-            return RMSE < 0.525;
+            return RMSE < 0.525f;
         }
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 13 and layer4 == 14 and layer5 == 15)
     {
-        return RMSE < 0.665;
+        return RMSE < 0.665f;
     }
     else if(layer1 == 3 and layer2 == 4 and layer3 == 5 and layer4 == 12 and layer5 == 13)
     {
-        return RMSE < 0.995;
+        return RMSE < 0.995f;
     }
     else if(layer1 == 3 and layer2 == 4 and layer3 == 12 and layer4 == 13 and layer5 == 14)
     {
-        return RMSE < 0.525;
+        return RMSE < 0.525f;
     }
     else if(layer1 == 3 and layer2 == 7 and layer3 == 8 and layer4 == 14 and layer5 == 15)
     {
-        return RMSE < 0.525;
+        return RMSE < 0.525f;
     }
     else if(layer1 == 3 and layer2 == 7 and layer3 == 13 and layer4 == 14 and layer5 == 15)
     {
-        return RMSE < 0.745;
+        return RMSE < 0.745f;
     }
     else if(layer1 == 3 and layer2 == 12 and layer3 == 13 and layer4 == 14 and layer5 == 15)
     {
-        return RMSE < 0.555; 
+        return RMSE < 0.555f; 
     }
     else if(layer1 == 7 and layer2 == 8 and layer3 == 9 and layer4 == 15 and layer5 == 16)
     {
-            return RMSE < 0.525;
+            return RMSE < 0.525f;
     }
     else if(layer1 == 7 and layer2 == 8 and layer3 == 14 and layer4 == 15 and layer5 == 16)
     {
-        return RMSE < 0.885;
+        return RMSE < 0.885f;
     }
     else if(layer1 == 7 and layer2 == 13 and layer3 == 14 and layer4 == 15 and layer5 == 16)
     {
-        return RMSE < 0.845;
+        return RMSE < 0.845f;
     }
 
     return true;
@@ -849,217 +849,217 @@ __device__ bool SDL::checkIntervalOverlap(const float& firstMin, const float& fi
 
 __device__ bool SDL::matchRadiiBBBBB(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax)
 {
-    float innerInvRadiusErrorBound =  0.1512;
-    float bridgeInvRadiusErrorBound = 0.1781;
-    float outerInvRadiusErrorBound = 0.1840;
+    float innerInvRadiusErrorBound =  0.1512f;
+    float bridgeInvRadiusErrorBound = 0.1781f;
+    float outerInvRadiusErrorBound = 0.1840f;
 
-    if(innerRadius > 2.0/(2 * k2Rinv1GeVf))
+    if(innerRadius > 2.0f/(2.f * k2Rinv1GeVf))
     {
-        innerInvRadiusErrorBound = 0.4449;
-        bridgeInvRadiusErrorBound = 0.4033;
-        outerInvRadiusErrorBound = 0.8016;
+        innerInvRadiusErrorBound = 0.4449f;
+        bridgeInvRadiusErrorBound = 0.4033f;
+        outerInvRadiusErrorBound = 0.8016f;
     }
 
-    innerRadiusMin = innerRadius/(1 + innerInvRadiusErrorBound);
-    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1 - innerInvRadiusErrorBound) : 123456789.f;
+    innerRadiusMin = innerRadius/(1.f + innerInvRadiusErrorBound);
+    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1.f - innerInvRadiusErrorBound) : 123456789.f;
 
-    bridgeRadiusMin = bridgeRadius/(1 + bridgeInvRadiusErrorBound);
-    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1 - bridgeInvRadiusErrorBound) : 123456789.f;
+    bridgeRadiusMin = bridgeRadius/(1.f + bridgeInvRadiusErrorBound);
+    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1.f - bridgeInvRadiusErrorBound) : 123456789.f;
 
-    outerRadiusMin = outerRadius/(1 + outerInvRadiusErrorBound);
-    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1 - outerInvRadiusErrorBound) : 123456789.f;
+    outerRadiusMin = outerRadius/(1.f + outerInvRadiusErrorBound);
+    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1.f - outerInvRadiusErrorBound) : 123456789.f;
 
-    return checkIntervalOverlap(1.0/innerRadiusMax, 1.0/innerRadiusMin, 1.0/bridgeRadiusMax, 1.0/bridgeRadiusMin);
+    return checkIntervalOverlap(1.0f/innerRadiusMax, 1.0f/innerRadiusMin, 1.0f/bridgeRadiusMax, 1.0f/bridgeRadiusMin);
 }
 
 __device__ bool SDL::matchRadiiBBBBE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax)
 {
 
-    float innerInvRadiusErrorBound =  0.1781;
-    float bridgeInvRadiusErrorBound = 0.2167;
-    float outerInvRadiusErrorBound = 1.1116;
+    float innerInvRadiusErrorBound =  0.1781f;
+    float bridgeInvRadiusErrorBound = 0.2167f;
+    float outerInvRadiusErrorBound = 1.1116f;
 
-    if(innerRadius > 2.0/(2 * k2Rinv1GeVf))
+    if(innerRadius > 2.0f/(2.f * k2Rinv1GeVf))
     {
-        innerInvRadiusErrorBound = 0.4750;
-        bridgeInvRadiusErrorBound = 0.3903;
-        outerInvRadiusErrorBound = 15.2120;
+        innerInvRadiusErrorBound = 0.4750f;
+        bridgeInvRadiusErrorBound = 0.3903f;
+        outerInvRadiusErrorBound = 15.2120f;
     }
 
 
-    innerRadiusMin = innerRadius/(1 + innerInvRadiusErrorBound);
-    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1 - innerInvRadiusErrorBound) : 123456789.f; //large number signifying infty
+    innerRadiusMin = innerRadius/(1.f + innerInvRadiusErrorBound);
+    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1.f - innerInvRadiusErrorBound) : 123456789.f; //large number signifying infty
 
-    bridgeRadiusMin = bridgeRadius/(1 + bridgeInvRadiusErrorBound);
-    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1 - bridgeInvRadiusErrorBound) : 123456789.f;
+    bridgeRadiusMin = bridgeRadius/(1.f + bridgeInvRadiusErrorBound);
+    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1.f - bridgeInvRadiusErrorBound) : 123456789.f;
 
-    outerRadiusMin = outerRadius/(1 + outerInvRadiusErrorBound);
-    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1 - outerInvRadiusErrorBound) : 123456789.f;
+    outerRadiusMin = outerRadius/(1.f + outerInvRadiusErrorBound);
+    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1.f - outerInvRadiusErrorBound) : 123456789.f;
 
-    return checkIntervalOverlap(1.0/innerRadiusMax, 1.0/innerRadiusMin, 1.0/bridgeRadiusMax, 1.0/bridgeRadiusMin);
+    return checkIntervalOverlap(1.0f/innerRadiusMax, 1.0f/innerRadiusMin, 1.0f/bridgeRadiusMax, 1.0f/bridgeRadiusMin);
 }
 
 __device__ bool SDL::matchRadiiBBBEE12378(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax)
 {
-    float innerInvRadiusErrorBound = 0.178;
-    float bridgeInvRadiusErrorBound = 0.507;
-    float outerInvRadiusErrorBound = 7.655;
+    float innerInvRadiusErrorBound = 0.178f;
+    float bridgeInvRadiusErrorBound = 0.507f;
+    float outerInvRadiusErrorBound = 7.655f;
 
-    innerRadiusMin = innerRadius/(1 + innerInvRadiusErrorBound);
-    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1 - innerInvRadiusErrorBound) : 123456789.f;
+    innerRadiusMin = innerRadius/(1.f + innerInvRadiusErrorBound);
+    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1.f - innerInvRadiusErrorBound) : 123456789.f;
 
-    bridgeRadiusMin = bridgeRadius/(1 + bridgeInvRadiusErrorBound);
-    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1 - bridgeInvRadiusErrorBound) : 123456789.f;
+    bridgeRadiusMin = bridgeRadius/(1.f + bridgeInvRadiusErrorBound);
+    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1.f - bridgeInvRadiusErrorBound) : 123456789.f;
 
-    outerRadiusMin = outerRadius/(1 + outerInvRadiusErrorBound);
-    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1 - outerInvRadiusErrorBound) : 123456789.f;
+    outerRadiusMin = outerRadius/(1.f + outerInvRadiusErrorBound);
+    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1.f - outerInvRadiusErrorBound) : 123456789.f;
 
-    return checkIntervalOverlap(1.0/innerRadiusMax, 1.0/innerRadiusMin, 1.0/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S),1.0/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
+    return checkIntervalOverlap(1.0f/innerRadiusMax, 1.0f/innerRadiusMin, 1.0f/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S),1.0f/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
 }
 
 __device__ bool SDL::matchRadiiBBBEE23478(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax)
 {
-    float innerInvRadiusErrorBound = 0.2097;
-    float bridgeInvRadiusErrorBound = 0.8557;
-    float outerInvRadiusErrorBound = 24.0450;
+    float innerInvRadiusErrorBound = 0.2097f;
+    float bridgeInvRadiusErrorBound = 0.8557f;
+    float outerInvRadiusErrorBound = 24.0450f;
 
-    innerRadiusMin = innerRadius/(1 + innerInvRadiusErrorBound);
-    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1 - innerInvRadiusErrorBound) : 123456789.f;
+    innerRadiusMin = innerRadius/(1.f + innerInvRadiusErrorBound);
+    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1.f - innerInvRadiusErrorBound) : 123456789.f;
 
-    bridgeRadiusMin = bridgeRadius/(1 + bridgeInvRadiusErrorBound);
-    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1 - bridgeInvRadiusErrorBound) : 123456789.f;
+    bridgeRadiusMin = bridgeRadius/(1.f + bridgeInvRadiusErrorBound);
+    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1.f - bridgeInvRadiusErrorBound) : 123456789.f;
 
-    outerRadiusMin = outerRadius/(1 + outerInvRadiusErrorBound);
-    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1 - outerInvRadiusErrorBound) : 123456789.f;
+    outerRadiusMin = outerRadius/(1.f + outerInvRadiusErrorBound);
+    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1.f - outerInvRadiusErrorBound) : 123456789.f;
 
-    return checkIntervalOverlap(1.0/innerRadiusMax, 1.0/innerRadiusMin, 1.0/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
+    return checkIntervalOverlap(1.0f/innerRadiusMax, 1.0f/innerRadiusMin, 1.0f/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0f/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
 
 }
 
 __device__ bool SDL::matchRadiiBBBEE34578(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax)
 {
-    float innerInvRadiusErrorBound = 0.066;
-    float bridgeInvRadiusErrorBound = 0.617;
-    float outerInvRadiusErrorBound = 2.688;
+    float innerInvRadiusErrorBound = 0.066f;
+    float bridgeInvRadiusErrorBound = 0.617f;
+    float outerInvRadiusErrorBound = 2.688f;
 
-    innerRadiusMin = innerRadius/(1 + innerInvRadiusErrorBound);
-    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1 - innerInvRadiusErrorBound) : 123456789.f;
+    innerRadiusMin = innerRadius/(1.f + innerInvRadiusErrorBound);
+    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1.f - innerInvRadiusErrorBound) : 123456789.f;
 
-    bridgeRadiusMin = bridgeRadius/(1 + bridgeInvRadiusErrorBound);
-    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1 - bridgeInvRadiusErrorBound) : 123456789.f;
+    bridgeRadiusMin = bridgeRadius/(1.f + bridgeInvRadiusErrorBound);
+    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1.f - bridgeInvRadiusErrorBound) : 123456789.f;
 
-    outerRadiusMin = outerRadius/(1 + outerInvRadiusErrorBound);
-    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1 - outerInvRadiusErrorBound) : 123456789.f;
+    outerRadiusMin = outerRadius/(1.f + outerInvRadiusErrorBound);
+    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1.f - outerInvRadiusErrorBound) : 123456789.f;
 
-    return checkIntervalOverlap(1.0/innerRadiusMax, 1.0/innerRadiusMin, 1.0/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
+    return checkIntervalOverlap(1.0f/innerRadiusMax, 1.0f/innerRadiusMin, 1.0f/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0f/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
 
 }
 
 __device__ bool SDL::matchRadiiBBBEE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax)
 {
 
-    float innerInvRadiusErrorBound =  0.1840;
-    float bridgeInvRadiusErrorBound = 0.5971;
-    float outerInvRadiusErrorBound = 11.7102;
+    float innerInvRadiusErrorBound =  0.1840f;
+    float bridgeInvRadiusErrorBound = 0.5971f;
+    float outerInvRadiusErrorBound = 11.7102f;
 
-    if(innerRadius > 2.0/(2 * k2Rinv1GeVf)) //as good as no selections
+    if(innerRadius > 2.0f/(2.f * k2Rinv1GeVf)) //as good as no selections
     {
-        innerInvRadiusErrorBound = 1.0412;
-        outerInvRadiusErrorBound = 32.2737;
-        bridgeInvRadiusErrorBound = 10.9688;
+        innerInvRadiusErrorBound = 1.0412f;
+        outerInvRadiusErrorBound = 32.2737f;
+        bridgeInvRadiusErrorBound = 10.9688f;
     }
 
-    innerRadiusMin = innerRadius/(1 + innerInvRadiusErrorBound);
-    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1 - innerInvRadiusErrorBound) : 123456789.f;
+    innerRadiusMin = innerRadius/(1.f + innerInvRadiusErrorBound);
+    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1.f - innerInvRadiusErrorBound) : 123456789.f;
 
-    bridgeRadiusMin = bridgeRadius/(1 + bridgeInvRadiusErrorBound);
-    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1 - bridgeInvRadiusErrorBound) : 123456789.f;
+    bridgeRadiusMin = bridgeRadius/(1.f + bridgeInvRadiusErrorBound);
+    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1.f - bridgeInvRadiusErrorBound) : 123456789.f;
 
-    outerRadiusMin = outerRadius/(1 + outerInvRadiusErrorBound);
-    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1 - outerInvRadiusErrorBound) : 123456789.f;
+    outerRadiusMin = outerRadius/(1.f + outerInvRadiusErrorBound);
+    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1.f - outerInvRadiusErrorBound) : 123456789.f;
 
-    return checkIntervalOverlap(1.0/innerRadiusMax, 1.0/innerRadiusMin, 1.0/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
+    return checkIntervalOverlap(1.0f/innerRadiusMax, 1.0f/innerRadiusMin, 1.0f/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0f/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
 
 }
 
 __device__ bool SDL::matchRadiiBBEEE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax)
 {
 
-    float innerInvRadiusErrorBound =  0.6376;
-    float bridgeInvRadiusErrorBound = 2.1381;
-    float outerInvRadiusErrorBound = 20.4179;
+    float innerInvRadiusErrorBound =  0.6376f;
+    float bridgeInvRadiusErrorBound = 2.1381f;
+    float outerInvRadiusErrorBound = 20.4179f;
 
-    if(innerRadius > 2.0/(2 * k2Rinv1GeVf)) //as good as no selections!
+    if(innerRadius > 2.0f/(2.f * k2Rinv1GeVf)) //as good as no selections!
     {
-        innerInvRadiusErrorBound = 12.9173;
-        outerInvRadiusErrorBound = 25.6702;
-        bridgeInvRadiusErrorBound = 5.1700;
+        innerInvRadiusErrorBound = 12.9173f;
+        outerInvRadiusErrorBound = 25.6702f;
+        bridgeInvRadiusErrorBound = 5.1700f;
     }
 
-    innerRadiusMin = innerRadius/(1 + innerInvRadiusErrorBound);
-    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1 - innerInvRadiusErrorBound) : 123456789.f;
+    innerRadiusMin = innerRadius/(1.f + innerInvRadiusErrorBound);
+    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1.f - innerInvRadiusErrorBound) : 123456789.f;
 
-    bridgeRadiusMin = bridgeRadius/(1 + bridgeInvRadiusErrorBound);
-    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1 - bridgeInvRadiusErrorBound) : 123456789.f;
+    bridgeRadiusMin = bridgeRadius/(1.f + bridgeInvRadiusErrorBound);
+    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1.f - bridgeInvRadiusErrorBound) : 123456789.f;
 
-    outerRadiusMin = outerRadius/(1 + outerInvRadiusErrorBound);
+    outerRadiusMin = outerRadius/(1.f + outerInvRadiusErrorBound);
     outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1 - outerInvRadiusErrorBound) : 123456789.f;
 
-    return checkIntervalOverlap(1.0/innerRadiusMax, 1.0/innerRadiusMin, 1.0/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
+    return checkIntervalOverlap(1.0f/innerRadiusMax, 1.0f/innerRadiusMin, 1.0f/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0f/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
 
 }
 
 __device__ bool SDL::matchRadiiBEEEE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax)
 {
 
-    float innerInvRadiusErrorBound =  1.9382;
-    float bridgeInvRadiusErrorBound = 3.7280;
-    float outerInvRadiusErrorBound = 5.7030;
+    float innerInvRadiusErrorBound =  1.9382f;
+    float bridgeInvRadiusErrorBound = 3.7280f;
+    float outerInvRadiusErrorBound = 5.7030f;
 
 
-    if(innerRadius > 2.0/(2 * k2Rinv1GeVf))
+    if(innerRadius > 2.0f/(2.f * k2Rinv1GeVf))
     {
-        innerInvRadiusErrorBound = 23.2713;
-        outerInvRadiusErrorBound = 24.0450;
-        bridgeInvRadiusErrorBound = 21.7980;
+        innerInvRadiusErrorBound = 23.2713f;
+        outerInvRadiusErrorBound = 24.0450f;
+        bridgeInvRadiusErrorBound = 21.7980f;
     }
 
-    innerRadiusMin = innerRadius/(1 + innerInvRadiusErrorBound);
-    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1 - innerInvRadiusErrorBound) : 123456789.f;
+    innerRadiusMin = innerRadius/(1.f + innerInvRadiusErrorBound);
+    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1.f - innerInvRadiusErrorBound) : 123456789.f;
 
-    bridgeRadiusMin = bridgeRadius/(1 + bridgeInvRadiusErrorBound);
-    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1 - bridgeInvRadiusErrorBound) : 123456789.f;
+    bridgeRadiusMin = bridgeRadius/(1.f + bridgeInvRadiusErrorBound);
+    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1.f - bridgeInvRadiusErrorBound) : 123456789.f;
 
-    outerRadiusMin = outerRadius/(1 + outerInvRadiusErrorBound);
-    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1 - outerInvRadiusErrorBound) : 123456789.f;
+    outerRadiusMin = outerRadius/(1.f + outerInvRadiusErrorBound);
+    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1.f - outerInvRadiusErrorBound) : 123456789.f;
 
-    return checkIntervalOverlap(1.0/fmaxf(innerRadiusMax, innerRadiusMax2S), 1.0/fminf(innerRadiusMin, innerRadiusMin2S), 1.0/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
+    return checkIntervalOverlap(1.0f/fmaxf(innerRadiusMax, innerRadiusMax2S), 1.0f/fminf(innerRadiusMin, innerRadiusMin2S), 1.0f/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0f/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
 
 }
 
 __device__ bool SDL::matchRadiiEEEEE(const float& innerRadius, const float& bridgeRadius, const float& outerRadius, const float& innerRadiusMin2S, const float& innerRadiusMax2S, const float& bridgeRadiusMin2S, const float& bridgeRadiusMax2S, const float& outerRadiusMin2S, const float& outerRadiusMax2S, float& innerRadiusMin, float& innerRadiusMax, float& bridgeRadiusMin, float& bridgeRadiusMax, float& outerRadiusMin, float& outerRadiusMax)
 {
-    float innerInvRadiusErrorBound =  1.9382;
-    float bridgeInvRadiusErrorBound = 2.2091;
-    float outerInvRadiusErrorBound = 7.4084;
+    float innerInvRadiusErrorBound =  1.9382f;
+    float bridgeInvRadiusErrorBound = 2.2091f;
+    float outerInvRadiusErrorBound = 7.4084f;
 
-    if(innerRadius > 2.0/(2 * k2Rinv1GeVf))
+    if(innerRadius > 2.0f/(2.f * k2Rinv1GeVf))
     {
-        innerInvRadiusErrorBound = 22.5226;
-        bridgeInvRadiusErrorBound = 21.0966;
-        outerInvRadiusErrorBound = 19.1252;
+        innerInvRadiusErrorBound = 22.5226f;
+        bridgeInvRadiusErrorBound = 21.0966f;
+        outerInvRadiusErrorBound = 19.1252f;
     }
 
-    innerRadiusMin = innerRadius/(1 + innerInvRadiusErrorBound);
-    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1 - innerInvRadiusErrorBound) : 123456789.f;
+    innerRadiusMin = innerRadius/(1.f + innerInvRadiusErrorBound);
+    innerRadiusMax = innerInvRadiusErrorBound < 1 ? innerRadius/(1.f - innerInvRadiusErrorBound) : 123456789.f;
 
-    bridgeRadiusMin = bridgeRadius/(1 + bridgeInvRadiusErrorBound);
-    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1 - bridgeInvRadiusErrorBound) : 123456789.f;
+    bridgeRadiusMin = bridgeRadius/(1.f + bridgeInvRadiusErrorBound);
+    bridgeRadiusMax = bridgeInvRadiusErrorBound < 1 ? bridgeRadius/(1.f - bridgeInvRadiusErrorBound) : 123456789.f;
 
-    outerRadiusMin = outerRadius/(1 + outerInvRadiusErrorBound);
-    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1 - outerInvRadiusErrorBound) : 123456789.f;
+    outerRadiusMin = outerRadius/(1.f + outerInvRadiusErrorBound);
+    outerRadiusMax = outerInvRadiusErrorBound < 1 ? outerRadius/(1.f - outerInvRadiusErrorBound) : 123456789.f;
 
-    return checkIntervalOverlap(1.0/fmaxf(innerRadiusMax, innerRadiusMax2S), 1.0/fminf(innerRadiusMin, innerRadiusMin2S), 1.0/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
+    return checkIntervalOverlap(1.0f/fmaxf(innerRadiusMax, innerRadiusMax2S), 1.0f/fminf(innerRadiusMin, innerRadiusMin2S), 1.0f/fmaxf(bridgeRadiusMax, bridgeRadiusMax2S), 1.0f/fminf(bridgeRadiusMin, bridgeRadiusMin2S));
 
 }
 
@@ -1069,7 +1069,7 @@ __device__ void SDL::computeErrorInRadius(float* x1Vec, float* y1Vec, float* x2V
     float candidateRadius;
     float g, f;
     minimumRadius = 123456789.f;
-    maximumRadius = 0;
+    maximumRadius = 0.f;
     for(size_t i = 0; i < 3; i++)
     {
         float x1 = x1Vec[i];
@@ -1091,7 +1091,7 @@ __device__ void SDL::computeErrorInRadius(float* x1Vec, float* y1Vec, float* x2V
 }
 __device__ float SDL::computeRadiusFromThreeAnchorHits(float x1, float y1, float x2, float y2, float x3, float y3, float& g, float& f)
 {
-    float radius = 0;
+    float radius = 0.f;
 
     //writing manual code for computing radius, which obviously sucks
     //TODO:Use fancy inbuilt libraries like cuBLAS or cuSOLVE for this!
@@ -1105,7 +1105,7 @@ __device__ float SDL::computeRadiusFromThreeAnchorHits(float x1, float y1, float
     }
     */
 
-    float denomInv = 1.0/((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3));
+    float denomInv = 1.0f/((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3));
 
     float xy1sqr = x1 * x1 + y1 * y1;
 
@@ -1113,16 +1113,16 @@ __device__ float SDL::computeRadiusFromThreeAnchorHits(float x1, float y1, float
 
     float xy3sqr = x3 * x3 + y3 * y3;
 
-    g = 0.5 * ((y3 - y2) * xy1sqr + (y1 - y3) * xy2sqr + (y2 - y1) * xy3sqr) * denomInv;
+    g = 0.5f * ((y3 - y2) * xy1sqr + (y1 - y3) * xy2sqr + (y2 - y1) * xy3sqr) * denomInv;
 
-    f = 0.5 * ((x2 - x3) * xy1sqr + (x3 - x1) * xy2sqr + (x1 - x2) * xy3sqr) * denomInv;
+    f = 0.5f * ((x2 - x3) * xy1sqr + (x3 - x1) * xy2sqr + (x1 - x2) * xy3sqr) * denomInv;
 
     float c = ((x2 * y3 - x3 * y2) * xy1sqr + (x3 * y1 - x1 * y3) * xy2sqr + (x1 * y2 - x2 * y1) * xy3sqr) * denomInv;
 
     if(((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3) == 0) || (g * g + f * f - c < 0))
     {
         printf("three collinear points or FATAL! r^2 < 0!\n");
-	radius = -1;
+	radius = -1.f;
     }
     else
       radius = sqrtf(g * g  + f * f - c);
@@ -1154,9 +1154,9 @@ __device__ void SDL::computeSigmasForRegression(SDL::modules& modulesInGPU, cons
     short moduleSubdet, moduleSide;
     ModuleLayerType moduleLayerType;
     float drdz;
-    float inv1 = 0.01/0.009;
-    float inv2 = 0.15/0.009;
-    float inv3 = 2.4/0.009;
+    float inv1 = 0.01f/0.009f;
+    float inv2 = 0.15f/0.009f;
+    float inv3 = 2.4f/0.009f;
     for(size_t i=0; i<nPoints; i++)
     {
         moduleType = modulesInGPU.moduleType[lowerModuleIndices[i]];
@@ -1170,7 +1170,7 @@ __device__ void SDL::computeSigmasForRegression(SDL::modules& modulesInGPU, cons
             //delta2[i] = 0.01;
             delta1[i] = inv1;//1.1111f;//0.01;
             delta2[i] = inv1;//1.1111f;//0.01;
-            slopes[i] = -999;
+            slopes[i] = -999.f;
             isFlat[i] = true;
         }
 
@@ -1179,9 +1179,9 @@ __device__ void SDL::computeSigmasForRegression(SDL::modules& modulesInGPU, cons
         {
             //delta1[i] = 0.009;
             //delta2[i] = 0.009;
-            delta1[i] = 1;//0.009;
-            delta2[i] = 1;//0.009;
-            slopes[i] = -999;
+            delta1[i] = 1.f;//0.009;
+            delta2[i] = 1.f;//0.009;
+            slopes[i] = -999.f;
             isFlat[i] = true;
         }
 
@@ -1254,8 +1254,8 @@ __device__ void SDL::computeSigmasForRegression(SDL::modules& modulesInGPU, cons
         {
             //delta1[i] = 0.009;
             //delta2[i] = 5.f;
-            delta1[i] = 1;//0.009;
-            delta2[i] = 500*inv1;//555.5555f;//5.f;
+            delta1[i] = 1.f;//0.009;
+            delta2[i] = 500.f*inv1;//555.5555f;//5.f;
             slopes[i] = modulesInGPU.slopes[lowerModuleIndices[i]];
             isFlat[i] = false;
         }
@@ -1274,7 +1274,7 @@ __device__ void SDL::computeSigmasForRegression(SDL::modules& modulesInGPU, cons
 
 __device__ float SDL::computeRadiusUsingRegression(int nPoints, float* xs, float* ys, float* delta1, float* delta2, float* slopes, bool* isFlat, float& g, float& f, float* sigmas, float& chiSquared)
 {
-    float radius = 0;
+    float radius = 0.f;
 
     //some extra variables
     //the two variables will be caled x1 and x2, and y (which is x^2 + y^2)
@@ -1295,23 +1295,23 @@ __device__ float SDL::computeRadiusUsingRegression(int nPoints, float* xs, float
         //computing sigmas is a very tricky affair
         //if the module is tilted or endcap, we need to use the slopes properly!
 
-        absArctanSlope = ((slopes[i] != 123456789) ? fabs(atanf(slopes[i])) : M_PI / 2); // Since C++ can't represent infinity, SDL_INF = 123456789 was used to represent infinity in the data table
+        absArctanSlope = ((slopes[i] != 123456789) ? fabs(atanf(slopes[i])) : 0.5f*float(M_PI)); // Since C++ can't represent infinity, SDL_INF = 123456789 was used to represent infinity in the data table
 
         if(xs[i] > 0 and ys[i] > 0)
         {
-            angleM = M_PI/2 - absArctanSlope;
+            angleM = 0.5f*float(M_PI) - absArctanSlope;
         }
         else if(xs[i] < 0 and ys[i] > 0)
         {
-            angleM = absArctanSlope + M_PI/2;
+            angleM = absArctanSlope + 0.5f*float(M_PI);
         }
         else if(xs[i] < 0 and ys[i] < 0)
         {
-            angleM = -(absArctanSlope + M_PI/2);
+            angleM = -(absArctanSlope + 0.5f*float(M_PI));
         }
         else if(xs[i] > 0 and ys[i] < 0)
         {
-            angleM = -(M_PI/2 - absArctanSlope);
+            angleM = -(0.5f*(M_PI) - absArctanSlope);
         }
 
         if(not isFlat[i])
@@ -1334,7 +1334,7 @@ __device__ float SDL::computeRadiusUsingRegression(int nPoints, float* xs, float
         sigmaY += (xs[i] * xs[i] + ys[i] * ys[i])/(sigmas[i] * sigmas[i]);
         sigmaX1 += xs[i]/(sigmas[i] * sigmas[i]);
         sigmaX2 += ys[i]/(sigmas[i] * sigmas[i]);
-        sigmaOne += 1.0/(sigmas[i] * sigmas[i]);
+        sigmaOne += 1.0f/(sigmas[i] * sigmas[i]);
     }
     float denominator = (sigmaX1X2 - sigmaX1 * sigmaX2) * (sigmaX1X2 - sigmaX1 * sigmaX2) - (sigmaX1Squared - sigmaX1 * sigmaX1) * (sigmaX2Squared - sigmaX2 * sigmaX2);
 
@@ -1342,8 +1342,8 @@ __device__ float SDL::computeRadiusUsingRegression(int nPoints, float* xs, float
     float twoF = ((sigmaX1y - sigmaX1 * sigmaY) * (sigmaX1X2 - sigmaX1 * sigmaX2) - (sigmaX2y - sigmaX2 * sigmaY) * (sigmaX1Squared - sigmaX1 * sigmaX1)) / denominator;
 
     float c = -(sigmaY - twoG * sigmaX1 - twoF * sigmaX2)/sigmaOne;
-    g = twoG/2;
-    f = twoF/2;
+    g = 0.5f*twoG;
+    f = 0.5f*twoF;
     if(g * g + f * f - c < 0)
     {
         printf("FATAL! r^2 < 0!\n");
@@ -1352,7 +1352,7 @@ __device__ float SDL::computeRadiusUsingRegression(int nPoints, float* xs, float
     
     radius = sqrtf(g * g  + f * f - c);
     //compute chi squared
-    chiSquared = 0;
+    chiSquared = 0.f;
     for(size_t i = 0; i < nPoints; i++)
     {
        chiSquared +=  (xs[i] * xs[i] + ys[i] * ys[i] - twoG * xs[i] - twoF * ys[i] + c) * (xs[i] * xs[i] + ys[i] * ys[i] - twoG * xs[i] - twoF * ys[i] + c) / (sigmas[i] * sigmas[i]);
@@ -1365,26 +1365,26 @@ __device__ float SDL::computeChiSquared(int nPoints, float* xs, float* ys, float
     // given values of (g, f, radius) and a set of points (and its uncertainties)
     //compute chi squared
     float c = g*g + f*f - radius*radius;
-    float chiSquared = 0;
+    float chiSquared = 0.f;
     float absArctanSlope, angleM, xPrime, yPrime, sigma;
     for(size_t i = 0; i < nPoints; i++)
     {
-        absArctanSlope = ((slopes[i] != 123456789) ? fabs(atanf(slopes[i])) : M_PI / 2); // Since C++ can't represent infinity, SDL_INF = 123456789 was used to represent infinity in the data table
+        absArctanSlope = ((slopes[i] != 123456789) ? fabs(atanf(slopes[i])) : 0.5f*float(M_PI)); // Since C++ can't represent infinity, SDL_INF = 123456789 was used to represent infinity in the data table
         if(xs[i] > 0 and ys[i] > 0)
         {
-            angleM = M_PI/2 - absArctanSlope;
+            angleM = 0.5f*float(M_PI) - absArctanSlope;
         }
         else if(xs[i] < 0 and ys[i] > 0)
         {
-            angleM = absArctanSlope + M_PI/2;
+            angleM = absArctanSlope + 0.5f*float(M_PI);
         }
         else if(xs[i] < 0 and ys[i] < 0)
         {
-            angleM = -(absArctanSlope + M_PI/2);
+            angleM = -(absArctanSlope + 0.5f*float(M_PI));
         }
         else if(xs[i] > 0 and ys[i] < 0)
         {
-            angleM = -(M_PI/2 - absArctanSlope);
+            angleM = -(0.5f*float(M_PI) - absArctanSlope);
         }
 
         if(not isFlat[i])

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -480,7 +480,7 @@ __device__ bool SDL::runQuintupletDefaultAlgo(struct SDL::modules& modulesInGPU,
     bridgeRadius = computeRadiusFromThreeAnchorHits(x2, y2, x3, y3, x4, y4, g, f);
 
 
-    if(innerRadius < 0.95/(2 * k2Rinv1GeVf))
+    if(innerRadius < 0.95f/(2.f * k2Rinv1GeVf))
     {
         pass = false;
     }
@@ -538,7 +538,7 @@ __device__ bool SDL::runQuintupletDefaultAlgo(struct SDL::modules& modulesInGPU,
     regressionRadius = computeRadiusUsingRegression(5,xVec, yVec, delta1, delta2, slopes, isFlat, regressionG, regressionF, sigmas, chiSquared);
 
     //extra chi squared cuts!
-    if(regressionRadius < 5.0/(2 * k2Rinv1GeVf))
+    if(regressionRadius < 5.0f/(2.f * k2Rinv1GeVf))
     {
         pass = pass & passChiSquaredConstraint(modulesInGPU, lowerModuleIndex1, lowerModuleIndex2, lowerModuleIndex3, lowerModuleIndex4, lowerModuleIndex5, chiSquared);
     }
@@ -566,117 +566,117 @@ __device__ bool SDL::passChiSquaredConstraint(struct SDL::modules& modulesInGPU,
     {
         if(layer4 == 10 and layer5 == 11)
         {
-            return chiSquared < 0.01788;
+            return chiSquared < 0.01788f;
         }
         else if(layer4 == 10 and layer5 == 16)
         {
-            return chiSquared < 0.04725;
+            return chiSquared < 0.04725f;
         }
         else if(layer4 == 15 and layer5 == 16)
         {
-            return chiSquared < 0.04725;
+            return chiSquared < 0.04725f;
         }
     }
     else if(layer1 == 1 and layer2 == 7 and layer3 == 8)
     {
         if(layer4 == 9 and layer5 == 10)
         {       
-            return chiSquared < 0.01788;
+            return chiSquared < 0.01788f;
         }   
         else if(layer4 == 9 and layer5 == 15)
         {
-            return chiSquared < 0.08234;
+            return chiSquared < 0.08234f;
         }
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 7)
     {
         if(layer4 == 8 and layer5 == 9)
         {
-            return chiSquared < 0.02360;
+            return chiSquared < 0.02360f;
         }
         else if(layer4 == 8 and layer5 == 14)
         {
-            return chiSquared < 0.07167;
+            return chiSquared < 0.07167f;
         }
         else if(layer4 == 13 and layer5 == 14)
         {   
-            return chiSquared < 0.08234;
+            return chiSquared < 0.08234f;
         }
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 3)
     {
         if(layer4 == 7 and layer5 == 8)
         {
-            return chiSquared < 0.01026;
+            return chiSquared < 0.01026f;
         }
         else if(layer4 == 7 and layer5 == 13)
         {
-            return chiSquared < 0.06238;
+            return chiSquared < 0.06238f;
         }
         else if(layer4 == 12 and layer5 == 13)
         {
-            return chiSquared < 0.06238;
+            return chiSquared < 0.06238f;
         }
     }
     else if(layer1 == 1 and layer2 == 2 and layer3 == 3 and layer4 == 4)
     {
         if(layer5 == 12)
         {
-            return chiSquared < 0.09461;
+            return chiSquared < 0.09461f;
         }
         else if(layer5 == 5)
         {
-            return chiSquared < 0.04725;
+            return chiSquared < 0.04725f;
         }
     }
     else if(layer1 == 2 and layer2 == 7 and layer3 == 8)
     {
         if(layer4 == 9 and layer5 == 10)
         {
-            return chiSquared < 0.00512;
+            return chiSquared < 0.00512f;
         }
         if(layer4 == 9 and layer5 == 15)
         {
-            return chiSquared < 0.04112;
+            return chiSquared < 0.04112f;
         }
         else if(layer4 == 14 and layer5 == 15)
         {
-            return chiSquared < 0.06238;
+            return chiSquared < 0.06238f;
         }
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 7)
     {
         if(layer4 == 8 and layer5 == 14)
         {
-            return chiSquared < 0.07167;
+            return chiSquared < 0.07167f;
         }
         else if(layer4 == 13 and layer5 == 14)
         {
-            return chiSquared < 0.06238;
+            return chiSquared < 0.06238f;
         }
     }
     else if(layer1 == 2 and layer2 == 3 and layer3 == 4)
     {
         if(layer4 == 12 and layer5 == 13)
         {
-            return chiSquared < 0.10870;
+            return chiSquared < 0.10870f;
         }
         else if(layer4 == 5 and layer5 == 12)
         {
-            return chiSquared < 0.10870;
+            return chiSquared < 0.10870f;
         }
         else if(layer4 == 5 and layer5 == 6)
         {
-            return chiSquared < 0.08234;
+            return chiSquared < 0.08234f;
         }
     }
     else if(layer1 == 3 and layer2 == 7 and layer3 == 8 and layer4 == 14 and layer5 == 15)
     {
-        return chiSquared < 0.09461;
+        return chiSquared < 0.09461f;
     }
     else if(layer1 == 3 and layer2 == 4 and layer3 == 5 and layer4 == 12 and layer5 == 13)
     {
-        return chiSquared < 0.09461;
+        return chiSquared < 0.09461f;
     }
 
     return true;
@@ -1311,7 +1311,7 @@ __device__ float SDL::computeRadiusUsingRegression(int nPoints, float* xs, float
         }
         else if(xs[i] > 0 and ys[i] < 0)
         {
-            angleM = -(0.5f*(M_PI) - absArctanSlope);
+            angleM = -(0.5f*float(M_PI) - absArctanSlope);
         }
 
         if(not isFlat[i])

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -406,8 +406,8 @@ __device__ void SDL::dAlphaThreshold(float* dAlphaThresholdValues, struct hits& 
 
     }
 
-    float innerModuleGapSize = SDL::moduleGapSize(modulesInGPU, innerLowerModuleIndex);
-    float outerModuleGapSize = SDL::moduleGapSize(modulesInGPU, outerLowerModuleIndex);
+    float innerModuleGapSize = SDL::moduleGapSize_seg(modulesInGPU, innerLowerModuleIndex);
+    float outerModuleGapSize = SDL::moduleGapSize_seg(modulesInGPU, outerLowerModuleIndex);
     const float innerminiTilt = isInnerTilted ? (0.5f * pixelPSZpitch * drdzInner / sqrtf(1.f + drdzInner * drdzInner) / innerModuleGapSize) : 0;
 
     const float outerminiTilt = isOuterTilted ? (0.5f * pixelPSZpitch * drdzOuter / sqrtf(1.f + drdzOuter * drdzOuter) / outerModuleGapSize) : 0;
@@ -778,4 +778,103 @@ void SDL::printSegment(struct SDL::segments& segmentsInGPU, struct SDL::miniDoub
         IndentingOStreambuf indent(std::cout);
         printMD(mdsInGPU, hitsInGPU, modulesInGPU, outerMDIndex);
     }
+}
+__device__ inline float SDL::isTighterTiltedModules_seg(struct modules& modulesInGPU, unsigned int moduleIndex)
+{
+    // The "tighter" tilted modules are the subset of tilted modules that have smaller spacing
+    // This is the same as what was previously considered as"isNormalTiltedModules"
+    // See Figure 9.1 of https://cds.cern.ch/record/2272264/files/CMS-TDR-014.pdf
+    short subdet = modulesInGPU.subdets[moduleIndex];
+    short layer = modulesInGPU.layers[moduleIndex];
+    short side = modulesInGPU.sides[moduleIndex];
+    short rod = modulesInGPU.rods[moduleIndex];
+
+    if (
+           (subdet == Barrel and side != Center and layer== 3)
+           or (subdet == Barrel and side == NegZ and layer == 2 and rod > 5)
+           or (subdet == Barrel and side == PosZ and layer == 2 and rod < 8)
+           or (subdet == Barrel and side == NegZ and layer == 1 and rod > 9)
+           or (subdet == Barrel and side == PosZ and layer == 1 and rod < 4)
+       )
+        return true;
+    else
+        return false;
+
+}
+
+
+
+__device__ float SDL::moduleGapSize_seg(struct modules& modulesInGPU, unsigned int moduleIndex)
+{
+    float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
+    float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
+    float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
+    float miniDeltaEndcap[5][15];
+
+    for (size_t i = 0; i < 5; i++)
+    {
+        for (size_t j = 0; j < 15; j++)
+        {
+            if (i == 0 || i == 1)
+            {
+                if (j < 10)
+                {
+                    miniDeltaEndcap[i][j] = 0.4f;
+                }
+                else
+                {
+                    miniDeltaEndcap[i][j] = 0.18f;
+                }
+            }
+            else if (i == 2 || i == 3)
+            {
+                if (j < 8)
+                {
+                    miniDeltaEndcap[i][j] = 0.4f;
+                }
+                else
+                {
+                    miniDeltaEndcap[i][j]  = 0.18f;
+                }
+            }
+            else
+            {
+                if (j < 9)
+                {
+                    miniDeltaEndcap[i][j] = 0.4f;
+                }
+                else
+                {
+                    miniDeltaEndcap[i][j] = 0.18f;
+                }
+            }
+        }
+    }
+
+
+    unsigned int iL = modulesInGPU.layers[moduleIndex]-1;
+    unsigned int iR = modulesInGPU.rings[moduleIndex] - 1;
+    short subdet = modulesInGPU.subdets[moduleIndex];
+    short side = modulesInGPU.sides[moduleIndex];
+
+    float moduleSeparation = 0;
+
+    if (subdet == Barrel and side == Center)
+    {
+        moduleSeparation = miniDeltaFlat[iL];
+    }
+    else if (isTighterTiltedModules_seg(modulesInGPU, moduleIndex))
+    {
+        moduleSeparation = miniDeltaTilted[iL];
+    }
+    else if (subdet == Endcap)
+    {
+        moduleSeparation = miniDeltaEndcap[iL][iR];
+    }
+    else //Loose tilted modules
+    {
+        moduleSeparation = miniDeltaLooseTilted[iL];
+    }
+
+    return moduleSeparation;
 }

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -78,11 +78,12 @@ void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned
     segmentsInGPU.eta = segmentsInGPU.dPhis + nMemoryLocations * 6 + maxPixelSegments * 6;
     segmentsInGPU.phi = segmentsInGPU.dPhis + nMemoryLocations * 6 + maxPixelSegments * 7;
     
-#pragma omp parallel for default(shared)
-    for(size_t i = 0; i < nModules; i++)
-    {
-        segmentsInGPU.nSegments[i] = 0;
-    }
+//#pragma omp parallel for default(shared)
+//    for(size_t i = 0; i < nModules; i++)
+//    {
+//        segmentsInGPU.nSegments[i] = 0;
+//    }
+    cudaMemset(segmentsInGPU.nSegments,0,nModules * sizeof(unsigned int));
     cudaMemset(segmentsInGPU.partOfPT5, false, maxPixelSegments * sizeof(bool));
 
 }
@@ -727,10 +728,10 @@ __device__ bool SDL::runSegmentDefaultAlgoBarrel(struct modules& modulesInGPU, s
 __device__ bool SDL::runSegmentDefaultAlgo(struct modules& modulesInGPU, struct hits& hitsInGPU, struct miniDoublets& mdsInGPU, unsigned int& innerLowerModuleIndex, unsigned int& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float&
         dAlphaInnerMDOuterMD, float& zLo, float& zHi, float& rtLo, float& rtHi, float& sdCut, float& dAlphaInnerMDSegmentThreshold, float& dAlphaOuterMDSegmentThreshold, float& dAlphaInnerMDOuterMDThreshold, unsigned int& innerMiniDoubletAnchorHitIndex, unsigned int& outerMiniDoubletAnchorHitIndex)
 {
-    zLo = -999;
-    zHi = -999;
-    rtLo = -999;
-    rtHi = -999;
+    zLo = -999.f;
+    zHi = -999.f;
+    rtLo = -999.f;
+    rtHi = -999.f;
 
     bool pass = true;
 

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -109,6 +109,7 @@ namespace SDL
         dAlphaInnerMDOuterMD, unsigned int& innerMiniDoubletAnchorHitIndex, unsigned int& outerMiniDoubletAnchorHitIndex);
 
     void printSegment(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInPGU, struct modules& modulesInGPU, unsigned int segmentIndex);
+    CUDA_DEV float moduleGapSize_seg(struct modules& modulesInGPU, unsigned int moduleIndex);
 
 }
 

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -110,6 +110,9 @@ namespace SDL
 
     void printSegment(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInPGU, struct modules& modulesInGPU, unsigned int segmentIndex);
     CUDA_DEV float moduleGapSize_seg(struct modules& modulesInGPU, unsigned int moduleIndex);
+    
+    CUDA_DEV extern inline float isTighterTiltedModules_seg(struct modules& modulesInGPU, unsigned int moduleIndex);
+    CUDA_DEV float moduleGapSize_seg(struct modules& modulesInGPU, unsigned int moduleIndex);
 
 }
 

--- a/SDL/Tracklet.cu
+++ b/SDL/Tracklet.cu
@@ -306,7 +306,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBBB(struct modules& modulesInGPU, st
     float coshEta = dr3_InSeg/drt_InSeg;
     float dzErr = (zpitch_InLo + zpitch_OutLo) * (zpitch_InLo + zpitch_OutLo) * 2.f;
 
-    float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2 * (rt_OutLo - rt_InLo) / 50.f) * sqrtf(r3_InLo / rt_InLo);
+    float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2f * (rt_OutLo - rt_InLo) / 50.f) * sqrtf(r3_InLo / rt_InLo);
     float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; // will need a better guess than x4?
     dzErr += sdlMuls * sdlMuls * drt_OutLo_InLo * drt_OutLo_InLo / 3.f * coshEta * coshEta; //sloppy
     dzErr = sqrtf(dzErr);
@@ -483,7 +483,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBBB(struct modules& modulesInGPU, st
     float pt_betaOut = drt_tl_axis * k2Rinv1GeVf / sinf(betaOut);
     float dBetaRes = 0.02f/fminf(sdOut_d,drt_InSeg);
     float dBetaCut2 = (dBetaRes*dBetaRes * 2.0f + dBetaMuls * dBetaMuls + dBetaLum2 + dBetaRIn2 + dBetaROut2
-            + 0.25 * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
+            + 0.25f * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
 
     float dBeta = betaIn - betaOut;
     deltaBetaCut = sqrtf(dBetaCut2);    
@@ -569,7 +569,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBEE(struct modules& modulesInGPU, st
     const float zGeom1_another = pixelPSZpitch; //What's this?
     kZ = (z_OutLo - z_InLo) / dzSDIn;
     float drtErr = zGeom1_another * zGeom1_another * drtSDIn * drtSDIn / dzSDIn / dzSDIn * (1.f - 2.f * kZ + 2.f * kZ * kZ); //Notes:122316
-    const float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2 * (rt_OutLo - rt_InLo) / 50.f) * sqrtf(rIn / rt_InLo);
+    const float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2f * (rt_OutLo - rt_InLo) / 50.f) * sqrtf(rIn / rt_InLo);
     const float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; //will need a better guess than x4?
     drtErr += sdlMuls * sdlMuls * multDzDr * multDzDr / 3.f * coshEta * coshEta; //sloppy: relative muls is 1/3 of total muls
     drtErr = sqrtf(drtErr);
@@ -823,7 +823,7 @@ __device__ bool SDL::runTrackletDefaultAlgoEEEE(struct modules& modulesInGPU, st
     float multDzDr = dzOutInAbs * coshEta / (coshEta * coshEta - 1.f);
 
     kZ = (z_OutLo - z_InLo) / dzSDIn;
-    float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2 * (rt_OutLo - rt_InLo) / 50.f);
+    float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2f * (rt_OutLo - rt_InLo) / 50.f);
 
     float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; //will need a better guess than x4?
 
@@ -979,7 +979,7 @@ __device__ bool SDL::runTrackletDefaultAlgoEEEE(struct modules& modulesInGPU, st
     float pt_betaOut = dr * k2Rinv1GeVf / sinf(betaOut);
     float dBetaRes = 0.02f/fminf(sdOut_d,sdIn_d);
     float dBetaCut2 = (dBetaRes*dBetaRes * 2.0f + dBetaMuls * dBetaMuls + dBetaLum2 + dBetaRIn2 + dBetaROut2
-            + 0.25 * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
+            + 0.25f * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
     float dBeta = betaIn - betaOut;
     //Cut #7: Cut on dBeta
     deltaBetaCut = sqrtf(dBetaCut2);
@@ -1018,7 +1018,7 @@ __device__ void SDL::runDeltaBetaIterations(float& betaIn, float& betaOut, float
         //update the av and pt
         betaAv = 0.5f * (betaIn + betaOut);
         //2nd update
-        pt_beta = dr * k2Rinv1GeVf / sin(betaAv); //get a better pt estimate
+        pt_beta = dr * k2Rinv1GeVf / sinf(betaAv); //get a better pt estimate
 
         //might need these for future iterations
 

--- a/SDL/Tracklet.cu
+++ b/SDL/Tracklet.cu
@@ -735,7 +735,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBEE(struct modules& modulesInGPU, st
     float pt_betaOut = dr * k2Rinv1GeVf / sinf(betaOut);
     float dBetaRes = 0.02f/fminf(sdOut_d,sdIn_d);
     float dBetaCut2 = (dBetaRes*dBetaRes * 2.0f + dBetaMuls * dBetaMuls + dBetaLum2 + dBetaRIn2 + dBetaROut2
-            + 0.25 * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
+            + 0.25f * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)) * (fabsf(betaInRHmin - betaInRHmax) + fabsf(betaOutRHmin - betaOutRHmax)));
     float dBeta = betaIn - betaOut;
     deltaBetaCut = sqrtf(dBetaCut2);
     //Cut #7: Cut on dBet
@@ -1011,7 +1011,7 @@ __device__ void SDL::runDeltaBetaIterations(float& betaIn, float& betaOut, float
         betaAv = 0.5f * (betaInUpd + betaOutUpd);
 
         //1st update
-        pt_beta = dr * k2Rinv1GeVf / sin(betaAv); //get a better pt estimate
+        pt_beta = dr * k2Rinv1GeVf / sinf(betaAv); //get a better pt estimate
 
         betaIn  += copysignf(asinf(fminf(sdIn_dr * k2Rinv1GeVf / fabsf(pt_beta), sinAlphaMax)), betaIn); //FIXME: need a faster version
         betaOut += copysignf(asinf(fminf(sdOut_dr * k2Rinv1GeVf / fabsf(pt_beta), sinAlphaMax)), betaOut); //FIXME: need a faster version
@@ -1048,9 +1048,9 @@ __device__ void SDL::runDeltaBetaIterations(float& betaIn, float& betaOut, float
     else if (lIn < 11 && fabsf(betaOut) < 0.2 * fabsf(betaIn) && fabsf(pt_beta) < 12.f * pt_betaMax)   //use betaIn sign as ref
     {
    
-        const float pt_betaIn = dr * k2Rinv1GeVf / sin(betaIn);
-        const float betaInUpd  = betaIn + copysignf(asinf(fminf(sdIn_dr * k2Rinv1GeVf / fabs(pt_betaIn), sinAlphaMax)), betaIn); //FIXME: need a faster version
-        const float betaOutUpd = betaOut + copysignf(asinf(fminf(sdOut_dr * k2Rinv1GeVf / fabs(pt_betaIn), sinAlphaMax)), betaIn); //FIXME: need a faster version
+        const float pt_betaIn = dr * k2Rinv1GeVf / sinf(betaIn);
+        const float betaInUpd  = betaIn + copysignf(asinf(fminf(sdIn_dr * k2Rinv1GeVf / fabsf(pt_betaIn), sinAlphaMax)), betaIn); //FIXME: need a faster version
+        const float betaOutUpd = betaOut + copysignf(asinf(fminf(sdOut_dr * k2Rinv1GeVf / fabsf(pt_betaIn), sinAlphaMax)), betaIn); //FIXME: need a faster version
         betaAv = (fabsf(betaOut) > 0.2f * fabsf(betaIn)) ? (0.5f * (betaInUpd + betaOutUpd)) : betaInUpd;
 
         //1st update

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -236,7 +236,7 @@ __device__ bool SDL::passRZConstraint(struct SDL::modules& modulesInGPU, struct 
     }
     else if (layer1 == 1 and layer2 == 2 and layer3 == 3)
     {
-        return fabsf(residual) < 0.53;
+        return fabsf(residual) < 0.53f;
     }
     else if (layer1 == 1 and layer2 == 2 and layer3 == 7)
     {
@@ -256,23 +256,23 @@ __device__ bool SDL::passRZConstraint(struct SDL::modules& modulesInGPU, struct 
     }
     else if (layer1 == 2 and layer2 == 3 and layer3 == 4)
     {
-        return fabsf(residual) < 1.21;
+        return fabsf(residual) < 1.21f;
     }
     else if (layer1 == 2 and layer2 == 3 and layer3 == 7)
     {
-        return fabsf(residual) < 1.;
+        return fabsf(residual) < 1.f;
     }
     else if (layer1 == 2 and layer2 == 7 and layer3 == 8)
     {
-        return fabsf(residual) < 1.;
+        return fabsf(residual) < 1.f;
     }
     else if (layer1 == 3 and layer2 == 4 and layer3 == 5)
     {
-        return fabsf(residual) < 2.7;
+        return fabsf(residual) < 2.7f;
     }
     else if (layer1 == 4 and layer2 == 5 and layer3 == 6)
     {
-        return fabsf(residual) < 3.06;
+        return fabsf(residual) < 3.06f;
     }
     else if (layer1 == 7 and layer2 == 8 and layer3 == 9)
     {
@@ -377,7 +377,7 @@ __device__ bool SDL::passPointingConstraintBBB(struct SDL::modules& modulesInGPU
     float coshEta = dr3_InSeg/drt_InSeg;
     float dzErr = (zpitch_InLo + zpitch_OutUp) * (zpitch_InLo + zpitch_OutUp) * 2.f;
 
-    float sdlThetaMulsF = 0.015f * sqrt(0.1f + 0.2 * (rt_OutUp - rt_InLo) / 50.f) * sqrt(r3_InLo / rt_InLo);
+    float sdlThetaMulsF = 0.015f * sqrt(0.1f + 0.2f * (rt_OutUp - rt_InLo) / 50.f) * sqrt(r3_InLo / rt_InLo);
     float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; // will need a better guess than x4?
     dzErr += sdlMuls * sdlMuls * drt_OutUp_InLo * drt_OutUp_InLo / 3.f * coshEta * coshEta; //sloppy
     dzErr = sqrt(dzErr);
@@ -565,7 +565,7 @@ __device__ bool SDL::passPointingConstraintEEE(struct SDL::modules& modulesInGPU
     float multDzDr = dzOutInAbs * coshEta / (coshEta * coshEta - 1.f);
 
     float kZ = (z_OutUp - z_InLo) / dzSDIn;
-    float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2 * (rt_OutUp - rt_InLo) / 50.f);
+    float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2f * (rt_OutUp - rt_InLo) / 50.f);
 
     float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; //will need a better guess than x4?
 

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -65,7 +65,7 @@ void createOccupancyBranches()
     ana.tx->createBranch<vector<int>>("sg_occupancies");
     ana.tx->createBranch<vector<int>>("t4_occupancies");
     ana.tx->createBranch<vector<int>>("t3_occupancies");
-    ana.tx->createBranch<vector<int>>("tc_occupancies");
+    ana.tx->createBranch<int>("tc_occupancies");
     ana.tx->createBranch<vector<int>>("t5_occupancies");
     ana.tx->createBranch<int>("pT3_occupancies");
     ana.tx->createBranch<int>("pT5_occupancies");
@@ -657,7 +657,7 @@ void fillOccupancyBranches(SDL::Event& event)
         segmentOccupancy.push_back(segmentsInGPU.nSegments[lowerIdx]);
         mdOccupancy.push_back(mdsInGPU.nMDs[lowerIdx]);
 
-        trackCandidateOccupancy.push_back(trackCandidatesInGPU.nTrackCandidates[idx]);
+//        trackCandidateOccupancy.push_back(trackCandidatesInGPU.nTrackCandidates[idx]);
         if(idx < *(modulesInGPU.nLowerModules))
         {
             quintupletOccupancy.push_back(quintupletsInGPU.nQuintuplets[idx]);
@@ -670,7 +670,8 @@ void fillOccupancyBranches(SDL::Event& event)
     ana.tx->setBranch<vector<int>>("md_occupancies",mdOccupancy);
     ana.tx->setBranch<vector<int>>("sg_occupancies",segmentOccupancy);
     ana.tx->setBranch<vector<int>>("t3_occupancies",tripletOccupancy);
-    ana.tx->setBranch<vector<int>>("tc_occupancies",trackCandidateOccupancy);
+    ana.tx->setBranch<int>("tc_occupancies",*(trackCandidatesInGPU.nTrackCandidates));
+    //ana.tx->setBranch<vector<int>>("tc_occupancies",trackCandidateOccupancy);
     ana.tx->setBranch<int>("pT3_occupancies", *(pixelTripletsInGPU.nPixelTriplets));
     ana.tx->setBranch<vector<int>>("t5_occupancies", quintupletOccupancy);
     ana.tx->setBranch<int>("pT5_occupancies", *(pixelQuintupletsInGPU.nPixelQuintuplets));

--- a/efficiency/src/SDL.cc
+++ b/efficiency/src/SDL.cc
@@ -3233,7 +3233,7 @@ const int &SDL::pT3_occupancies() {
   }
   return pT3_occupancies_;
 }
-const vector<int> &SDL::tc_occupancies() {
+const int &SDL::tc_occupancies() {
   if (not tc_occupancies_isLoaded) {
     if (tc_occupancies_branch != 0) {
       tc_occupancies_branch->GetEntry(index);
@@ -3852,7 +3852,7 @@ namespace tas {
   const vector<float> &t5_outerRadiusMin2S() { return sdl.t5_outerRadiusMin2S(); }
   const vector<float> &t3_betaIn() { return sdl.t3_betaIn(); }
   const int &pT3_occupancies() { return sdl.pT3_occupancies(); }
-  const vector<int> &tc_occupancies() { return sdl.tc_occupancies(); }
+  const int &tc_occupancies() { return sdl.tc_occupancies(); }
   const vector<float> &t5_innerRadius() { return sdl.t5_innerRadius(); }
   const vector<int> &sim_TC_matched() { return sdl.sim_TC_matched(); }
   const vector<int> &pLS_isDuplicate() { return sdl.pLS_isDuplicate(); }

--- a/efficiency/src/SDL.h
+++ b/efficiency/src/SDL.h
@@ -488,7 +488,7 @@ protected:
   int pT3_occupancies_;
   TBranch *pT3_occupancies_branch;
   bool pT3_occupancies_isLoaded;
-  vector<int> *tc_occupancies_;
+  int *tc_occupancies_;
   TBranch *tc_occupancies_branch;
   bool tc_occupancies_isLoaded;
   vector<float> *t5_innerRadius_;
@@ -759,7 +759,7 @@ public:
   const vector<float> &t5_outerRadiusMin2S();
   const vector<float> &t3_betaIn();
   const int &pT3_occupancies();
-  const vector<int> &tc_occupancies();
+  const int &tc_occupancies();
   const vector<float> &t5_innerRadius();
   const vector<int> &sim_TC_matched();
   const vector<int> &pLS_isDuplicate();
@@ -961,7 +961,7 @@ namespace tas {
   const vector<float> &t5_outerRadiusMin2S();
   const vector<float> &t3_betaIn();
   const int &pT3_occupancies();
-  const vector<int> &tc_occupancies();
+  const int &tc_occupancies();
   const vector<float> &t5_innerRadius();
   const vector<int> &sim_TC_matched();
   const vector<int> &pLS_isDuplicate();


### PR DESCRIPTION
Changes all instances of double precision to single. Also reduces register usage in segment creation (leftover from previous PR)
This also moves TC memory allocation to pT5 kernel, adds pT5 to TC in pT5 step and marks used objects at the same time