### PR TITLE
fixed pT5 plots

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -180,6 +180,17 @@ SDL::Event::~Event()
         delete pixelTripletsInCPU;
     }
 #endif
+#ifdef Explicit_PT5
+    if(pixelQuintupletsInCPU != nullptr)
+    {
+        delete[] pixelQuintupletsInCPU->pixelIndices;
+        delete[] pixelQuintupletsInCPU->T5Indices;
+        delete[] pixelQuintupletsInCPU->isDup;
+        delete[] pixelQuintupletsInCPU->score;
+        delete pixelQuintupletsInCPU->nPixelQuintuplets;
+        delete pixelQuintupletsInCPU;
+    }
+#endif
 
 #ifdef Explicit_Track
     if(trackCandidatesInCPU != nullptr)
@@ -393,7 +404,18 @@ void SDL::Event::resetEvent()
         pixelTripletsInCPU = nullptr;
     }
 #endif
-
+#ifdef Explicit_PT5
+    if(pixelQuintupletsInCPU != nullptr)
+    {
+        delete[] pixelQuintupletsInCPU->pixelIndices;
+        delete[] pixelQuintupletsInCPU->T5Indices;
+        delete[] pixelQuintupletsInCPU->isDup;
+        delete[] pixelQuintupletsInCPU->score;
+        delete pixelQuintupletsInCPU->nPixelQuintuplets;
+        delete pixelQuintupletsInCPU;
+        pixelQuintupletsInCPU = nullptr;
+    }
+#endif
 #ifdef Explicit_Track
     if(trackCandidatesInCPU != nullptr)
     {


### PR DESCRIPTION
bug fix in saving pT5 values for validation plots.
Fixed Validation plots: https://www.classe.cornell.edu/~mgr85/www/SegmentLinking_keep/PR98/eff_plots__GPU_explicit_175dcebDIRTY_PU200/