### PR TITLE
Cache bin retuning

### DIFF
--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -192,7 +192,7 @@ void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsI
     quintupletsInGPU.nQuintuplets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int), stream);
     quintupletsInGPU.innerRadius = (FPX*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(FPX), stream);
     quintupletsInGPU.outerRadius = (FPX*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(FPX), stream);
-    quintupletsInGPU.pt = (FPX*)cms::cuda::allocate_managed(nMemoryLocations *7* sizeof(FPX), stream);
+    quintupletsInGPU.pt = (FPX*)cms::cuda::allocate_managed(nMemoryLocations *4* sizeof(FPX), stream);
     quintupletsInGPU.layer = (int*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(int), stream);
     quintupletsInGPU.isDup = (bool*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(bool), stream);
     quintupletsInGPU.partOfPT5 = (bool*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(bool), stream);
@@ -266,7 +266,7 @@ void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintuplets
     quintupletsInGPU.nQuintuplets = (unsigned int*)cms::cuda::allocate_device(dev, nLowerModules * sizeof(unsigned int), stream);
     quintupletsInGPU.innerRadius = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(FPX), stream);
     quintupletsInGPU.outerRadius = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(FPX), stream);
-    quintupletsInGPU.pt = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations *7* sizeof(FPX), stream);
+    quintupletsInGPU.pt = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations *4* sizeof(FPX), stream);
     quintupletsInGPU.layer = (int*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(int), stream);
     quintupletsInGPU.isDup = (bool*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(bool), stream);
     quintupletsInGPU.partOfPT5 = (bool*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(bool), stream);

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -10,7 +10,8 @@ void SDL::segments::resetMemory(unsigned int maxSegments, unsigned int nModules,
     unsigned int nMemoryLocations = maxSegments * (nModules - 1) + maxPixelSegments;
     cudaMemsetAsync(mdIndices,0, nMemoryLocations * 6 * sizeof(unsigned int),stream);
     cudaMemsetAsync(nSegments, 0,nModules * sizeof(unsigned int),stream);
-    cudaMemsetAsync(dPhis, 0,(nMemoryLocations * 6 + maxPixelSegments * 8)*sizeof(float),stream);
+    cudaMemsetAsync(dPhis, 0,(nMemoryLocations * 6 )*sizeof(FPX),stream);
+    cudaMemsetAsync(ptIn, 0,(maxPixelSegments * 8)*sizeof(float),stream);
     cudaMemsetAsync(superbin, 0,(maxPixelSegments )*sizeof(int),stream);
     cudaMemsetAsync(pixelType, 0,(maxPixelSegments )*sizeof(int),stream);
     cudaMemsetAsync(isQuad, 0,(maxPixelSegments )*sizeof(bool),stream);
@@ -226,6 +227,7 @@ void SDL::segments::freeMemoryCache()
     cudaGetDevice(&dev);
     cms::cuda::free_device(dev,mdIndices);
     cms::cuda::free_device(dev,dPhis);
+    cms::cuda::free_device(dev,ptIn);
     cms::cuda::free_device(dev,nSegments);
     cms::cuda::free_device(dev,superbin);
     cms::cuda::free_device(dev,pixelType);
@@ -239,6 +241,7 @@ void SDL::segments::freeMemoryCache()
 #else
     cms::cuda::free_managed(mdIndices);
     cms::cuda::free_managed(dPhis);
+    cms::cuda::free_managed(ptIn);
     cms::cuda::free_managed(nSegments);
     cms::cuda::free_managed(superbin);
     cms::cuda::free_managed(pixelType);
@@ -256,6 +259,7 @@ void SDL::segments::freeMemory(cudaStream_t stream)
     cudaFree(mdIndices);
     cudaFree(nSegments);
     cudaFree(dPhis);
+    cudaFree(ptIn);
     cudaFree(superbin);
     cudaFree(pixelType);
     cudaFree(isQuad);

--- a/SDL/getCachingAllocator.h
+++ b/SDL/getCachingAllocator.h
@@ -11,11 +11,11 @@ namespace cms::cuda::allocator {
   // Use caching or not
   constexpr bool useCaching = true;
   // Growth factor (bin_growth in cub::CachingDeviceAllocator
-  constexpr unsigned int binGrowth = 9;
+  constexpr unsigned int binGrowth = 2;//9;
   // Smallest bin, corresponds to binGrowth^minBin bytes (min_bin in cub::CacingDeviceAllocator
-  constexpr unsigned int minBin = 1;
+  constexpr unsigned int minBin = 8;//1;
   // Largest bin, corresponds to binGrowth^maxBin bytes (max_bin in cub::CachingDeviceAllocator). Note that unlike in cub, allocations larger than binGrowth^maxBin are set to fail.
-  constexpr unsigned int maxBin = 10;
+  constexpr unsigned int maxBin = 30;//10;
   // Total storage for the allocator. 0 means no limit.
   constexpr size_t maxCachedBytes = 0;
   // Fraction of total device memory taken for the allocator. In case there are multiple devices with different amounts of memory, the smallest of them is taken. If maxCachedBytes is non-zero, the smallest of them is taken.

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -12,11 +12,11 @@ run_gpu()
     sdl_make_tracklooper -m $*
     sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s1.root -v 1 -w 0 -i ${sample} | tee -a timing_temp.txt
     sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s2.root -v 1 -w 0 -s 2 -i ${sample} | tee -a timing_temp.txt
-    if [ ${version} != "explicit_cache" ]; then
+    #if [ ${version} != "explicit_cache" ]; then
       sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s4.root -v 1 -w 0 -s 4 -i ${sample} | tee -a timing_temp.txt
       sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s6.root -v 1 -w 0 -s 6 -i ${sample} | tee -a timing_temp.txt
       sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s8.root -v 1 -w 0 -s 8 -i ${sample} | tee -a timing_temp.txt
-    fi
+    #fi
 }
 
 run_timing_test_usage()
@@ -124,5 +124,5 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache
 fi
 
 echo "Total Timing Summary"
-echo "   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       TCE      Event      Short             Loop      Effective"
+echo "   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       TCE      Event      Short           Loop      Effective"
 grep -hr "avg " timing_temp.txt # space is needed to not get certain bad lines 

--- a/efficiency/bin/sdl_validate_efficiency
+++ b/efficiency/bin/sdl_validate_efficiency
@@ -123,4 +123,12 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; 
     run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 ${runExtension}
     :
 fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
+    run_gpu unified ${SAMPLE} ${NEVENTS} -8 -c ${runExtension}
+    :
+fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
+    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 -c ${runExtension}
+    :
+fi
 sdl_compare_efficiencies -i ${SAMPLE} -t ${GITHASH} -f


### PR DESCRIPTION
Retunes cache bin sizes following what Matti had done. 
Explicit cache with extensions memory usage: 23 GB -> ~6 GB
approximate memory usage spreadsheet: https://docs.google.com/spreadsheets/d/1-tDK4nIPlrB-0SoeEbnJlf_lyt-xTZcIhmZGRnR-fnY/edit?usp=sharing