### PR TITLE
pt0p8 Patch

### DIFF
--- a/SDL/Kernels.cuh
+++ b/SDL/Kernels.cuh
@@ -41,20 +41,29 @@ const unsigned int N_MAX_PIXEL_MD_PER_MODULES = 100000;
 const unsigned int N_MAX_PIXEL_SEGMENTS_PER_MODULE = 50000;
 
 //const unsigned int N_MAX_TRIPLETS_PER_MODULE = 5000;
-//const unsigned int N_MAX_TOTAL_TRIPLETS = 200000;
+const unsigned int N_MAX_TOTAL_TRIPLETS = 200000;
 //const unsigned int N_MAX_QUINTUPLETS_PER_MODULE = 5000;
 //const unsigned int N_MAX_PIXEL_TRIPLETS = 250000;
 //const unsigned int N_MAX_PIXEL_QUINTUPLETS = 1000000;
 //const unsigned int N_MAX_TRACK_CANDIDATES = 10000;
 //const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES = 400000;
 
-const unsigned int N_MAX_TRIPLETS_PER_MODULE = 1000;
-const unsigned int N_MAX_TOTAL_TRIPLETS = 100000;
-const unsigned int N_MAX_QUINTUPLETS_PER_MODULE = 2000;
-const unsigned int N_MAX_PIXEL_TRIPLETS = 2500;
-const unsigned int N_MAX_PIXEL_QUINTUPLETS = 10000;
+//const unsigned int N_MAX_TRIPLETS_PER_MODULE = 1000;
+//const unsigned int N_MAX_TOTAL_TRIPLETS = 100000;
+//const unsigned int N_MAX_QUINTUPLETS_PER_MODULE = 2000;
+//const unsigned int N_MAX_PIXEL_TRIPLETS = 2500;
+//const unsigned int N_MAX_PIXEL_QUINTUPLETS = 10000;
+//const unsigned int N_MAX_TRACK_CANDIDATES = 10000;
+//const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES = 10000;
+
+const unsigned int N_MAX_TRIPLETS_PER_MODULE = 2500;
+//const unsigned int N_MAX_TOTAL_TRIPLETS = 130000;
+const unsigned int N_MAX_QUINTUPLETS_PER_MODULE = 3000;
+const unsigned int N_MAX_PIXEL_TRIPLETS = 5000;
+const unsigned int N_MAX_PIXEL_QUINTUPLETS = 15000;
 const unsigned int N_MAX_TRACK_CANDIDATES = 10000;
-const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES = 10000;
+const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES = 15000;
+
 
 __device__ float scorepT3(struct SDL::modules& modulesInGPU,struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, unsigned int innerPix,unsigned int outerTrip,float pt, float pz);
 __global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::triplets& tripletsInGPU, bool secondPass);

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -1322,7 +1322,7 @@ void fillQuintupletOutputBranches(SDL::Event* event)
     std::vector<int> moduleType_binaries;
 #endif
 
-    const int MAX_NQUINTUPLET_PER_MODULE = 2000;
+    const int MAX_NQUINTUPLET_PER_MODULE = 3000;
     const float kRinv1GeVf = (2.99792458e-3 * 3.8);
     const float k2Rinv1GeVf = kRinv1GeVf / 2.;
     
@@ -1613,7 +1613,7 @@ void fillPixelTripletOutputBranches(SDL::Event* event)
     std::vector<float> pT3_rzChiSquared;
 #endif
 
-    const unsigned int N_MAX_PIXEL_TRIPLETS = 2500;
+    const unsigned int N_MAX_PIXEL_TRIPLETS = 5000;
 
     unsigned int nPixelTriplets = std::min(*(pixelTripletsInGPU.nPixelTriplets), N_MAX_PIXEL_TRIPLETS);
 
@@ -1846,7 +1846,7 @@ void fillPixelQuintupletOutputBranches(SDL::Event* event)
     std::vector<float> pT5_rPhiChiSquaredInwards;
     std::vector<float> pT5_simpt;
 #endif
-    const unsigned int N_MAX_PIXEL_QUINTUPLETS = 10000;
+    const unsigned int N_MAX_PIXEL_QUINTUPLETS = 15000;
     unsigned int nPixelQuintuplets = std::min(*(pixelQuintupletsInGPU.nPixelQuintuplets), N_MAX_PIXEL_QUINTUPLETS);
 
     for(unsigned int jdx = 0; jdx < nPixelQuintuplets; jdx++)
@@ -2345,7 +2345,7 @@ void fillTripletOutputBranches(SDL::Event* event)
     std::vector<int> moduleType_binaries;
 #endif
 
-    const int MAX_NTRIPLET_PER_MODULE = 1000;
+    const int MAX_NTRIPLET_PER_MODULE = 2500;
     for (unsigned int idx = 0; idx < *(modulesInGPU.nLowerModules); idx++) // "<=" because cheating to include pixel track candidate lower module
     {
 

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -12,9 +12,11 @@ run_gpu()
     sdl_make_tracklooper -m $*
     sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s1.root -v 1 -w 0 -i ${sample} | tee -a timing_temp.txt
     sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s2.root -v 1 -w 0 -s 2 -i ${sample} | tee -a timing_temp.txt
-    sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s4.root -v 1 -w 0 -s 4 -i ${sample} | tee -a timing_temp.txt
-    sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s6.root -v 1 -w 0 -s 6 -i ${sample} | tee -a timing_temp.txt
-    sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s8.root -v 1 -w 0 -s 8 -i ${sample} | tee -a timing_temp.txt
+    if [ ${version} != "explicit_cache" ]; then
+      sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s4.root -v 1 -w 0 -s 4 -i ${sample} | tee -a timing_temp.txt
+      sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s6.root -v 1 -w 0 -s 6 -i ${sample} | tee -a timing_temp.txt
+      sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s8.root -v 1 -w 0 -s 8 -i ${sample} | tee -a timing_temp.txt
+    fi
 }
 
 run_timing_test_usage()
@@ -105,19 +107,19 @@ rm -f timing_temp.txt
 
 # Run different GPU configurations
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified" ]]; then
-    run_gpu unified ${SAMPLE} ${NEVENTS}
+    run_gpu unified ${SAMPLE} ${NEVENTS} -8
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
-    run_gpu unified_cache ${SAMPLE} ${NEVENTS} -c
+    run_gpu unified_cache ${SAMPLE} ${NEVENTS} -c -8
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; then
-    run_gpu explicit ${SAMPLE} ${NEVENTS} -x
+    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
-     run_gpu explicit_cache ${SAMPLE} ${NEVENTS} -x -c # Does not run on phi3
+     run_gpu explicit_cache ${SAMPLE} ${NEVENTS} -x -c -8 # Does not run on phi3
     :
 fi
 

--- a/efficiency/bin/sdl_validate_efficiency
+++ b/efficiency/bin/sdl_validate_efficiency
@@ -113,11 +113,11 @@ mkdir -p ${OUTDIR}
 
 # Run different GPU configurations
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified" ]]; then
-    run_gpu unified ${SAMPLE} ${NEVENTS}
+    run_gpu unified ${SAMPLE} ${NEVENTS} -8
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; then
-    run_gpu explicit ${SAMPLE} ${NEVENTS} -x
+    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 
     :
 fi
 sdl_compare_efficiencies -i ${SAMPLE} -t ${GITHASH} -f


### PR DESCRIPTION
changed max object values and validation/ timing scripts to support the reduction in the pixel pt thresholds.
Note that this only allows for up to 2 streams for the explict cache version. Previously, explicit cache with 4-6 streams was the fastest time. 