### PR TITLE
Fixes for running CMSSW12 geometry NTuples and fixing the efficiency

### DIFF
--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -720,7 +720,11 @@ __device__ void SDL::shiftStripHits(struct modules& modulesInGPU, /*struct hits&
     // Assign hit pointers based on their hit type
     if (modulesInGPU.moduleType[lowerModuleIndex] == PS)
     {
-        if (modulesInGPU.moduleLayerType[lowerModuleIndex]== Pixel)
+#ifdef CMSSW12GEOM // TODO: This is somewhat of an mystery.... somewhat confused why this is the case
+        if (modulesInGPU.subdets[lowerModuleIndex] == Barrel ? modulesInGPU.moduleLayerType[lowerModuleIndex] != Pixel : modulesInGPU.moduleLayerType[lowerModuleIndex] == Pixel)
+#else
+        if (modulesInGPU.moduleLayerType[lowerModuleIndex] == Pixel)
+#endif
         {
             //old to delete
        //     pixelHitIndex = lowerHitIndex;

--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -79,6 +79,31 @@ int main(int argc, char** argv)
     ana.input_raw_string = result["input"].as<std::string>();
 
     // A default value one
+#ifdef CMSSW12GEOM
+    if (ana.input_raw_string.EqualTo("muonGun"))
+        ana.input_file_list_tstring = "/data2/phchang/trackingNtuple_100MuGun_Pt_0p5_2_CMSSW_12_2_0_pre2.root";
+    else if (ana.input_raw_string.EqualTo("muonGun_highE"))
+        ana.input_file_list_tstring = "/data2/phchang/trackingNtuple_10MuGun_CMSSW_12_2_0_pre2.root";
+    else if (ana.input_raw_string.EqualTo("pionGun"))
+    {
+        std::cout << "ERROR: The input file does not exist for the CMSSW 12 geometry!" << std::endl;
+        exit(2);
+    }
+    else if (ana.input_raw_string.EqualTo("PU200"))
+        ana.input_file_list_tstring = "/data2/phchang/trackingNtuple_ttbar_PU200.root";
+    else if (ana.input_raw_string.EqualTo("cube"))
+    {
+        std::cout << "ERROR: The input file does not exist for the CMSSW 12 geometry!" << std::endl;
+        exit(2);
+    }
+    else if (ana.input_raw_string.EqualTo("cube50cm"))
+    {
+        std::cout << "ERROR: The input file does not exist for the CMSSW 12 geometry!" << std::endl;
+        exit(2);
+    }
+    else
+        ana.input_file_list_tstring = ana.input_raw_string;
+#else
     if (ana.input_raw_string.EqualTo("muonGun"))
         ana.input_file_list_tstring = "/data2/segmentlinking/trackingNtuple_100_pt0p5_2p0.root";
     else if (ana.input_raw_string.EqualTo("muonGun_highE"))
@@ -93,6 +118,7 @@ int main(int argc, char** argv)
         ana.input_file_list_tstring = "/data2/segmentlinking/trackingNtuple_10_pt0p5_50_50cm_cube.root";
     else
         ana.input_file_list_tstring = ana.input_raw_string;
+#endif
 
     //_______________________________________________________________________________
     // --tree

--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -1,126 +1,123 @@
-#include "trkCore.h"
-
-//__________________________________________________________________________________________
-float simhit_p(unsigned int simhitidx)
-{
-
-    // |momentum| calculation
-
-    float px = trk.simhit_px()[simhitidx];
-    float py = trk.simhit_py()[simhitidx];
-    float pz = trk.simhit_pz()[simhitidx];
-    return sqrt(px*px + py*py + pz*pz);
-}
-
-//__________________________________________________________________________________________
-float hitAngle(unsigned int simhitidx)
-{
-
-    // This is the angle calculation between position vector and the momentum vector
-
-    float x = trk.simhit_x()[simhitidx];
-    float y = trk.simhit_y()[simhitidx];
-    float z = trk.simhit_z()[simhitidx];
-    float r3 = sqrt(x*x + y*y + z*z);
-    float px = trk.simhit_px()[simhitidx];
-    float py = trk.simhit_py()[simhitidx];
-    float pz = trk.simhit_pz()[simhitidx];
-    float p = sqrt(px*px + py*py + pz*pz);
-    float rdotp = x*px + y*py + z*pz;
-    rdotp = rdotp / r3;
-    rdotp = rdotp / p;
-    float angle = acos(rdotp);
-    return angle;
-}
-
-//__________________________________________________________________________________________
-bool isMuonCurlingHit(unsigned int isimtrk, unsigned int ith_hit)
-{
-
-    // To assess whether the ith_hit for isimtrk is a "curling" hit
-
-    // Retrieve the sim hit idx
-    unsigned int simhitidx = trk.sim_simHitIdx()[isimtrk][ith_hit];
-
-    // We're only concerned about hits in the outer tracker
-    // This is more of a sanity check
-    if (not (trk.simhit_subdet()[simhitidx] == 4 or trk.simhit_subdet()[simhitidx] == 5))
-        return false;
-
-    // Retrieve the sim hit pdgId
-    int simhit_particle = trk.simhit_particle()[simhitidx];
-
-    // If the hit is not muon then we can't tell anything
-    if (abs(simhit_particle) != 13)
-        return false;
-
-    // Get the angle
-    float angle = hitAngle(simhitidx);
-
-    // If the angle is quite different then it's the last hit
-    if (abs(angle) > 1.6)
-        return true;
-
-    // Afterwards, we check the energy loss
-    //
-    // If it is the first hit without any previous hit present,
-    // we can't tell whether it is last hit or not
-    // so we just say false to be conservative
-    if (ith_hit == 0)
-        return false;
-
-    // Retrieve the module where the hit lies
-    int detid = trk.simhit_detId()[simhitidx];
-    SDL::CPU::Module module = SDL::CPU::Module(detid);
-
-    // Calculate the momentum
-    float p = simhit_p(simhitidx);
-
-    // Find the previous simhit that is on the lower side of the module
-    int simhitidx_previous = -999;
-    for (unsigned int ith_back = 1; ith_back <= ith_hit; ith_back++)
-    {
-        // Retrieve the hit idx of ith_hit - ith_back;
-        unsigned int simhitidx_previous_candidate = trk.sim_simHitIdx()[isimtrk][ith_hit-ith_back];
-
-        if (not (trk.simhit_subdet()[simhitidx_previous_candidate] == 4 or trk.simhit_subdet()[simhitidx_previous_candidate] == 5))
-            continue;
-
-        if (not (trk.simhit_particle()[simhitidx_previous_candidate] == 13))
-            continue;
-
-        // Retrieve the module where the previous candidate hit lies
-        int detid = trk.simhit_detId()[simhitidx_previous_candidate];
-        SDL::CPU::Module module = SDL::CPU::Module(detid);
-
-        // If the module is lower, then we get the index
-        if (module.isLower())
-        {
-            simhitidx_previous = simhitidx_previous_candidate;
-            break;
-        }
-
-    }
-
-    // If no previous layer is found then can't do much
-    if (simhitidx_previous == -999)
-        return false;
-
-    // Get the previous layer momentum
-    float p_previous = simhit_p(simhitidx_previous);
-
-    // Calculate the momentum loss
-    float loss = fabs(p_previous - p) / p_previous;
-
-    // If the momentum loss is large it is the last hit
-    if (loss > 0.35)
-        return true;
-
-    // If it reaches this point again, we're not sure what this hit is
-    // So we return false
-    return false;
-
-}
+//float simhit_p(unsigned int simhitidx)
+//{
+//
+//    // |momentum| calculation
+//
+//    float px = trk.simhit_px()[simhitidx];
+//    float py = trk.simhit_py()[simhitidx];
+//    float pz = trk.simhit_pz()[simhitidx];
+//    return sqrt(px*px + py*py + pz*pz);
+//}
+//
+////__________________________________________________________________________________________
+//float hitAngle(unsigned int simhitidx)
+//{
+//
+//    // This is the angle calculation between position vector and the momentum vector
+//
+//    float x = trk.simhit_x()[simhitidx];
+//    float y = trk.simhit_y()[simhitidx];
+//    float z = trk.simhit_z()[simhitidx];
+//    float r3 = sqrt(x*x + y*y + z*z);
+//    float px = trk.simhit_px()[simhitidx];
+//    float py = trk.simhit_py()[simhitidx];
+//    float pz = trk.simhit_pz()[simhitidx];
+//    float p = sqrt(px*px + py*py + pz*pz);
+//    float rdotp = x*px + y*py + z*pz;
+//    rdotp = rdotp / r3;
+//    rdotp = rdotp / p;
+//    float angle = acos(rdotp);
+//    return angle;
+//}
+//
+////__________________________________________________________________________________________
+//bool isMuonCurlingHit(unsigned int isimtrk, unsigned int ith_hit)
+//{
+//
+//    // To assess whether the ith_hit for isimtrk is a "curling" hit
+//
+//    // Retrieve the sim hit idx
+//    unsigned int simhitidx = trk.sim_simHitIdx()[isimtrk][ith_hit];
+//
+//    // We're only concerned about hits in the outer tracker
+//    // This is more of a sanity check
+//    if (not (trk.simhit_subdet()[simhitidx] == 4 or trk.simhit_subdet()[simhitidx] == 5))
+//        return false;
+//
+//    // Retrieve the sim hit pdgId
+//    int simhit_particle = trk.simhit_particle()[simhitidx];
+//
+//    // If the hit is not muon then we can't tell anything
+//    if (abs(simhit_particle) != 13)
+//        return false;
+//
+//    // Get the angle
+//    float angle = hitAngle(simhitidx);
+//
+//    // If the angle is quite different then it's the last hit
+//    if (abs(angle) > 1.6)
+//        return true;
+//
+//    // Afterwards, we check the energy loss
+//    //
+//    // If it is the first hit without any previous hit present,
+//    // we can't tell whether it is last hit or not
+//    // so we just say false to be conservative
+//    if (ith_hit == 0)
+//        return false;
+//
+//    // Retrieve the module where the hit lies
+//    int detid = trk.simhit_detId()[simhitidx];
+//    SDL::Module module = SDL::Module(detid);
+//
+//    // Calculate the momentum
+//    float p = simhit_p(simhitidx);
+//
+//    // Find the previous simhit that is on the lower side of the module
+//    int simhitidx_previous = -999;
+//    for (unsigned int ith_back = 1; ith_back <= ith_hit; ith_back++)
+//    {
+//        // Retrieve the hit idx of ith_hit - ith_back;
+//        unsigned int simhitidx_previous_candidate = trk.sim_simHitIdx()[isimtrk][ith_hit-ith_back];
+//
+//        if (not (trk.simhit_subdet()[simhitidx_previous_candidate] == 4 or trk.simhit_subdet()[simhitidx_previous_candidate] == 5))
+//            continue;
+//
+//        if (not (trk.simhit_particle()[simhitidx_previous_candidate] == 13))
+//            continue;
+//
+//        // Retrieve the module where the previous candidate hit lies
+//        int detid = trk.simhit_detId()[simhitidx_previous_candidate];
+//        SDL::Module module = SDL::Module(detid);
+//
+//        // If the module is lower, then we get the index
+//        if (module.isLower())
+//        {
+//            simhitidx_previous = simhitidx_previous_candidate;
+//            break;
+//        }
+//
+//    }
+//
+//    // If no previous layer is found then can't do much
+//    if (simhitidx_previous == -999)
+//        return false;
+//
+//    // Get the previous layer momentum
+//    float p_previous = simhit_p(simhitidx_previous);
+//
+//    // Calculate the momentum loss
+//    float loss = fabs(p_previous - p) / p_previous;
+//
+//    // If the momentum loss is large it is the last hit
+//    if (loss > 0.35)
+//        return true;
+//
+//    // If it reaches this point again, we're not sure what this hit is
+//    // So we return false
+//    return false;
+//
+//}
 
 
 
@@ -147,8 +144,8 @@ bool hasAll12HitsWithNBarrelUsingModuleMap(unsigned int isimtrk, int nbarrel, bo
         if (not (trk.simhit_particle()[simhitidx] == trk.sim_pdgId()[isimtrk]))
             continue;
 
-        if (isMuonCurlingHit(isimtrk, ith_hit))
-            break;
+        //if (isMuonCurlingHit(isimtrk, ith_hit))
+        //    break;
 
         if (not usesimhits)
         {
@@ -296,8 +293,8 @@ bool hasAll12HitsWithNBarrel(unsigned int isimtrk, int nbarrel)
         // if (not (trk.simhit_particle()[simhitidx] == trk.sim_pdgId()[isimtrk]))
         //     continue;
 
-        if (isMuonCurlingHit(isimtrk, ith_hit))
-            break;
+        //if (isMuonCurlingHit(isimtrk, ith_hit))
+        //    break;
 
         // list of reco hit matched to this sim hit
         for (unsigned int irecohit = 0; irecohit < trk.simhit_hitIdx()[simhitidx].size(); ++irecohit)

--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -1,3 +1,5 @@
+#include "trkCore.h"
+
 //float simhit_p(unsigned int simhitidx)
 //{
 //

--- a/code/core/trkCore.h
+++ b/code/core/trkCore.h
@@ -33,9 +33,9 @@ enum TrackletType {
     EE2EE4,
 };
 
-float simhit_p(unsigned int simhitidx);
-float hitAngle(unsigned int simhitidx);
-bool isMuonCurlingHit(unsigned int isimtrk, unsigned int ith_hit);
+//float simhit_p(unsigned int simhitidx);
+//float hitAngle(unsigned int simhitidx);
+//bool isMuonCurlingHit(unsigned int isimtrk, unsigned int ith_hit);
 bool hasAll12HitsWithNBarrel(unsigned int isimtrk, int nbarrel);
 bool hasAll12HitsWithNBarrelUsingModuleMap(unsigned int isimtrk, int nbarrel, bool usesimhits=false);
 bool checkModuleConnectionsAreGood(std::array<std::vector<unsigned int>, 6>& layers_good_paired_modules);

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -930,12 +930,12 @@ void fillSimTrackOutputBranches()
           //if (not (trk.simhit_particle()[simhitidx] == trk.sim_pdgId()[isimtrk]))
           //  continue;
 
-          if (isMuonCurlingHit(isimtrk, ith_hit)){
-          // if (false) {
-            len = -2;
-            lengap = -2;
-            break;
-          }
+          //if (isMuonCurlingHit(isimtrk, ith_hit)){
+          //// if (false) {
+          //  len = -2;
+          //  lengap = -2;
+          //  break;
+          //}
           len =0;
           lengap =0;
           hits++;


### PR DESCRIPTION
As per title. As shown in our last meeting, the efficiency is largely restored, being comparable with the old geometry for all samples:

New branch (new geometry):
[muonGun](https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/muonGunInnefficiencies/PR137Validation/eff_plots__GPU_explicit_cache_bb11f66_muonGun_PR137Validation/)
[muonGun_highE](https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/muonGunInnefficiencies/PR137Validation/eff_plots__GPU_explicit_cache_bb11f66_muonGun_highE_PR137Validation/)
[PU200](https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/muonGunInnefficiencies/PR137Validation/eff_plots__GPU_explicit_cache_bb11f66_PU200_PR137Validation/)

Current master (old geometry):
[muonGun](https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/muonGunInnefficiencies/PR137Validation/eff_plots__GPU_explicit_cache_d981d7e_muonGun_PR137ValidationMaster/)
[muonGun_highE](https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/muonGunInnefficiencies/PR137Validation/eff_plots__GPU_explicit_cache_d981d7e_muonGun_highE_PR137ValidationMaster/)
[PU200](https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/muonGunInnefficiencies/PR137Validation/eff_plots__GPU_explicit_cache_d981d7e_PU200_PR137ValidationMaster/)

The commented-out function are not included because we are missing the `simhit_px`, `simhit_py` and `simhit_pz` branches. Even like this, this PR can be merged and we can include those functions back when we reproduce the new geometry NTuples with the issing branches included.