### PR TITLE
Extension kernel cleanup

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1425,25 +1425,8 @@ void SDL::Event::createExtendedTracks()
     createTrackExtensionsInUnifiedMemory(*trackExtensionsInGPU, nTrackCandidates * N_MAX_TRACK_EXTENSIONS_PER_TC, nTrackCandidates, stream);
 #endif
 
-//    uint16_t nLowerModules;    
-//    cudaMemcpy(&nLowerModules,modulesInGPU->nLowerModules,sizeof(uint16_t),cudaMemcpyDeviceToHost);
-//    
-//    unsigned int *nTriplets;
-//    cudaMallocHost(&nTriplets, nLowerModules * sizeof(unsigned int));
-//    cudaMemcpy(nTriplets, tripletsInGPU->nTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost);
-    /* extremely naive way - 3D grid
-     * most of the threads launched here will exit without running
-     */
-//    dim3 nThreads(256,4,1);
-//    dim3 nThreads(16,4,4);
-//    unsigned int maxT3s = *std::max_element(nTriplets, nTriplets + nLowerModules); 
-//    unsigned int nOverlaps = 3;
-//    dim3 nBlocks(1,80,1); 
     dim3 nThreads(32,1,16);
     dim3 nBlocks(80,1,200); 
-    //dim3 nThreads(32,16,1);
-    //dim3 nBlocks(80,200,1); 
-//    dim3 nBlocks(nTrackCandidates % nThreads.x == 0 ? nTrackCandidates / nThreads.x : nTrackCandidates / nThreads.x + 1, maxT3s % nThreads.y == 0 ? maxT3s / nThreads.y : maxT3s / nThreads.y + 1, nOverlaps % nThreads.z == 0 ? nOverlaps / nThreads.z : nOverlaps / nThreads.z + 1);
     createExtendedTracksInGPU<<<nBlocks,nThreads>>>(*modulesInGPU, *hitsInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, *quintupletsInGPU, *pixelQuintupletsInGPU, *trackCandidatesInGPU, *trackExtensionsInGPU);
 
     cudaError_t cudaerr = cudaGetLastError();
@@ -1476,7 +1459,6 @@ void SDL::Event::createExtendedTracks()
 	    std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
     }cudaStreamSynchronize(stream);
 
- //   cudaFreeHost(nTriplets); 
     cudaDeviceSynchronize();
 }
 #endif

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1425,26 +1425,28 @@ void SDL::Event::createExtendedTracks()
     createTrackExtensionsInUnifiedMemory(*trackExtensionsInGPU, nTrackCandidates * N_MAX_TRACK_EXTENSIONS_PER_TC, nTrackCandidates, stream);
 #endif
 
-    uint16_t nLowerModules;    
-    cudaMemcpy(&nLowerModules,modulesInGPU->nLowerModules,sizeof(uint16_t),cudaMemcpyDeviceToHost);
-    
-    unsigned int *nTriplets;
-    cudaMallocHost(&nTriplets, nLowerModules * sizeof(unsigned int));
-    cudaMemcpy(nTriplets, tripletsInGPU->nTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost);
+//    uint16_t nLowerModules;    
+//    cudaMemcpy(&nLowerModules,modulesInGPU->nLowerModules,sizeof(uint16_t),cudaMemcpyDeviceToHost);
+//    
+//    unsigned int *nTriplets;
+//    cudaMallocHost(&nTriplets, nLowerModules * sizeof(unsigned int));
+//    cudaMemcpy(nTriplets, tripletsInGPU->nTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost);
     /* extremely naive way - 3D grid
      * most of the threads launched here will exit without running
      */
-    dim3 nThreads(16,4,4);
-    unsigned int maxT3s = *std::max_element(nTriplets, nTriplets + nLowerModules); 
-    unsigned int nOverlaps = 3;
-    dim3 nBlocks(nTrackCandidates % nThreads.x == 0 ? nTrackCandidates / nThreads.x : nTrackCandidates / nThreads.x + 1, maxT3s % nThreads.y == 0 ? maxT3s / nThreads.y : maxT3s / nThreads.y + 1, nOverlaps % nThreads.z == 0 ? nOverlaps / nThreads.z : nOverlaps / nThreads.z + 1);
+    dim3 nThreads(256,4,1);
+    //dim3 nThreads(16,4,4);
+//    unsigned int maxT3s = *std::max_element(nTriplets, nTriplets + nLowerModules); 
+//    unsigned int nOverlaps = 3;
+    dim3 nBlocks(1,80,1); 
+    //dim3 nBlocks(nTrackCandidates % nThreads.x == 0 ? nTrackCandidates / nThreads.x : nTrackCandidates / nThreads.x + 1, maxT3s % nThreads.y == 0 ? maxT3s / nThreads.y : maxT3s / nThreads.y + 1, nOverlaps % nThreads.z == 0 ? nOverlaps / nThreads.z : nOverlaps / nThreads.z + 1);
     createExtendedTracksInGPU<<<nBlocks,nThreads>>>(*modulesInGPU, *hitsInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, *quintupletsInGPU, *pixelQuintupletsInGPU, *trackCandidatesInGPU, *trackExtensionsInGPU);
 
-    cudaError_t cudaerr = cudaDeviceSynchronize();
+    cudaError_t cudaerr = cudaGetLastError();
     if(cudaerr != cudaSuccess)
     {
 	    std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
-    }
+    }cudaStreamSynchronize(stream);
 
 #ifdef T3T3_EXTENSIONS
     dim3 nThreadsT3T3(1,16,16);
@@ -1464,13 +1466,13 @@ void SDL::Event::createExtendedTracks()
 
     cleanDuplicateExtendedTracks<<<nThreadsDupCleaning, nBlocksDupCleaning>>>(*trackExtensionsInGPU, nTrackCandidates);
 
-    cudaerr = cudaDeviceSynchronize();
+    cudaerr = cudaGetLastError();
     if(cudaerr != cudaSuccess)
     {
 	    std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
-    }
+    }cudaStreamSynchronize(stream);
 
-    cudaFreeHost(nTriplets); 
+ //   cudaFreeHost(nTriplets); 
 }
 #endif
 

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1434,12 +1434,16 @@ void SDL::Event::createExtendedTracks()
     /* extremely naive way - 3D grid
      * most of the threads launched here will exit without running
      */
-    dim3 nThreads(256,4,1);
-    //dim3 nThreads(16,4,4);
+//    dim3 nThreads(256,4,1);
+//    dim3 nThreads(16,4,4);
 //    unsigned int maxT3s = *std::max_element(nTriplets, nTriplets + nLowerModules); 
 //    unsigned int nOverlaps = 3;
-    dim3 nBlocks(1,80,1); 
-    //dim3 nBlocks(nTrackCandidates % nThreads.x == 0 ? nTrackCandidates / nThreads.x : nTrackCandidates / nThreads.x + 1, maxT3s % nThreads.y == 0 ? maxT3s / nThreads.y : maxT3s / nThreads.y + 1, nOverlaps % nThreads.z == 0 ? nOverlaps / nThreads.z : nOverlaps / nThreads.z + 1);
+//    dim3 nBlocks(1,80,1); 
+    dim3 nThreads(32,1,16);
+    dim3 nBlocks(80,1,200); 
+    //dim3 nThreads(32,16,1);
+    //dim3 nBlocks(80,200,1); 
+//    dim3 nBlocks(nTrackCandidates % nThreads.x == 0 ? nTrackCandidates / nThreads.x : nTrackCandidates / nThreads.x + 1, maxT3s % nThreads.y == 0 ? maxT3s / nThreads.y : maxT3s / nThreads.y + 1, nOverlaps % nThreads.z == 0 ? nOverlaps / nThreads.z : nOverlaps / nThreads.z + 1);
     createExtendedTracksInGPU<<<nBlocks,nThreads>>>(*modulesInGPU, *hitsInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, *quintupletsInGPU, *pixelQuintupletsInGPU, *trackCandidatesInGPU, *trackExtensionsInGPU);
 
     cudaError_t cudaerr = cudaGetLastError();
@@ -1473,6 +1477,7 @@ void SDL::Event::createExtendedTracks()
     }cudaStreamSynchronize(stream);
 
  //   cudaFreeHost(nTriplets); 
+    cudaDeviceSynchronize();
 }
 #endif
 

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1427,7 +1427,7 @@ void SDL::Event::createExtendedTracks()
 
     dim3 nThreads(32,1,16);
     dim3 nBlocks(80,1,200); 
-    createExtendedTracksInGPU<<<nBlocks,nThreads>>>(*modulesInGPU, *hitsInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, *quintupletsInGPU, *pixelQuintupletsInGPU, *trackCandidatesInGPU, *trackExtensionsInGPU);
+    createExtendedTracksInGPU<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *hitsInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, *quintupletsInGPU, *pixelQuintupletsInGPU, *trackCandidatesInGPU, *trackExtensionsInGPU);
 
     cudaError_t cudaerr = cudaGetLastError();
     if(cudaerr != cudaSuccess)
@@ -1439,7 +1439,7 @@ void SDL::Event::createExtendedTracks()
     dim3 nThreadsT3T3(1,16,16);
     dim3 nBlocksT3T3(nLowerModules % nThreadsT3T3.x == 0 ? nLowerModules / nThreadsT3T3.x: nLowerModules / nThreadsT3T3.x + 1, maxT3s % nThreadsT3T3.y == 0 ? maxT3s / nThreadsT3T3.y : maxT3s / nThreadsT3T3.y + 1, maxT3s % nThreadsT3T3.z == 0 ? maxT3s / nThreadsT3T3.z : maxT3s / nThreadsT3T3.z + 1);
 
-    createT3T3ExtendedTracksInGPU<<<nBlocksT3T3, nThreadsT3T3>>>(*modulesInGPU, *hitsInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *quintupletsInGPU, *pixelTripletsInGPU, *pixelQuintupletsInGPU, *trackCandidatesInGPU, *trackExtensionsInGPU, nTrackCandidates);
+    createT3T3ExtendedTracksInGPU<<<nBlocksT3T3, nThreadsT3T3,0,stream>>>(*modulesInGPU, *hitsInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *quintupletsInGPU, *pixelTripletsInGPU, *pixelQuintupletsInGPU, *trackCandidatesInGPU, *trackExtensionsInGPU, nTrackCandidates);
 
     cudaerr = cudaDeviceSynchronize();
     if(cudaerr != cudaSuccess)
@@ -1451,7 +1451,7 @@ void SDL::Event::createExtendedTracks()
     int nThreadsDupCleaning = 512;
     int nBlocksDupCleaning = (nTrackCandidates % nThreadsDupCleaning == 0) ? nTrackCandidates / nThreadsDupCleaning : nTrackCandidates / nThreadsDupCleaning + 1;
 
-    cleanDuplicateExtendedTracks<<<nThreadsDupCleaning, nBlocksDupCleaning>>>(*trackExtensionsInGPU, nTrackCandidates);
+    cleanDuplicateExtendedTracks<<<nThreadsDupCleaning, nBlocksDupCleaning,0,stream>>>(*trackExtensionsInGPU, nTrackCandidates);
 
     cudaerr = cudaGetLastError();
     if(cudaerr != cudaSuccess)
@@ -1459,7 +1459,7 @@ void SDL::Event::createExtendedTracks()
 	    std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
     }cudaStreamSynchronize(stream);
 
-    cudaDeviceSynchronize();
+//    cudaDeviceSynchronize();
 }
 #endif
 

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -1532,15 +1532,17 @@ __global__ void createExtendedTracksInGPU(struct SDL::modules& modulesInGPU, str
     //int layerOverlap = blockIdx.z * blockDim.z + threadIdx.z;
     //layerOverlap
     //if(layerOverlap == 0 or layerOverlap >= 3) return;
-    for(int layerOverlap = 1+blockIdx.z*blockDim.z+threadIdx.z; layerOverlap < 3; layerOverlap+= blockDim.z*gridDim.z){
+    //for(int layerOverlap = 1+blockIdx.z*blockDim.z+threadIdx.z; layerOverlap < 3; layerOverlap+= blockDim.z*gridDim.z){
     //if(tcIdx >= *(trackCandidatesInGPU.nTrackCandidates)) return;
-    for(int tcIdx = blockIdx.y*blockDim.y+threadIdx.y; tcIdx < *(trackCandidatesInGPU.nTrackCandidates); tcIdx+= blockDim.y*gridDim.y){
+    for(int tcIdx = blockIdx.z*blockDim.z+threadIdx.z; tcIdx < *(trackCandidatesInGPU.nTrackCandidates); tcIdx+= blockDim.z*gridDim.z){
+    //for(int tcIdx = blockIdx.y*blockDim.y+threadIdx.y; tcIdx < *(trackCandidatesInGPU.nTrackCandidates); tcIdx+= blockDim.y*gridDim.y){
     short tcType = trackCandidatesInGPU.trackCandidateType[tcIdx];                                
     uint16_t outerT3StartingModuleIndex;
     unsigned int outerT3Index;
     if(tcType == 8) continue;//return;
+    for(int layerOverlap = 1+blockIdx.y*blockDim.y+threadIdx.y; layerOverlap < 3; layerOverlap+= blockDim.y*gridDim.y){
     //FIXME: Need to use staggering modules for the first outer T3 module itself!
-    else if(tcType == 7 or tcType == 4)
+    if(tcType == 7 or tcType == 4)
     {
         unsigned int outerT5Index = trackCandidatesInGPU.objectIndices[2 * tcIdx + 1];
         outerT3Index = quintupletsInGPU.tripletIndices[2 * outerT5Index];

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -1527,15 +1527,7 @@ __global__ void createT3T3ExtendedTracksInGPU(struct SDL::modules& modulesInGPU,
 
 __global__ void createExtendedTracksInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::quintuplets& quintupletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU, struct SDL::trackExtensions& trackExtensionsInGPU)
 {
-    //int tcIdx = blockIdx.x * blockDim.x + threadIdx.x;
-    //int t3ArrayIdx = blockIdx.y * blockDim.y + threadIdx.y;
-    //int layerOverlap = blockIdx.z * blockDim.z + threadIdx.z;
-    //layerOverlap
-    //if(layerOverlap == 0 or layerOverlap >= 3) return;
-    //for(int layerOverlap = 1+blockIdx.z*blockDim.z+threadIdx.z; layerOverlap < 3; layerOverlap+= blockDim.z*gridDim.z){
-    //if(tcIdx >= *(trackCandidatesInGPU.nTrackCandidates)) return;
     for(int tcIdx = blockIdx.z*blockDim.z+threadIdx.z; tcIdx < *(trackCandidatesInGPU.nTrackCandidates); tcIdx+= blockDim.z*gridDim.z){
-    //for(int tcIdx = blockIdx.y*blockDim.y+threadIdx.y; tcIdx < *(trackCandidatesInGPU.nTrackCandidates); tcIdx+= blockDim.y*gridDim.y){
     short tcType = trackCandidatesInGPU.trackCandidateType[tcIdx];                                
     uint16_t outerT3StartingModuleIndex;
     unsigned int outerT3Index;

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -1527,16 +1527,18 @@ __global__ void createT3T3ExtendedTracksInGPU(struct SDL::modules& modulesInGPU,
 
 __global__ void createExtendedTracksInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::quintuplets& quintupletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU, struct SDL::trackExtensions& trackExtensionsInGPU)
 {
-    int tcIdx = blockIdx.x * blockDim.x + threadIdx.x;
-    int t3ArrayIdx = blockIdx.y * blockDim.y + threadIdx.y;
-    int layerOverlap = blockIdx.z * blockDim.z + threadIdx.z;
+    //int tcIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    //int t3ArrayIdx = blockIdx.y * blockDim.y + threadIdx.y;
+    //int layerOverlap = blockIdx.z * blockDim.z + threadIdx.z;
     //layerOverlap
-    if(layerOverlap == 0 or layerOverlap >= 3) return;
-    if(tcIdx >= *(trackCandidatesInGPU.nTrackCandidates)) return;
+    //if(layerOverlap == 0 or layerOverlap >= 3) return;
+    for(int layerOverlap = 1+blockIdx.z*blockDim.z+threadIdx.z; layerOverlap < 3; layerOverlap+= blockDim.z*gridDim.z){
+    //if(tcIdx >= *(trackCandidatesInGPU.nTrackCandidates)) return;
+    for(int tcIdx = blockIdx.y*blockDim.y+threadIdx.y; tcIdx < *(trackCandidatesInGPU.nTrackCandidates); tcIdx+= blockDim.y*gridDim.y){
     short tcType = trackCandidatesInGPU.trackCandidateType[tcIdx];                                
     uint16_t outerT3StartingModuleIndex;
     unsigned int outerT3Index;
-    if(tcType == 8) return;
+    if(tcType == 8) continue;//return;
     //FIXME: Need to use staggering modules for the first outer T3 module itself!
     else if(tcType == 7 or tcType == 4)
     {
@@ -1552,7 +1554,8 @@ __global__ void createExtendedTracksInGPU(struct SDL::modules& modulesInGPU, str
     }
 
 
-    if(t3ArrayIdx >= tripletsInGPU.nTriplets[outerT3StartingModuleIndex]) return;
+    //if(t3ArrayIdx >= tripletsInGPU.nTriplets[outerT3StartingModuleIndex]) return;
+    for(int t3ArrayIdx = blockIdx.x*blockDim.x+threadIdx.x; t3ArrayIdx < tripletsInGPU.nTriplets[outerT3StartingModuleIndex]; t3ArrayIdx+= blockDim.x*gridDim.x){
     unsigned int t3Idx =  outerT3StartingModuleIndex * N_MAX_TRIPLETS_PER_MODULE + t3ArrayIdx;
     short constituentTCType[3];
     unsigned int constituentTCIndex[3];
@@ -1583,7 +1586,7 @@ __global__ void createExtendedTracksInGPU(struct SDL::modules& modulesInGPU, str
             trackCandidatesInGPU.partOfExtension[tcIdx] = true;
             tripletsInGPU.partOfExtension[t3Idx] = true;
         }
-    }
+    }}}}
 }
 
 __global__ void cleanDuplicateExtendedTracks(struct SDL::trackExtensions& trackExtensionsInGPU, unsigned int nTrackCandidates)

--- a/efficiency/bin/sdl_validate_efficiency
+++ b/efficiency/bin/sdl_validate_efficiency
@@ -123,12 +123,12 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; 
     run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 ${runExtension}
     :
 fi
-if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
-    run_gpu unified ${SAMPLE} ${NEVENTS} -8 -c ${runExtension}
-    :
-fi
-if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
-    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 -c ${runExtension}
-    :
-fi
+#if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
+#    run_gpu unified ${SAMPLE} ${NEVENTS} -8 -c ${runExtension}
+#    :
+#fi
+#if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
+#    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 -c ${runExtension}
+#    :
+#fi
 sdl_compare_efficiencies -i ${SAMPLE} -t ${GITHASH} -f


### PR DESCRIPTION
redoes the division of work for each thread in the track extensions.
blocks launched are close to the previous values without the host calculations. 
Bei found the issue with the sync. The previous stream sync did not work because the kernel launch was not launched on the stream. This is now fixed and the timing seems ok. 