### PR TITLE
Change Behavior for Storing Maximum Values of Objects

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -178,6 +178,7 @@ SDL::Event::~Event()
         delete[] pixelTripletsInCPU->pixelRadius;
         delete[] pixelTripletsInCPU->tripletRadius;
         delete pixelTripletsInCPU->nPixelTriplets;
+        delete pixelTripletsInCPU->totOccupancyPixelTriplets;
         delete pixelTripletsInCPU;
     }
 #endif
@@ -406,6 +407,7 @@ void SDL::Event::resetEvent()
         delete[] pixelTripletsInCPU->pixelRadius;
         delete[] pixelTripletsInCPU->tripletRadius;
         delete pixelTripletsInCPU->nPixelTriplets;
+        delete pixelTripletsInCPU->totOccupancyPixelTriplets;
         delete pixelTripletsInCPU;
         pixelTripletsInCPU = nullptr;
     }
@@ -2555,7 +2557,9 @@ SDL::pixelTriplets* SDL::Event::getPixelTriplets()
         pixelTripletsInCPU = new SDL::pixelTriplets;
 
         pixelTripletsInCPU->nPixelTriplets = new unsigned int;
+        pixelTripletsInCPU->totOccupancyPixelTriplets = new unsigned int;
         cudaMemcpyAsync(pixelTripletsInCPU->nPixelTriplets, pixelTripletsInGPU->nPixelTriplets, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
+        cudaMemcpyAsync(pixelTripletsInCPU->totOccupancyPixelTriplets, pixelTripletsInGPU->totOccupancyPixelTriplets, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 cudaStreamSynchronize(stream);
         unsigned int nPixelTriplets = *(pixelTripletsInCPU->nPixelTriplets);
         pixelTripletsInCPU->tripletIndices = new unsigned int[nPixelTriplets];

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -191,6 +191,7 @@ SDL::Event::~Event()
         delete[] pixelQuintupletsInCPU->isDup;
         delete[] pixelQuintupletsInCPU->score;
         delete pixelQuintupletsInCPU->nPixelQuintuplets;
+        delete pixelQuintupletsInCPU->totOccupancyPixelQuintuplets;
         delete pixelQuintupletsInCPU;
     }
 #endif
@@ -422,6 +423,7 @@ void SDL::Event::resetEvent()
         delete[] pixelQuintupletsInCPU->isDup;
         delete[] pixelQuintupletsInCPU->score;
         delete pixelQuintupletsInCPU->nPixelQuintuplets;
+        delete pixelQuintupletsInCPU->totOccupancyPixelQuintuplets;
         delete pixelQuintupletsInCPU;
         pixelQuintupletsInCPU = nullptr;
     }
@@ -2603,7 +2605,9 @@ SDL::pixelQuintuplets* SDL::Event::getPixelQuintuplets()
         pixelQuintupletsInCPU = new SDL::pixelQuintuplets;
 
         pixelQuintupletsInCPU->nPixelQuintuplets = new unsigned int;
+        pixelQuintupletsInCPU->totOccupancyPixelQuintuplets = new unsigned int;
         cudaMemcpyAsync(pixelQuintupletsInCPU->nPixelQuintuplets, pixelQuintupletsInGPU->nPixelQuintuplets, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
+        cudaMemcpyAsync(pixelQuintupletsInCPU->totOccupancyPixelQuintuplets, pixelQuintupletsInGPU->totOccupancyPixelQuintuplets, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 cudaStreamSynchronize(stream);
         unsigned int nPixelQuintuplets = *(pixelQuintupletsInCPU->nPixelQuintuplets);
 

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -145,6 +145,7 @@ SDL::Event::~Event()
     {
         delete[] tripletsInCPU->segmentIndices;
         delete[] tripletsInCPU->nTriplets;
+        delete[] tripletsInCPU->totOccupancyTriplets;
         delete[] tripletsInCPU->betaIn;
         delete[] tripletsInCPU->betaOut;
         delete[] tripletsInCPU->pt_beta;
@@ -370,6 +371,7 @@ void SDL::Event::resetEvent()
     {
         delete[] tripletsInCPU->segmentIndices;
         delete[] tripletsInCPU->nTriplets;
+        delete[] tripletsInCPU->totOccupancyTriplets;
         delete[] tripletsInCPU->betaIn;
         delete[] tripletsInCPU->betaOut;
         delete[] tripletsInCPU->pt_beta;
@@ -2474,6 +2476,7 @@ cudaStreamSynchronize(stream);
         unsigned int nMemoryLocations = (N_MAX_TRIPLETS_PER_MODULE) * (nLowerModules);
         tripletsInCPU->segmentIndices = new unsigned[2 * nMemoryLocations];
         tripletsInCPU->nTriplets = new unsigned int[nLowerModules];
+        tripletsInCPU->totOccupancyTriplets = new unsigned int[nLowerModules];
         tripletsInCPU->betaIn  = new FPX[nMemoryLocations];
         tripletsInCPU->betaOut = new FPX[nMemoryLocations];
         tripletsInCPU->pt_beta = new FPX[nMemoryLocations];
@@ -2486,6 +2489,7 @@ cudaStreamSynchronize(stream);
         cudaMemcpyAsync(tripletsInCPU->betaOut, tripletsInGPU->betaOut, nMemoryLocations * sizeof(FPX), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(tripletsInCPU->pt_beta, tripletsInGPU->pt_beta, nMemoryLocations * sizeof(FPX), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(tripletsInCPU->nTriplets, tripletsInGPU->nTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
+        cudaMemcpyAsync(tripletsInCPU->totOccupancyTriplets, tripletsInGPU->totOccupancyTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 
 cudaStreamSynchronize(stream);
     }

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -122,6 +122,7 @@ SDL::Event::~Event()
     {
         delete[] mdsInCPU->anchorHitIndices;
         delete[] mdsInCPU->nMDs;
+        delete[] mdsInCPU->totOccupancyMDs;
         delete mdsInCPU;
     }
 #endif
@@ -343,6 +344,7 @@ void SDL::Event::resetEvent()
     {
         delete[] mdsInCPU->anchorHitIndices;
         delete[] mdsInCPU->nMDs;
+        delete[] mdsInCPU->totOccupancyMDs;
         delete mdsInCPU;
         mdsInCPU = nullptr;
     }
@@ -875,6 +877,7 @@ cudaStreamSynchronize(stream);
    cudaMemcpyAsync(&(segmentsInGPU->nSegments)[pixelModuleIndex], &size, sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
    unsigned int mdSize = 2 * size;
    cudaMemcpyAsync(&(mdsInGPU->nMDs)[pixelModuleIndex], &mdSize, sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
+   cudaMemcpyAsync(&(mdsInGPU->totOccupancyMDs)[pixelModuleIndex], &mdSize, sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
 cudaStreamSynchronize(stream);
 
     //cudaFreeAsync(hitIndices0_dev,stream);
@@ -2399,10 +2402,12 @@ SDL::miniDoublets* SDL::Event::getMiniDoublets()
         mdsInCPU->anchorHitIndices = new unsigned int[nMemoryLocations];
         mdsInCPU->outerHitIndices = new unsigned int[nMemoryLocations];
         mdsInCPU->nMDs = new unsigned int[nLowerModules+1];
+        mdsInCPU->totOccupancyMDs = new unsigned int[nLowerModules+1];
         cudaMemcpyAsync(mdsInCPU->anchorHitIndices, mdsInGPU->anchorHitIndices, nMemoryLocations * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(mdsInCPU->outerHitIndices, mdsInGPU->outerHitIndices, nMemoryLocations * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 
         cudaMemcpyAsync(mdsInCPU->nMDs, mdsInGPU->nMDs, (nLowerModules+1) * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
+        cudaMemcpyAsync(mdsInCPU->totOccupancyMDs, mdsInGPU->totOccupancyMDs, (nLowerModules+1) * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 cudaStreamSynchronize(stream);
     }
     return mdsInCPU;

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -161,6 +161,7 @@ SDL::Event::~Event()
     {
         delete[] quintupletsInCPU->tripletIndices;
         delete[] quintupletsInCPU->nQuintuplets;
+        delete[] quintupletsInCPU->totOccupancyQuintuplets;
         delete[] quintupletsInCPU->lowerModuleIndices;
         delete[] quintupletsInCPU->innerRadius;
         delete[] quintupletsInCPU->outerRadius;
@@ -389,6 +390,7 @@ void SDL::Event::resetEvent()
     {
         delete[] quintupletsInCPU->tripletIndices;
         delete[] quintupletsInCPU->nQuintuplets;
+        delete[] quintupletsInCPU->totOccupancyQuintuplets;
         delete[] quintupletsInCPU->lowerModuleIndices;
         delete[] quintupletsInCPU->innerRadius;
         delete[] quintupletsInCPU->outerRadius;
@@ -2518,6 +2520,7 @@ cudaStreamSynchronize(stream);
         unsigned int nMemoryLocations = nEligibleT5Modules * N_MAX_QUINTUPLETS_PER_MODULE;
 
         quintupletsInCPU->nQuintuplets = new unsigned int[nLowerModules];
+        quintupletsInCPU->totOccupancyQuintuplets = new unsigned int[nLowerModules];
         quintupletsInCPU->tripletIndices = new unsigned int[2 * nMemoryLocations];
         quintupletsInCPU->lowerModuleIndices = new uint16_t[5 * nMemoryLocations];
         quintupletsInCPU->innerRadius = new FPX[nMemoryLocations];
@@ -2528,6 +2531,7 @@ cudaStreamSynchronize(stream);
         quintupletsInCPU->phi = new FPX[nMemoryLocations];
         quintupletsInCPU->regressionRadius = new float[nMemoryLocations];
         cudaMemcpyAsync(quintupletsInCPU->nQuintuplets, quintupletsInGPU->nQuintuplets,  nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
+        cudaMemcpyAsync(quintupletsInCPU->totOccupancyQuintuplets, quintupletsInGPU->totOccupancyQuintuplets,  nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(quintupletsInCPU->tripletIndices, quintupletsInGPU->tripletIndices, 2 * nMemoryLocations * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(quintupletsInCPU->lowerModuleIndices, quintupletsInGPU->lowerModuleIndices, 5 * nMemoryLocations * sizeof(uint16_t), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(quintupletsInCPU->innerRadius, quintupletsInGPU->innerRadius, nMemoryLocations * sizeof(FPX), cudaMemcpyDeviceToHost,stream);

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -212,6 +212,7 @@ SDL::Event::~Event()
     if(trackExtensionsInCPU != nullptr)
     {
         delete[] trackExtensionsInCPU->nTrackExtensions;
+        delete[] trackExtensionsInCPU->totOccupancyTrackExtensions;
         delete[] trackExtensionsInCPU->constituentTCTypes;
         delete[] trackExtensionsInCPU->constituentTCIndices;
         delete[] trackExtensionsInCPU->nLayerOverlaps;
@@ -445,6 +446,7 @@ void SDL::Event::resetEvent()
     if(trackExtensionsInCPU != nullptr)
     {
         delete[] trackExtensionsInCPU->nTrackExtensions;
+        delete[] trackExtensionsInCPU->totOccupancyTrackExtensions;
         delete[] trackExtensionsInCPU->constituentTCTypes;
         delete[] trackExtensionsInCPU->constituentTCIndices;
         delete[] trackExtensionsInCPU->nLayerOverlaps;
@@ -2767,6 +2769,7 @@ SDL::trackExtensions* SDL::Event::getTrackExtensions()
 #endif
        std::cout<<"nTrackCandidates = "<<nTrackCandidates<<std::endl;
        trackExtensionsInCPU->nTrackExtensions = new unsigned int[nTrackCandidates];
+       trackExtensionsInCPU->totOccupancyTrackExtensions = new unsigned int[nTrackCandidates];
        trackExtensionsInCPU->constituentTCTypes = new short[3 * maxTrackExtensions];
        trackExtensionsInCPU->constituentTCIndices = new unsigned int[3 * maxTrackExtensions];
        trackExtensionsInCPU->nLayerOverlaps = new uint8_t[2 * maxTrackExtensions];
@@ -2775,6 +2778,7 @@ SDL::trackExtensions* SDL::Event::getTrackExtensions()
        trackExtensionsInCPU->regressionRadius = new FPX[maxTrackExtensions];
 
        cudaMemcpyAsync(trackExtensionsInCPU->nTrackExtensions, trackExtensionsInGPU->nTrackExtensions, nTrackCandidates * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+       cudaMemcpyAsync(trackExtensionsInCPU->totOccupancyTrackExtensions, trackExtensionsInGPU->totOccupancyTrackExtensions, nTrackCandidates * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
        cudaMemcpy(trackExtensionsInCPU->constituentTCTypes, trackExtensionsInGPU->constituentTCTypes, 3 * maxTrackExtensions * sizeof(short), cudaMemcpyDeviceToHost);
        cudaMemcpyAsync(trackExtensionsInCPU->constituentTCIndices, trackExtensionsInGPU->constituentTCIndices, 3 * maxTrackExtensions * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
 

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -688,6 +688,7 @@ __global__ void createPixelQuintupletsInGPUFromMap(struct SDL::modules& modulesI
 
             if(success)
             {
+                atomicAdd(pixelQuintupletsInGPU.totOccupancyPixelQuintuplets, 1);
                 if(*pixelQuintupletsInGPU.nPixelQuintuplets >= N_MAX_PIXEL_QUINTUPLETS)
                 {
 #ifdef Warnings

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -133,6 +133,7 @@ __global__ void createSegmentsInGPU(struct SDL::modules& modulesInGPU, struct SD
 
             if(success)
             {
+                atomicAdd(&segmentsInGPU.totOccupancySegments[innerLowerModuleIndex],1);
                 if(segmentsInGPU.nSegments[innerLowerModuleIndex] >= N_MAX_SEGMENTS_PER_MODULE)
                 {
 #ifdef Warnings

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -609,6 +609,7 @@ __global__ void createQuintupletsInGPU(struct SDL::modules& modulesInGPU, struct
                 {
                     return;
                 } // ignore anything else TODO: move this to start, before object is made (faster)
+                atomicAdd(&quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1);
                 if(quintupletsInGPU.nQuintuplets[lowerModule1] >= N_MAX_QUINTUPLETS_PER_MODULE)
                 {
 #ifdef Warnings

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -1449,6 +1449,7 @@ __global__ void createT3T3ExtendedTracksInGPU(struct SDL::modules& modulesInGPU,
 
         if(success and nLayerOverlaps[0] == 2)
         {
+            atomicAdd(&trackExtensionsInGPU.totOccupancyTrackExtensions[nTrackCandidates], 1);
             if(trackExtensionsInGPU.nTrackExtensions[nTrackCandidates] >= N_MAX_T3T3_TRACK_EXTENSIONS)
             {
 #ifdef Warnings
@@ -1487,6 +1488,7 @@ __global__ void createT3T3ExtendedTracksInGPU(struct SDL::modules& modulesInGPU,
 
         if(success and nLayerOverlaps[0] == 1 and nHitOverlaps[0] != 2)        
         {
+            atomicAdd(&trackExtensionsInGPU.totOccupancyTrackExtensions[nTrackCandidates], 1);
             if(trackExtensionsInGPU.nTrackExtensions[nTrackCandidates] >= N_MAX_T3T3_TRACK_EXTENSIONS)
             {
 #ifdef Warnings
@@ -1546,6 +1548,7 @@ __global__ void createExtendedTracksInGPU(struct SDL::modules& modulesInGPU, str
     bool success = runTrackExtensionDefaultAlgo(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, pixelTripletsInGPU, pixelQuintupletsInGPU, trackCandidatesInGPU, tcIdx, t3Idx, tcType, 3, outerT3Index, layerOverlap, constituentTCType, constituentTCIndex, nLayerOverlaps, nHitOverlaps, rPhiChiSquared, rzChiSquared, regressionRadius, innerRadius, outerRadius);
     if(success)
     {
+        atomicAdd(&trackExtensionsInGPU.nTrackExtensions[tcIdx], 1);
         if(trackExtensionsInGPU.nTrackExtensions[tcIdx] >= N_MAX_TRACK_EXTENSIONS_PER_TC)
         {
 #ifdef Warnings

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -531,6 +531,7 @@ __global__ void createPixelTripletsInGPUFromMap(struct SDL::modules& modulesInGP
                 float phi_pix = segmentsInGPU.phi[pixelSegmentArrayIndex];
                 float pt = segmentsInGPU.ptIn[pixelSegmentArrayIndex];
                 float score = rPhiChiSquared+rPhiChiSquaredInwards;
+                atomicAdd(pixelTripletsInGPU.totOccupancyPixelTriplets, 1);
                 if(*pixelTripletsInGPU.nPixelTriplets >= N_MAX_PIXEL_TRIPLETS)
                 {
 #ifdef Warnings

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -1548,7 +1548,7 @@ __global__ void createExtendedTracksInGPU(struct SDL::modules& modulesInGPU, str
     bool success = runTrackExtensionDefaultAlgo(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, pixelTripletsInGPU, pixelQuintupletsInGPU, trackCandidatesInGPU, tcIdx, t3Idx, tcType, 3, outerT3Index, layerOverlap, constituentTCType, constituentTCIndex, nLayerOverlaps, nHitOverlaps, rPhiChiSquared, rzChiSquared, regressionRadius, innerRadius, outerRadius);
     if(success)
     {
-        atomicAdd(&trackExtensionsInGPU.nTrackExtensions[tcIdx], 1);
+        atomicAdd(&trackExtensionsInGPU.totOccupancyTrackExtensions[tcIdx], 1);
         if(trackExtensionsInGPU.nTrackExtensions[tcIdx] >= N_MAX_TRACK_EXTENSIONS_PER_TC)
         {
 #ifdef Warnings

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -191,6 +191,7 @@ __global__ void createTripletsInGPU(struct SDL::modules& modulesInGPU, struct SD
         bool success = runTripletDefaultAlgo(modulesInGPU, mdsInGPU, segmentsInGPU, innerInnerLowerModuleIndex, middleLowerModuleIndex, outerOuterLowerModuleIndex, innerSegmentIndex, outerSegmentIndex, zOut, rtOut, deltaPhiPos, deltaPhi, betaIn, betaOut, pt_beta, zLo, zHi, rtLo, rtHi, zLoPointed, zHiPointed, sdlCut, betaInCut, betaOutCut, deltaBetaCut, kZ);
 
         if(success) {
+          atomicAdd(&tripletsInGPU.totOccupancyTriplets[innerInnerLowerModuleIndex], 1);
           if(tripletsInGPU.nTriplets[innerInnerLowerModuleIndex] >= N_MAX_TRIPLETS_PER_MODULE) {
 #ifdef Warnings
             printf("Triplet excess alert! Module index = %d\n",innerInnerLowerModuleIndex);

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -68,6 +68,7 @@ __global__ void createMiniDoubletsInGPU(struct SDL::modules& modulesInGPU, struc
 
             if(success)
             {
+                atomicAdd(&mdsInGPU.totOccupancyMDs[lowerModuleIndex],1);
                 if(mdsInGPU.nMDs[lowerModuleIndex] >= N_MAX_MD_PER_MODULES)
                 {
 #ifdef Warnings

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -33,6 +33,7 @@ namespace SDL
         unsigned int* outerHitIndices;
         uint16_t* moduleIndices;
         unsigned int* nMDs; //counter per module
+        unsigned int* totOccupancyMDs; //counter per module
         float* dphichanges;
 
         float* dzs; //will store drt if the module is endcap

--- a/SDL/PixelQuintuplet.cuh
+++ b/SDL/PixelQuintuplet.cuh
@@ -31,6 +31,7 @@ namespace SDL
         unsigned int* pixelIndices;
         unsigned int* T5Indices;
         unsigned int* nPixelQuintuplets;
+        unsigned int* totOccupancyPixelQuintuplets;
         bool* isDup;
         FPX* score;
         FPX* eta;

--- a/SDL/PixelTriplet.cuh
+++ b/SDL/PixelTriplet.cuh
@@ -29,6 +29,7 @@ namespace SDL
         unsigned int* pixelSegmentIndices;         
         unsigned int* tripletIndices;
         unsigned int* nPixelTriplets; //size 1
+        unsigned int* totOccupancyPixelTriplets; //size 1
 
         float* pixelRadiusError;
         float* rPhiChiSquared;

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -9,6 +9,7 @@ SDL::quintuplets::quintuplets()
     tripletIndices = nullptr;
     lowerModuleIndices = nullptr;
     nQuintuplets = nullptr;
+    totOccupancyQuintuplets = nullptr;
     innerRadius = nullptr;
     outerRadius = nullptr;
     regressionRadius = nullptr;
@@ -52,6 +53,7 @@ void SDL::quintuplets::freeMemoryCache()
     cms::cuda::free_device(dev,tripletIndices);
     cms::cuda::free_device(dev, lowerModuleIndices);
     cms::cuda::free_device(dev, nQuintuplets);
+    cms::cuda::free_device(dev, totOccupancyQuintuplets);
     cms::cuda::free_device(dev, innerRadius);
     cms::cuda::free_device(dev, outerRadius);
     cms::cuda::free_device(dev, partOfPT5);
@@ -67,6 +69,7 @@ void SDL::quintuplets::freeMemoryCache()
     cms::cuda::free_managed(tripletIndices);
     cms::cuda::free_managed(lowerModuleIndices);
     cms::cuda::free_managed(nQuintuplets);
+    cms::cuda::free_managed(totOccupancyQuintuplets);
     cms::cuda::free_managed(innerRadius);
     cms::cuda::free_managed(outerRadius);
     cms::cuda::free_managed(partOfPT5);
@@ -87,6 +90,7 @@ void SDL::quintuplets::freeMemory(cudaStream_t stream)
     cudaFree(tripletIndices);
     cudaFree(lowerModuleIndices);
     cudaFree(nQuintuplets);
+    cudaFree(totOccupancyQuintuplets);
     cudaFree(innerRadius);
     cudaFree(outerRadius);
     cudaFree(regressionRadius);
@@ -176,6 +180,7 @@ void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsI
     quintupletsInGPU.tripletIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations * 2 * sizeof(unsigned int), stream);
     quintupletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_managed(nMemoryLocations * 5 * sizeof(uint16_t), stream);
     quintupletsInGPU.nQuintuplets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int), stream);
+    quintupletsInGPU.totOccupancyQuintuplets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int), stream);
     quintupletsInGPU.innerRadius = (FPX*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(FPX), stream);
     quintupletsInGPU.outerRadius = (FPX*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(FPX), stream);
     quintupletsInGPU.pt = (FPX*)cms::cuda::allocate_managed(nMemoryLocations *4* sizeof(FPX), stream);
@@ -192,6 +197,7 @@ void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsI
     cudaMallocManaged(&quintupletsInGPU.lowerModuleIndices, 5 * nMemoryLocations * sizeof(uint16_t));
 
     cudaMallocManaged(&quintupletsInGPU.nQuintuplets, nLowerModules * sizeof(unsigned int));
+    cudaMallocManaged(&quintupletsInGPU.totOccupancyQuintuplets, nLowerModules * sizeof(unsigned int));
     cudaMallocManaged(&quintupletsInGPU.innerRadius, nMemoryLocations * sizeof(FPX));
     cudaMallocManaged(&quintupletsInGPU.outerRadius, nMemoryLocations * sizeof(FPX));
     cudaMallocManaged(&quintupletsInGPU.pt, nMemoryLocations *4* sizeof(FPX));
@@ -234,6 +240,7 @@ void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsI
 //    }
 
     cudaMemsetAsync(quintupletsInGPU.nQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
+    cudaMemsetAsync(quintupletsInGPU.totOccupancyQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(quintupletsInGPU.isDup,0,nMemoryLocations * sizeof(bool),stream);
     cudaMemsetAsync(quintupletsInGPU.partOfPT5,0,nMemoryLocations * sizeof(bool),stream);
     cudaStreamSynchronize(stream);
@@ -249,6 +256,7 @@ void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintuplets
     quintupletsInGPU.tripletIndices = (unsigned int*)cms::cuda::allocate_device(dev, 2 * nMemoryLocations * sizeof(unsigned int), stream);
     quintupletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_device(dev, 5 * nMemoryLocations * sizeof(uint16_t), stream);
     quintupletsInGPU.nQuintuplets = (unsigned int*)cms::cuda::allocate_device(dev, nLowerModules * sizeof(unsigned int), stream);
+    quintupletsInGPU.totOccupancyQuintuplets = (unsigned int*)cms::cuda::allocate_device(dev, nLowerModules * sizeof(unsigned int), stream);
     quintupletsInGPU.innerRadius = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(FPX), stream);
     quintupletsInGPU.outerRadius = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(FPX), stream);
     quintupletsInGPU.pt = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations *4* sizeof(FPX), stream);
@@ -264,6 +272,7 @@ void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintuplets
     cudaMalloc(&quintupletsInGPU.tripletIndices, 2 * nMemoryLocations * sizeof(unsigned int));
     cudaMalloc(&quintupletsInGPU.lowerModuleIndices, 5 * nMemoryLocations * sizeof(uint16_t));
     cudaMalloc(&quintupletsInGPU.nQuintuplets, nLowerModules * sizeof(unsigned int));
+    cudaMalloc(&quintupletsInGPU.totOccupancyQuintuplets, nLowerModules * sizeof(unsigned int));
     cudaMalloc(&quintupletsInGPU.innerRadius, nMemoryLocations * sizeof(FPX));
     cudaMalloc(&quintupletsInGPU.outerRadius, nMemoryLocations * sizeof(FPX));
     cudaMalloc(&quintupletsInGPU.pt, nMemoryLocations *4* sizeof(FPX));
@@ -277,6 +286,7 @@ void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintuplets
     cudaMalloc(&quintupletsInGPU.hitIndices, nMemoryLocations * 10 * sizeof(unsigned int));
 #endif
     cudaMemsetAsync(quintupletsInGPU.nQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
+    cudaMemsetAsync(quintupletsInGPU.totOccupancyQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(quintupletsInGPU.isDup,0,nMemoryLocations * sizeof(bool),stream);
     cudaMemsetAsync(quintupletsInGPU.partOfPT5,0,nMemoryLocations * sizeof(bool),stream);
     cudaStreamSynchronize(stream);

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -29,6 +29,7 @@ namespace SDL
         unsigned int* tripletIndices;
         uint16_t* lowerModuleIndices;
         unsigned int* nQuintuplets;
+        unsigned int* totOccupancyQuintuplets;
         FPX* innerRadius;
         FPX* outerRadius;
         FPX* pt;

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -11,6 +11,7 @@ void SDL::segments::resetMemory(unsigned int maxSegments, unsigned int nLowerMod
     cudaMemsetAsync(mdIndices,0, nMemoryLocations * 2 * sizeof(unsigned int),stream);
     cudaMemsetAsync(innerLowerModuleIndices,0, nMemoryLocations * 2 * sizeof(uint16_t),stream);
     cudaMemsetAsync(nSegments, 0,(nLowerModules+1) * sizeof(unsigned int),stream);
+    cudaMemsetAsync(totOccupancySegments, 0,(nLowerModules+1) * sizeof(unsigned int),stream);
     cudaMemsetAsync(dPhis, 0,(nMemoryLocations * 6 )*sizeof(FPX),stream);
     cudaMemsetAsync(ptIn, 0,(maxPixelSegments * 8)*sizeof(float),stream);
     cudaMemsetAsync(superbin, 0,(maxPixelSegments )*sizeof(int),stream);
@@ -33,6 +34,7 @@ void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned
     segmentsInGPU.mdIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations*4 *sizeof(unsigned int),stream);
     segmentsInGPU.innerLowerModuleIndices = (uint16_t*)cms::cuda::allocate_managed(nMemoryLocations*2 *sizeof(uint16_t),stream);
     segmentsInGPU.nSegments = (unsigned int*)cms::cuda::allocate_managed((nLowerModules + 1) *sizeof(unsigned int),stream);
+    segmentsInGPU.totOccupancySegments = (unsigned int*)cms::cuda::allocate_managed((nLowerModules + 1) *sizeof(unsigned int),stream);
     segmentsInGPU.dPhis = (FPX*)cms::cuda::allocate_managed(nMemoryLocations*6  *sizeof(FPX),stream);
     segmentsInGPU.ptIn = (float*)cms::cuda::allocate_managed(maxPixelSegments * 8 *sizeof(float),stream);
     segmentsInGPU.superbin = (int*)cms::cuda::allocate_managed((maxPixelSegments) *sizeof(int),stream);
@@ -48,6 +50,7 @@ void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned
     cudaMallocManaged(&segmentsInGPU.mdIndices, nMemoryLocations * 4 * sizeof(unsigned int));
     cudaMallocManaged(&segmentsInGPU.innerLowerModuleIndices, nMemoryLocations * 2 * sizeof(uint16_t));
     cudaMallocManaged(&segmentsInGPU.nSegments, (nLowerModules + 1) * sizeof(unsigned int));
+    cudaMallocManaged(&segmentsInGPU.totOccupancySegments, (nLowerModules + 1) * sizeof(unsigned int));
     cudaMallocManaged(&segmentsInGPU.dPhis, nMemoryLocations * 6 *sizeof(FPX));
     cudaMallocManaged(&segmentsInGPU.ptIn, maxPixelSegments * 8*sizeof(float));
     cudaMallocManaged(&segmentsInGPU.superbin, (maxPixelSegments )*sizeof(int));
@@ -100,6 +103,7 @@ void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned
     segmentsInGPU.phi    = segmentsInGPU.ptIn + maxPixelSegments * 7;
     
     cudaMemsetAsync(segmentsInGPU.nSegments,0, (nLowerModules + 1) * sizeof(unsigned int),stream);
+    cudaMemsetAsync(segmentsInGPU.totOccupancySegments,0, (nLowerModules + 1) * sizeof(unsigned int),stream);
     cudaMemsetAsync(segmentsInGPU.partOfPT5, false, maxPixelSegments * sizeof(bool),stream);
     cudaStreamSynchronize(stream);
 
@@ -116,6 +120,7 @@ void SDL::createSegmentsInExplicitMemory(struct segments& segmentsInGPU, unsigne
     segmentsInGPU.mdIndices = (unsigned int*)cms::cuda::allocate_device(dev,nMemoryLocations*4 *sizeof(unsigned int),stream);
     segmentsInGPU.innerLowerModuleIndices = (uint16_t*)cms::cuda::allocate_device(dev,nMemoryLocations*2 *sizeof(uint16_t),stream);
     segmentsInGPU.nSegments = (unsigned int*)cms::cuda::allocate_device(dev, (nLowerModules + 1) *sizeof(unsigned int),stream);
+    segmentsInGPU.totOccupancySegments = (unsigned int*)cms::cuda::allocate_device(dev, (nLowerModules + 1) *sizeof(unsigned int),stream);
     segmentsInGPU.dPhis = (FPX*)cms::cuda::allocate_device(dev,nMemoryLocations*6 *sizeof(FPX),stream);
     segmentsInGPU.ptIn = (float*)cms::cuda::allocate_device(dev, maxPixelSegments * 8 *sizeof(float),stream);
     segmentsInGPU.superbin = (int*)cms::cuda::allocate_device(dev,(maxPixelSegments) *sizeof(int),stream);
@@ -132,6 +137,7 @@ void SDL::createSegmentsInExplicitMemory(struct segments& segmentsInGPU, unsigne
     cudaMalloc(&segmentsInGPU.mdIndices, nMemoryLocations * 4 * sizeof(unsigned int));
     cudaMalloc(&segmentsInGPU.innerLowerModuleIndices, nMemoryLocations * 2 * sizeof(uint16_t));
     cudaMalloc(&segmentsInGPU.nSegments, (nLowerModules + 1) * sizeof(unsigned int));
+    cudaMalloc(&segmentsInGPU.totOccupancySegments, (nLowerModules + 1) * sizeof(unsigned int));
     cudaMalloc(&segmentsInGPU.dPhis, nMemoryLocations * 6 *sizeof(FPX));
     cudaMalloc(&segmentsInGPU.ptIn, maxPixelSegments * 8*sizeof(float));
     cudaMalloc(&segmentsInGPU.superbin, (maxPixelSegments )*sizeof(int));
@@ -166,6 +172,7 @@ void SDL::createSegmentsInExplicitMemory(struct segments& segmentsInGPU, unsigne
     segmentsInGPU.phi    = segmentsInGPU.ptIn + maxPixelSegments * 7;
 
     cudaMemsetAsync(segmentsInGPU.nSegments,0, (nLowerModules + 1) * sizeof(unsigned int),stream);
+    cudaMemsetAsync(segmentsInGPU.totOccupancySegments,0, (nLowerModules + 1) * sizeof(unsigned int),stream);
     cudaMemsetAsync(segmentsInGPU.partOfPT5, false, maxPixelSegments * sizeof(bool),stream);
     cudaStreamSynchronize(stream);
 
@@ -188,6 +195,7 @@ SDL::segments::segments()
     outerMiniDoubletAnchorHitIndices = nullptr;
 
     nSegments = nullptr;
+    totOccupancySegments = nullptr;
     dPhis = nullptr;
     dPhiMins = nullptr;
     dPhiMaxs = nullptr;
@@ -230,6 +238,7 @@ void SDL::segments::freeMemoryCache()
     cms::cuda::free_device(dev,dPhis);
     cms::cuda::free_device(dev,ptIn);
     cms::cuda::free_device(dev,nSegments);
+    cms::cuda::free_device(dev,totOccupancySegments);
     cms::cuda::free_device(dev,superbin);
     cms::cuda::free_device(dev,pixelType);
     cms::cuda::free_device(dev,isQuad);
@@ -245,6 +254,7 @@ void SDL::segments::freeMemoryCache()
     cms::cuda::free_managed(dPhis);
     cms::cuda::free_managed(ptIn);
     cms::cuda::free_managed(nSegments);
+    cms::cuda::free_managed(totOccupancySegments);
     cms::cuda::free_managed(superbin);
     cms::cuda::free_managed(pixelType);
     cms::cuda::free_managed(isQuad);
@@ -261,6 +271,7 @@ void SDL::segments::freeMemory(cudaStream_t stream)
     cudaFree(mdIndices);
     cudaFree(innerLowerModuleIndices);
     cudaFree(nSegments);
+    cudaFree(totOccupancySegments);
     cudaFree(dPhis);
     cudaFree(ptIn);
     cudaFree(superbin);

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -31,6 +31,7 @@ namespace SDL
         unsigned int* outerMiniDoubletAnchorHitIndices;
         
         unsigned int* nSegments; //number of segments per inner lower module
+        unsigned int* totOccupancySegments; //number of segments per inner lower module
         FPX* dPhis;
         FPX* dPhiMins;
         FPX* dPhiMaxs;

--- a/SDL/TrackExtensions.cuh
+++ b/SDL/TrackExtensions.cuh
@@ -32,7 +32,8 @@ namespace SDL
         unsigned int* constituentTCIndices;
         uint8_t* nLayerOverlaps;
         uint8_t* nHitOverlaps;
-        unsigned int* nTrackExtensions; //overall counter!
+        unsigned int* nTrackExtensions;
+        unsigned int* totOccupancyTrackExtensions; //overall counter!
         FPX* rPhiChiSquared;
         FPX* rzChiSquared;
         FPX* regressionRadius;

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -8,6 +8,7 @@ void SDL::triplets::resetMemory(unsigned int maxTriplets, unsigned int nLowerMod
 {
     cudaMemsetAsync(segmentIndices,0, 5 * maxTriplets * nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(nTriplets,0, nLowerModules * sizeof(unsigned int),stream);
+    cudaMemsetAsync(totOccupancyTriplets,0, nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(betaIn,0, maxTriplets * nLowerModules * 3 * sizeof(FPX),stream);
     cudaMemsetAsync(partOfPT5,0, maxTriplets * nLowerModules * sizeof(bool),stream);
     cudaMemsetAsync(partOfT5,0, maxTriplets * nLowerModules * sizeof(bool));
@@ -20,6 +21,7 @@ void SDL::createTripletsInUnifiedMemory(struct triplets& tripletsInGPU, unsigned
     tripletsInGPU.segmentIndices = (unsigned int*)cms::cuda::allocate_managed(maxTriplets * nLowerModules * sizeof(unsigned int) *2/*5*/,stream);
     tripletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_managed(maxTriplets * nLowerModules * sizeof(uint16_t) *3,stream);
     tripletsInGPU.nTriplets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int),stream);
+    tripletsInGPU.totOccupancyTriplets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int),stream);
     tripletsInGPU.betaIn = (FPX*)cms::cuda::allocate_managed(maxTriplets * nLowerModules * sizeof(FPX) * 3,stream);
     tripletsInGPU.partOfPT5 = (bool*)cms::cuda::allocate_managed(maxTriplets * nLowerModules * sizeof(bool), stream);
     tripletsInGPU.partOfPT3 = (bool*)cms::cuda::allocate_managed(maxTriplets * nLowerModules * sizeof(bool), stream);
@@ -31,6 +33,7 @@ void SDL::createTripletsInUnifiedMemory(struct triplets& tripletsInGPU, unsigned
     cudaMallocManaged(&tripletsInGPU.segmentIndices, /*5*/2 * maxTriplets * nLowerModules * sizeof(unsigned int));
     cudaMallocManaged(&tripletsInGPU.lowerModuleIndices, 3 * maxTriplets * nLowerModules * sizeof(uint16_t));
     cudaMallocManaged(&tripletsInGPU.nTriplets, nLowerModules * sizeof(unsigned int));
+    cudaMallocManaged(&tripletsInGPU.totOccupancyTriplets, nLowerModules * sizeof(unsigned int));
     cudaMallocManaged(&tripletsInGPU.betaIn, maxTriplets * nLowerModules * 3 * sizeof(FPX));
 
     cudaMallocManaged(&tripletsInGPU.partOfPT5, maxTriplets * nLowerModules * sizeof(bool));
@@ -61,6 +64,7 @@ void SDL::createTripletsInUnifiedMemory(struct triplets& tripletsInGPU, unsigned
     tripletsInGPU.betaOut = tripletsInGPU.betaIn + nLowerModules * maxTriplets ;
     tripletsInGPU.pt_beta = tripletsInGPU.betaIn + nLowerModules * maxTriplets * 2;
     cudaMemsetAsync(tripletsInGPU.nTriplets,0,nLowerModules * sizeof(unsigned int),stream);
+    cudaMemsetAsync(tripletsInGPU.totOccupancyTriplets,0,nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(tripletsInGPU.partOfPT5,0,maxTriplets*nLowerModules * sizeof(bool),stream);
 #ifdef TRACK_EXTENSIONS
     cudaMemsetAsync(tripletsInGPU.partOfPT3,0,maxTriplets*nLowerModules * sizeof(bool),stream);
@@ -79,6 +83,7 @@ void SDL::createTripletsInExplicitMemory(struct triplets& tripletsInGPU, unsigne
     tripletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_device(dev,maxTriplets * nLowerModules * sizeof(uint16_t) *3,stream);
     tripletsInGPU.betaIn = (FPX*)cms::cuda::allocate_device(dev,maxTriplets * nLowerModules * sizeof(FPX) *3,stream);
     tripletsInGPU.nTriplets = (unsigned int*)cms::cuda::allocate_device(dev,nLowerModules * sizeof(unsigned int),stream);
+    tripletsInGPU.totOccupancyTriplets = (unsigned int*)cms::cuda::allocate_device(dev,nLowerModules * sizeof(unsigned int),stream);
     tripletsInGPU.partOfPT5 = (bool*)cms::cuda::allocate_device(dev, maxTriplets * nLowerModules * sizeof(bool), stream);
     tripletsInGPU.partOfPT3 = (bool*)cms::cuda::allocate_device(dev, maxTriplets * nLowerModules * sizeof(bool), stream);
     tripletsInGPU.partOfT5 = (bool*)cms::cuda::allocate_device(dev, maxTriplets * nLowerModules * sizeof(bool), stream);
@@ -91,6 +96,7 @@ void SDL::createTripletsInExplicitMemory(struct triplets& tripletsInGPU, unsigne
     cudaMalloc(&tripletsInGPU.lowerModuleIndices, 3 * maxTriplets * nLowerModules * sizeof(uint16_t));
     cudaMalloc(&tripletsInGPU.betaIn, maxTriplets * nLowerModules * 3 * sizeof(FPX));
     cudaMalloc(&tripletsInGPU.nTriplets, nLowerModules * sizeof(unsigned int));
+    cudaMalloc(&tripletsInGPU.totOccupancyTriplets, nLowerModules * sizeof(unsigned int));
     cudaMalloc(&tripletsInGPU.partOfPT5, maxTriplets * nLowerModules * sizeof(bool));
     cudaMalloc(&tripletsInGPU.partOfPT3, maxTriplets * nLowerModules * sizeof(bool));
     cudaMalloc(&tripletsInGPU.partOfT5, maxTriplets * nLowerModules * sizeof(bool));
@@ -100,6 +106,7 @@ void SDL::createTripletsInExplicitMemory(struct triplets& tripletsInGPU, unsigne
     cudaMalloc(&tripletsInGPU.hitIndices, maxTriplets * nLowerModules * 6 * sizeof(unsigned int));
 #endif
     cudaMemsetAsync(tripletsInGPU.nTriplets,0,nLowerModules * sizeof(unsigned int),stream);
+    cudaMemsetAsync(tripletsInGPU.totOccupancyTriplets,0,nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(tripletsInGPU.partOfPT5,0,maxTriplets*nLowerModules * sizeof(bool),stream);
     cudaMemsetAsync(tripletsInGPU.partOfPT3,0,maxTriplets*nLowerModules * sizeof(bool),stream);
     cudaMemsetAsync(tripletsInGPU.partOfT5,0,maxTriplets*nLowerModules * sizeof(bool),stream);
@@ -202,6 +209,7 @@ void SDL::triplets::freeMemoryCache()
     cms::cuda::free_device(dev,lowerModuleIndices);
     cms::cuda::free_device(dev,betaIn);
     cms::cuda::free_device(dev,nTriplets);
+    cms::cuda::free_device(dev,totOccupancyTriplets);
     cms::cuda::free_device(dev, partOfPT5);
     cms::cuda::free_device(dev, partOfPT3);
     cms::cuda::free_device(dev, partOfT5);
@@ -213,6 +221,7 @@ void SDL::triplets::freeMemoryCache()
     cms::cuda::free_managed(lowerModuleIndices);
     cms::cuda::free_managed(betaIn);
     cms::cuda::free_managed(nTriplets);
+    cms::cuda::free_managed(totOccupancyTriplets);
     cms::cuda::free_managed(partOfPT5);
     cms::cuda::free_managed(partOfPT3);
     cms::cuda::free_managed(partOfT5);
@@ -226,6 +235,7 @@ void SDL::triplets::freeMemory(cudaStream_t stream)
     cudaFree(segmentIndices);
     cudaFree(lowerModuleIndices);
     cudaFree(nTriplets);
+    cudaFree(totOccupancyTriplets);
     cudaFree(betaIn);
     cudaFree(partOfPT5);
     cudaFree(partOfPT3);

--- a/SDL/Triplet.cuh
+++ b/SDL/Triplet.cuh
@@ -28,6 +28,7 @@ namespace SDL
         unsigned int* segmentIndices;
         uint16_t* lowerModuleIndices; //3 of them now
         unsigned int* nTriplets;
+        unsigned int* totOccupancyTriplets;
 
         //for track extensions
         uint8_t* logicalLayers;

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -1396,7 +1396,7 @@ void fillT3T3TrackExtensionOutputBranches(SDL::Event* event)
     const unsigned int N_MAX_T3T3_TRACK_EXTENSIONS = 40000;
 
     std::vector<int> tce_anchorType;;
-    unsigned int nTrackExtensions = (trackExtensionsInGPU.nTrackExtensions)[nTrackCandidates] > N_MAX_T3T3_TRACK_EXTENSIONS ? N_MAX_T3T3_TRACK_EXTENSIONS : (trackExtensionsInGPU.nTrackExtensions)[nTrackCandidates]; 
+    unsigned int nTrackExtensions = (trackExtensionsInGPU.nTrackExtensions)[nTrackCandidates]; 
 
     std::vector<std::vector<int>> hitIndices;
 
@@ -1593,15 +1593,7 @@ void fillPureTrackExtensionOutputBranches(SDL::Event* event)
     for(size_t i = 0; i < nTrackCandidates; i++)
 #endif
     {
-        unsigned int nTrackExtensions;
-        if(i < nTrackCandidates)
-        {
-            nTrackExtensions = (trackExtensionsInGPU.nTrackExtensions)[i] > N_MAX_TRACK_EXTENSIONS_PER_TC ? N_MAX_TRACK_EXTENSIONS_PER_TC : (trackExtensionsInGPU.nTrackExtensions)[i];
-        }
-        else
-        {
-            nTrackExtensions = (trackExtensionsInGPU.nTrackExtensions)[i] > N_MAX_T3T3_TRACK_EXTENSIONS ? N_MAX_T3T3_TRACK_EXTENSIONS : (trackExtensionsInGPU.nTrackExtensions)[i]; 
-        }
+        unsigned int nTrackExtensions = (trackExtensionsInGPU.nTrackExtensions)[i];
         for(size_t j = 0; j < nTrackExtensions; j++)
         {
             unsigned int teIdx = i * N_MAX_TRACK_EXTENSIONS_PER_TC + j;
@@ -1811,15 +1803,7 @@ void fillTrackExtensionOutputBranches(SDL::Event* event)
     for(size_t i = 0; i < nTrackCandidates; i++)
 #endif
     {
-        unsigned int nTrackExtensions;
-        if(i < nTrackCandidates)
-        {
-            nTrackExtensions = (trackExtensionsInGPU.nTrackExtensions)[i] > N_MAX_TRACK_EXTENSIONS_PER_TC ? N_MAX_TRACK_EXTENSIONS_PER_TC : (trackExtensionsInGPU.nTrackExtensions)[i];
-        }
-        else
-        {
-            nTrackExtensions = (trackExtensionsInGPU.nTrackExtensions)[i] > N_MAX_T3T3_TRACK_EXTENSIONS ? N_MAX_T3T3_TRACK_EXTENSIONS : (trackExtensionsInGPU.nTrackExtensions)[i]; 
-        }
+        unsigned int nTrackExtensions = (trackExtensionsInGPU.nTrackExtensions)[i];
         for(size_t j = 0; j < nTrackExtensions; j++)
         {
             unsigned int teIdx = i * N_MAX_TRACK_EXTENSIONS_PER_TC + j;

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -3077,7 +3077,7 @@ void fillTripletOutputBranches(SDL::Event* event)
 #endif
 
     const int MAX_NTRIPLET_PER_MODULE = 2500;
-    for (unsigned int idx = 0; idx < *(modulesInGPU.nLowerModules); idx++) // "<=" because cheating to include pixel track candidate lower module
+    for (unsigned int idx = 0; idx < *(modulesInGPU.nLowerModules); idx++)
     {
 
         unsigned int nTriplets = tripletsInGPU.nTriplets[idx];

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -739,7 +739,7 @@ void fillOccupancyBranches(SDL::Event* event)
     ana.tx->setBranch<vector<int>>("sg_occupancies",segmentOccupancy);
     ana.tx->setBranch<vector<int>>("t3_occupancies",tripletOccupancy);
     ana.tx->setBranch<int>("tc_occupancies",*(trackCandidatesInGPU.nTrackCandidates));
-    ana.tx->setBranch<int>("pT3_occupancies", *(pixelTripletsInGPU.nPixelTriplets));
+    ana.tx->setBranch<int>("pT3_occupancies", *(pixelTripletsInGPU.totOccupancyPixelTriplets));
     ana.tx->setBranch<vector<int>>("t5_occupancies", quintupletOccupancy);
     ana.tx->setBranch<int>("pT5_occupancies", *(pixelQuintupletsInGPU.nPixelQuintuplets));
 }

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -724,7 +724,7 @@ void fillOccupancyBranches(SDL::Event* event)
         moduleSubdet.push_back(modulesInGPU.subdets[lowerIdx]);
         moduleRing.push_back(modulesInGPU.rings[lowerIdx]);
         segmentOccupancy.push_back(segmentsInGPU.nSegments[lowerIdx]);
-        mdOccupancy.push_back(mdsInGPU.nMDs[lowerIdx]);
+        mdOccupancy.push_back(mdsInGPU.totOccupancyMDs[lowerIdx]);
 
         if(idx < *(modulesInGPU.nLowerModules))
         {
@@ -5574,14 +5574,17 @@ void printMiniDoubletMultiplicities(SDL::Event* event)
     SDL::modules& modulesInGPU = (*event->getModules());
 
     int nMiniDoublets = 0;
+    int totOccupancyMiniDoublets = 0;
     for (unsigned int idx = 0; idx <= *(modulesInGPU.nModules); idx++) // "<=" because cheating to include pixel track candidate lower module
     {
         if(modulesInGPU.isLower[idx])
         {
             nMiniDoublets += miniDoubletsInGPU.nMDs[idx];
+            totOccupancyMiniDoublets += miniDoubletsInGPU.totOccupancyMDs[idx];
         }
     }
     std::cout <<  " nMiniDoublets: " << nMiniDoublets <<  std::endl;
+    std::cout <<  " totOccupancyMiniDoublets (including trucated ones): " << totOccupancyMiniDoublets <<  std::endl;
 }
 
 //________________________________________________________________________________________________________________________________

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -729,7 +729,7 @@ void fillOccupancyBranches(SDL::Event* event)
         if(idx < *(modulesInGPU.nLowerModules))
         {
             quintupletOccupancy.push_back(quintupletsInGPU.nQuintuplets[idx]);
-            tripletOccupancy.push_back(tripletsInGPU.nTriplets[idx]);
+            tripletOccupancy.push_back(tripletsInGPU.totOccupancyTriplets[idx]);
         }
     }
     ana.tx->setBranch<vector<int>>("module_layers",moduleLayer);
@@ -3102,11 +3102,6 @@ void fillTripletOutputBranches(SDL::Event* event)
     {
 
         unsigned int nTriplets = tripletsInGPU.nTriplets[idx];
-
-        if (idx < *(modulesInGPU.nLowerModules) and nTriplets > MAX_NTRIPLET_PER_MODULE)
-        {
-            nTriplets = MAX_NTRIPLET_PER_MODULE;
-        }
 
         for (unsigned int jdx = 0; jdx < nTriplets; jdx++)
         {

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -723,7 +723,7 @@ void fillOccupancyBranches(SDL::Event* event)
         moduleLayer.push_back(modulesInGPU.layers[lowerIdx]);
         moduleSubdet.push_back(modulesInGPU.subdets[lowerIdx]);
         moduleRing.push_back(modulesInGPU.rings[lowerIdx]);
-        segmentOccupancy.push_back(segmentsInGPU.nSegments[lowerIdx]);
+        segmentOccupancy.push_back(segmentsInGPU.totOccupancySegments[lowerIdx]);
         mdOccupancy.push_back(mdsInGPU.totOccupancyMDs[lowerIdx]);
 
         if(idx < *(modulesInGPU.nLowerModules))

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -728,7 +728,7 @@ void fillOccupancyBranches(SDL::Event* event)
 
         if(idx < *(modulesInGPU.nLowerModules))
         {
-            quintupletOccupancy.push_back(quintupletsInGPU.nQuintuplets[idx]);
+            quintupletOccupancy.push_back(quintupletsInGPU.totOccupancyQuintuplets[idx]);
             tripletOccupancy.push_back(tripletsInGPU.totOccupancyTriplets[idx]);
         }
     }
@@ -2072,11 +2072,6 @@ void fillQuintupletOutputBranches(SDL::Event* event)
         }
 
         unsigned int nQuintuplets = quintupletsInGPU.nQuintuplets[idx];
-        
-        if(nQuintuplets > MAX_NQUINTUPLET_PER_MODULE)
-        {
-            nQuintuplets = MAX_NQUINTUPLET_PER_MODULE;
-        }
 
         for(unsigned int jdx = 0; jdx < nQuintuplets; jdx++)
         {

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -741,7 +741,7 @@ void fillOccupancyBranches(SDL::Event* event)
     ana.tx->setBranch<int>("tc_occupancies",*(trackCandidatesInGPU.nTrackCandidates));
     ana.tx->setBranch<int>("pT3_occupancies", *(pixelTripletsInGPU.totOccupancyPixelTriplets));
     ana.tx->setBranch<vector<int>>("t5_occupancies", quintupletOccupancy);
-    ana.tx->setBranch<int>("pT5_occupancies", *(pixelQuintupletsInGPU.nPixelQuintuplets));
+    ana.tx->setBranch<int>("pT5_occupancies", *(pixelQuintupletsInGPU.totOccupancyPixelQuintuplets));
 }
 
 //________________________________________________________________________________________________________________________________

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -2353,7 +2353,7 @@ void fillPixelTripletOutputBranches(SDL::Event* event)
 
     const unsigned int N_MAX_PIXEL_TRIPLETS = 5000;
 
-    unsigned int nPixelTriplets = std::min(*(pixelTripletsInGPU.nPixelTriplets), N_MAX_PIXEL_TRIPLETS);
+    unsigned int nPixelTriplets = *(pixelTripletsInGPU.nPixelTriplets);
 
     for(unsigned int jdx = 0; jdx < nPixelTriplets; jdx++)
     {
@@ -2586,7 +2586,7 @@ void fillPixelQuintupletOutputBranches(SDL::Event* event)
     std::vector<float> pT5_simpt;
 #endif
     const unsigned int N_MAX_PIXEL_QUINTUPLETS = 15000;
-    unsigned int nPixelQuintuplets = std::min(*(pixelQuintupletsInGPU.nPixelQuintuplets), N_MAX_PIXEL_QUINTUPLETS);
+    unsigned int nPixelQuintuplets = *(pixelQuintupletsInGPU.nPixelQuintuplets);
 
     for(unsigned int jdx = 0; jdx < nPixelQuintuplets; jdx++)
     {
@@ -2846,7 +2846,7 @@ void fillPixelLineSegmentOutputBranches(SDL::Event* event)
     const unsigned int N_MAX_PIXEL_SEGMENTS_PER_MODULE = 50000; 
     const unsigned int N_MAX_SEGMENTS_PER_MODULE = 600;
     unsigned int pixelModuleIndex = *(modulesInGPU.nLowerModules);
-    unsigned int nPixelSegments = std::min(segmentsInGPU.nSegments[pixelModuleIndex], N_MAX_PIXEL_SEGMENTS_PER_MODULE);
+    unsigned int nPixelSegments = segmentsInGPU.nSegments[pixelModuleIndex];
     for(unsigned int jdx = 0; jdx < nPixelSegments; jdx++)
     {
         if(segmentsInGPU.isDup[jdx]) {continue;}

--- a/efficiency/bin/sdl_validate_efficiency
+++ b/efficiency/bin/sdl_validate_efficiency
@@ -123,12 +123,12 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; 
     run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 ${runExtension}
     :
 fi
-#if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
-#    run_gpu unified ${SAMPLE} ${NEVENTS} -8 -c ${runExtension}
-#    :
-#fi
-#if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
-#    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 -c ${runExtension}
-#    :
-#fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
+    run_gpu unified ${SAMPLE} ${NEVENTS} -8 -c ${runExtension}
+    :
+fi
+if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
+    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 -c ${runExtension}
+    :
+fi
 sdl_compare_efficiencies -i ${SAMPLE} -t ${GITHASH} -f


### PR DESCRIPTION
This PR changes the behavior of the `n[X]` struct members to not exceed the maximum value of the `[X]` object, as set in `Kernels.cuh`.

To accommodate occupancy studies, a new struct member is introduced, `totOccupancy[X]`.