### PR TITLE
Host Caching Allocator

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -94,18 +94,21 @@ SDL::Event::~Event()
     if(trackCandidatesInGPU){trackCandidatesInGPU->freeMemory(stream);}
     if(trackExtensionsInGPU){trackExtensionsInGPU->freeMemory(stream);}
 #endif
-    if(rangesInGPU != nullptr){cudaFreeHost(rangesInGPU);}
-    if(mdsInGPU != nullptr){cudaFreeHost(mdsInGPU);}
-    if(segmentsInGPU!= nullptr){cudaFreeHost(segmentsInGPU);}
-    if(tripletsInGPU!= nullptr){cudaFreeHost(tripletsInGPU);}
-    if(trackCandidatesInGPU!= nullptr){cudaFreeHost(trackCandidatesInGPU);}
-    if(hitsInGPU!= nullptr){cudaFreeHost(hitsInGPU);}
+    if(rangesInGPU != nullptr){cms::cuda::free_host(rangesInGPU);}
+    if(mdsInGPU != nullptr){cms::cuda::free_host(mdsInGPU);}
+    if(segmentsInGPU!= nullptr){cms::cuda::free_host(segmentsInGPU);}
+    if(tripletsInGPU!= nullptr){cms::cuda::free_host(tripletsInGPU);}
+    if(trackCandidatesInGPU!= nullptr){cms::cuda::free_host(trackCandidatesInGPU);}
+    if(hitsInGPU!= nullptr){//cms::cuda::free_host(hitsInGPU);
+        cudaFreeHost(hitsInGPU);}
 
-    if(pixelTripletsInGPU!= nullptr){cudaFreeHost(pixelTripletsInGPU);}
-    if(pixelQuintupletsInGPU!= nullptr){cudaFreeHost(pixelQuintupletsInGPU);}
+    if(pixelTripletsInGPU!= nullptr){//cms::cuda::free_host(pixelTripletsInGPU);
+        cudaFreeHost(pixelTripletsInGPU);}
+    if(pixelQuintupletsInGPU!= nullptr){cms::cuda::free_host(pixelQuintupletsInGPU);}
 
-    if(quintupletsInGPU!= nullptr){cudaFreeHost(quintupletsInGPU);}
-    if(trackExtensionsInGPU != nullptr){cudaFreeHost(trackExtensionsInGPU);}
+    if(quintupletsInGPU!= nullptr){cms::cuda::free_host(quintupletsInGPU);}
+    if(trackExtensionsInGPU != nullptr){//cms::cuda::free_host(trackExtensionsInGPU);
+        cudaFreeHost(trackExtensionsInGPU);}
 
 #ifdef Explicit_Hit
     if(hitsInCPU != nullptr)
@@ -326,25 +329,28 @@ void SDL::Event::resetEvent()
             n_quintuplets_by_layer_endcap_[i] = 0;
         }
     }
-    if(hitsInGPU){cudaFreeHost(hitsInGPU);
+    if(hitsInGPU){//cms::cuda::free_host(hitsInGPU);
+    cudaFreeHost(hitsInGPU);
     hitsInGPU = nullptr;}
-    if(mdsInGPU){cudaFreeHost(mdsInGPU);
+    if(mdsInGPU){cms::cuda::free_host(mdsInGPU);
     mdsInGPU = nullptr;}
-    if(rangesInGPU){cudaFreeHost(rangesInGPU);
+    if(rangesInGPU){cms::cuda::free_host(rangesInGPU);
     rangesInGPU = nullptr;}
-    if(segmentsInGPU){cudaFreeHost(segmentsInGPU);
+    if(segmentsInGPU){cms::cuda::free_host(segmentsInGPU);
     segmentsInGPU = nullptr;}
-    if(tripletsInGPU){cudaFreeHost(tripletsInGPU);
+    if(tripletsInGPU){cms::cuda::free_host(tripletsInGPU);
     tripletsInGPU = nullptr;}
-      if(quintupletsInGPU){cudaFreeHost(quintupletsInGPU);
+      if(quintupletsInGPU){cms::cuda::free_host(quintupletsInGPU);
       quintupletsInGPU = nullptr;}
-    if(trackCandidatesInGPU){cudaFreeHost(trackCandidatesInGPU);
+    if(trackCandidatesInGPU){cms::cuda::free_host(trackCandidatesInGPU);
     trackCandidatesInGPU = nullptr;}
-    if(pixelTripletsInGPU){cudaFreeHost(pixelTripletsInGPU);
+    if(pixelTripletsInGPU){//cms::cuda::free_host(pixelTripletsInGPU);
+    cudaFreeHost(pixelTripletsInGPU);
     pixelTripletsInGPU = nullptr;}
-    if(pixelQuintupletsInGPU){cudaFreeHost(pixelQuintupletsInGPU);
+    if(pixelQuintupletsInGPU){cms::cuda::free_host(pixelQuintupletsInGPU);
     pixelQuintupletsInGPU = nullptr;}
-    if(trackExtensionsInGPU){cudaFreeHost(trackExtensionsInGPU);
+    if(trackExtensionsInGPU){//cms::cuda::free_host(trackExtensionsInGPU);
+    cudaFreeHost(trackExtensionsInGPU);
     trackExtensionsInGPU = nullptr;}
 #ifdef Explicit_Hit
     if(hitsInCPU != nullptr)
@@ -534,9 +540,11 @@ void SDL::initModules(const char* moduleMetaDataFilePath)
     {
     cudaStream_t modStream;
     cudaStreamCreate(&modStream);
+        //modulesInGPU = (SDL::modules*)cms::cuda::allocate_host(sizeof(struct SDL::modules), modStream);
         cudaMallocHost(&modulesInGPU, sizeof(struct SDL::modules));
         //pixelMapping = new pixelMap;
         cudaMallocHost(&pixelMapping, sizeof(struct SDL::pixelMap));
+        //pixelMapping = (SDL::pixelMap*)cms::cuda::allocate_host(sizeof(struct SDL::pixelMap), modStream);
         loadModulesFromFile(*modulesInGPU,nModules,nLowerModules, *pixelMapping,modStream,moduleMetaDataFilePath); //nModules gets filled here
     cudaStreamSynchronize(modStream);
     cudaStreamDestroy(modStream);
@@ -558,6 +566,8 @@ void SDL::cleanModules()
   //#endif
     cudaFreeHost(modulesInGPU);
     cudaFreeHost(pixelMapping);
+    //cms::cuda::free_host(modulesInGPU);
+    //cms::cuda::free_host(pixelMapping);
 //    cudaDeviceReset(); // uncomment for leak check "cuda-memcheck --leak-check full --show-backtrace yes" does not work with caching.
 }
 
@@ -575,8 +585,7 @@ cudaStreamSynchronize(stream);
 
     if(rangesInGPU == nullptr)
     {
-
-        cudaMallocHost(&rangesInGPU, sizeof(SDL::objectRanges));
+        rangesInGPU = (SDL::objectRanges*)cms::cuda::allocate_host(sizeof(SDL::objectRanges), stream);
         #ifdef Explicit_Hit
     	  createRangesInExplicitMemory(*rangesInGPU, nModules,stream,nLowerModules); //unclear why but this has to be 2*loopsize to avoid crashing later (reported in tracklet allocation). seems to do with nHits values as well. this allows nhits to be set to the correct value of loopsize to get correct results without crashing. still beats the "max hits" so i think this is fine.
         #else
@@ -595,7 +604,7 @@ cudaStreamSynchronize(stream);
 //        #endif
 //    }
 //cudaStreamSynchronize(stream);
-        hitsInGPU = hitsInGPU_event;
+    hitsInGPU = hitsInGPU_event;
 //      cudaMemcpyAsync(hitsInGPU->xs,                  hitsInGPU_event->xs,2*loopsize*sizeof(float),cudaMemcpyDeviceToDevice,stream);
 //      cudaMemcpyAsync(hitsInGPU->ys,                  hitsInGPU_event->ys,2*loopsize*sizeof(float),cudaMemcpyDeviceToDevice,stream);
 //      cudaMemcpyAsync(hitsInGPU->zs,                  hitsInGPU_event->zs,2*loopsize*sizeof(float),cudaMemcpyDeviceToDevice,stream);
@@ -633,11 +642,11 @@ cudaStreamSynchronize(stream);
     float* host_z;// = &z[0];
     unsigned int* host_detId;// = &detId[0];
     unsigned int* host_idxs;// = &idxInNtuple[0];
-    cudaMallocHost(&host_x,sizeof(float)*loopsize);
-    cudaMallocHost(&host_y,sizeof(float)*loopsize);
-    cudaMallocHost(&host_z,sizeof(float)*loopsize);
-    cudaMallocHost(&host_detId,sizeof(unsigned int)*loopsize);
-    cudaMallocHost(&host_idxs,sizeof(unsigned int)*loopsize);
+    host_x = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_y = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_z = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_detId = (unsigned int*)cms::cuda::allocate_host(sizeof(unsigned int)*loopsize, stream);
+    host_idxs = (unsigned int*)cms::cuda::allocate_host(sizeof(unsigned int)*loopsize, stream);
 
     float* host_phis;
     float* host_etas;
@@ -647,14 +656,14 @@ cudaStreamSynchronize(stream);
     float* host_highEdgeYs;
     float* host_lowEdgeXs;
     float* host_lowEdgeYs;
-    cudaMallocHost(&host_moduleIndex, sizeof(float)*loopsize);
-    cudaMallocHost(&host_phis,sizeof(float)*loopsize);
-    cudaMallocHost(&host_etas,sizeof(float)*loopsize);
-    cudaMallocHost(&host_rts,sizeof(float)*loopsize);
-    cudaMallocHost(&host_highEdgeXs,sizeof(float)*loopsize);
-    cudaMallocHost(&host_highEdgeYs,sizeof(float)*loopsize);
-    cudaMallocHost(&host_lowEdgeXs,sizeof(float)*loopsize);
-    cudaMallocHost(&host_lowEdgeYs,sizeof(float)*loopsize);
+    host_moduleIndex = (unsigned int*)cms::cuda::allocate_host(sizeof(unsigned int)*loopsize, stream);
+    host_phis = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_etas = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_rts = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_highEdgeXs = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_highEdgeYs = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_lowEdgeXs = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_lowEdgeYs = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
 
 
     short* module_layers;
@@ -666,15 +675,15 @@ cudaStreamSynchronize(stream);
     int8_t* module_hitRangesnUpper;
     int8_t* module_hitRangesnLower;
     ModuleType* module_moduleType;
-    cudaMallocHost(&module_layers,sizeof(short)*nModules);
-    cudaMallocHost(&module_subdet,sizeof(short)*nModules);
-    cudaMallocHost(&module_partnerModuleIndices, sizeof(uint16_t) * nModules);
-    cudaMallocHost(&module_hitRanges,sizeof(int)*2*nModules);
-    cudaMallocHost(&module_hitRangesUpper,sizeof(int)*nModules);
-    cudaMallocHost(&module_hitRangesLower,sizeof(int)*nModules);
-    cudaMallocHost(&module_hitRangesnUpper,sizeof(int8_t)*nModules);
-    cudaMallocHost(&module_hitRangesnLower,sizeof(int8_t)*nModules);
-    cudaMallocHost(&module_moduleType,sizeof(ModuleType)*nModules);
+    module_layers = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    module_subdet = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    module_partnerModuleIndices = (uint16_t*)cms::cuda::allocate_host(sizeof(uint16_t) * nModules, stream);
+    module_hitRanges = (int*)cms::cuda::allocate_host(sizeof(int)*2*nModules, stream);
+    module_hitRangesUpper = (int*)cms::cuda::allocate_host(sizeof(int)*nModules, stream);
+    module_hitRangesLower = (int*)cms::cuda::allocate_host(sizeof(int)*nModules, stream);
+    module_hitRangesnUpper = (int8_t*)cms::cuda::allocate_host(sizeof(int8_t) * nModules, stream);
+    module_hitRangesnLower = (int8_t*)cms::cuda::allocate_host(sizeof(int8_t) * nModules, stream);
+    module_moduleType = (ModuleType*)cms::cuda::allocate_host(sizeof(ModuleType) * nModules, stream);
 
     cudaMemcpyAsync(module_layers,modulesInGPU->layers,nModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     cudaMemcpyAsync(module_subdet,modulesInGPU->subdets,nModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
@@ -766,29 +775,28 @@ cudaStreamSynchronize(stream);
     cudaMemcpyAsync(hitsInGPU_event.hitRangesnUpper,module_hitRangesnUpper,nModules*sizeof(int8_t),cudaMemcpyHostToDevice,stream);// value can't correctly be set in hit allocation
 cudaStreamSynchronize(stream);
 
-
-    cudaFreeHost(host_rts);
-    cudaFreeHost(host_phis);
-    cudaFreeHost(host_etas);
-    cudaFreeHost(host_moduleIndex);
-    cudaFreeHost(host_highEdgeXs);
-    cudaFreeHost(host_highEdgeYs);
-    cudaFreeHost(host_lowEdgeXs);
-    cudaFreeHost(host_lowEdgeYs);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_subdet);
-    cudaFreeHost(module_partnerModuleIndices);
-    cudaFreeHost(module_hitRanges);
-    cudaFreeHost(module_hitRangesLower);
-    cudaFreeHost(module_hitRangesUpper);
-    cudaFreeHost(module_hitRangesnLower);
-    cudaFreeHost(module_hitRangesnUpper);
-    cudaFreeHost(module_moduleType);
-    cudaFreeHost(host_x);
-    cudaFreeHost(host_y);
-    cudaFreeHost(host_z);
-    cudaFreeHost(host_detId);
-    cudaFreeHost(host_idxs);
+    cms::cuda::free_host(host_rts);
+    cms::cuda::free_host(host_phis);
+    cms::cuda::free_host(host_etas);
+    cms::cuda::free_host(host_moduleIndex);
+    cms::cuda::free_host(host_highEdgeXs);
+    cms::cuda::free_host(host_highEdgeYs);
+    cms::cuda::free_host(host_lowEdgeXs);
+    cms::cuda::free_host(host_lowEdgeYs);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_subdet);
+    cms::cuda::free_host(module_partnerModuleIndices);
+    cms::cuda::free_host(module_hitRanges);
+    cms::cuda::free_host(module_hitRangesLower);
+    cms::cuda::free_host(module_hitRangesUpper);
+    cms::cuda::free_host(module_hitRangesnLower);
+    cms::cuda::free_host(module_hitRangesnUpper);
+    cms::cuda::free_host(module_moduleType);
+    cms::cuda::free_host(host_x);
+    cms::cuda::free_host(host_y);
+    cms::cuda::free_host(host_z);
+    cms::cuda::free_host(host_detId);
+    cms::cuda::free_host(host_idxs);
 
 }
 
@@ -824,7 +832,7 @@ std::vector<std::vector<short>>&    out_isQuad_vec
     for(int evt=0; evt < static_cast<int>(out_trkX.size()); evt++)
     {
         struct SDL::hits* hitsInGPU_event;
-        cudaMallocHost(&hitsInGPU_event, sizeof(struct SDL::hits));
+        hitsInGPU_event = (struct SDL::hits*)cms::cuda::allocate_host(sizeof(struct SDL::hits), modStream);
         #ifdef Explicit_Hit
         createHitsInExplicitMemory(*hitsInGPU_event, hitOffset.at(evt+1),modStream,1); //unclear why but this has to be 2*loopsize to avoid crashing later (reported in tracklet allocation). seems to do with nHits values as well. this allows nhits to be set to the correct value of loopsize to get correct results without crashing. still beats the "max hits" so i think this is fine.
         #else
@@ -851,8 +859,7 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
 
     if(rangesInGPU == nullptr)
     {
-
-        cudaMallocHost(&rangesInGPU, sizeof(SDL::objectRanges));
+        rangesInGPU = (SDL::objectRanges*)cms::cuda::allocate_host(sizeof(SDL::objectRanges), stream);
         #ifdef Explicit_Hit
     	  createRangesInExplicitMemory(*rangesInGPU, nModules,stream,nLowerModules); //unclear why but this has to be 2*loopsize to avoid crashing later (reported in tracklet allocation). seems to do with nHits values as well. this allows nhits to be set to the correct value of loopsize to get correct results without crashing. still beats the "max hits" so i think this is fine.
         #else
@@ -862,8 +869,8 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
     }
     if(hitsInGPU == nullptr)
     {
-
-        cudaMallocHost(&hitsInGPU, sizeof(SDL::hits));
+        //cudaMallocHost(&hitsInGPU, sizeof(SDL::hits));
+        hitsInGPU = (SDL::hits*)cms::cuda::allocate_host(sizeof(SDL::hits), stream);
         #ifdef Explicit_Hit
     	  createHitsInExplicitMemory(*hitsInGPU, 2*loopsize,stream,1); //unclear why but this has to be 2*loopsize to avoid crashing later (reported in tracklet allocation). seems to do with nHits values as well. this allows nhits to be set to the correct value of loopsize to get correct results without crashing. still beats the "max hits" so i think this is fine.
         #else
@@ -878,11 +885,11 @@ cudaStreamSynchronize(stream);
     float* host_z;// = &z[0];
     unsigned int* host_detId;// = &detId[0];
     unsigned int* host_idxs;// = &idxInNtuple[0];
-    cudaMallocHost(&host_x,sizeof(float)*loopsize);
-    cudaMallocHost(&host_y,sizeof(float)*loopsize);
-    cudaMallocHost(&host_z,sizeof(float)*loopsize);
-    cudaMallocHost(&host_detId,sizeof(unsigned int)*loopsize);
-    cudaMallocHost(&host_idxs,sizeof(unsigned int)*loopsize);
+    host_x = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_y = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_z = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_detId = (unsigned int*)cms::cuda::allocate_host(sizeof(unsigned int)*loopsize, stream);
+    host_idxs = (unsigned int*)cms::cuda::allocate_host(sizeof(unsigned int)*loopsize, stream);
 
     float* host_phis;
     float* host_etas;
@@ -892,14 +899,14 @@ cudaStreamSynchronize(stream);
     float* host_highEdgeYs;
     float* host_lowEdgeXs;
     float* host_lowEdgeYs;
-    cudaMallocHost(&host_moduleIndex, sizeof(float)*loopsize);
-    cudaMallocHost(&host_phis,sizeof(float)*loopsize);
-    cudaMallocHost(&host_etas,sizeof(float)*loopsize);
-    cudaMallocHost(&host_rts,sizeof(float)*loopsize);
-    cudaMallocHost(&host_highEdgeXs,sizeof(float)*loopsize);
-    cudaMallocHost(&host_highEdgeYs,sizeof(float)*loopsize);
-    cudaMallocHost(&host_lowEdgeXs,sizeof(float)*loopsize);
-    cudaMallocHost(&host_lowEdgeYs,sizeof(float)*loopsize);
+    host_moduleIndex = (unsigned int*)cms::cuda::allocate_host(sizeof(unsigned int)*loopsize, stream);
+    host_phis = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_etas = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_rts = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_highEdgeXs = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_highEdgeYs = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_lowEdgeXs = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
+    host_lowEdgeYs = (float*)cms::cuda::allocate_host(sizeof(float)*loopsize, stream);
 
 
     short* module_layers;
@@ -911,15 +918,15 @@ cudaStreamSynchronize(stream);
     int8_t* module_hitRangesnUpper;
     int8_t* module_hitRangesnLower;
     ModuleType* module_moduleType;
-    cudaMallocHost(&module_layers,sizeof(short)*nModules);
-    cudaMallocHost(&module_subdet,sizeof(short)*nModules);
-    cudaMallocHost(&module_partnerModuleIndices, sizeof(uint16_t) * nModules);
-    cudaMallocHost(&module_hitRanges,sizeof(int)*2*nModules);
-    cudaMallocHost(&module_hitRangesUpper,sizeof(int)*nModules);
-    cudaMallocHost(&module_hitRangesLower,sizeof(int)*nModules);
-    cudaMallocHost(&module_hitRangesnUpper,sizeof(int8_t)*nModules);
-    cudaMallocHost(&module_hitRangesnLower,sizeof(int8_t)*nModules);
-    cudaMallocHost(&module_moduleType,sizeof(ModuleType)*nModules);
+    module_layers = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    module_subdet = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    module_partnerModuleIndices = (uint16_t*)cms::cuda::allocate_host(sizeof(uint16_t) * nModules, stream);
+    module_hitRanges = (int*)cms::cuda::allocate_host(sizeof(int)*2*nModules, stream);
+    module_hitRangesUpper = (int*)cms::cuda::allocate_host(sizeof(int)*nModules, stream);
+    module_hitRangesLower = (int*)cms::cuda::allocate_host(sizeof(int)*nModules, stream);
+    module_hitRangesnUpper = (int8_t*)cms::cuda::allocate_host(sizeof(int8_t) * nModules, stream);
+    module_hitRangesnLower = (int8_t*)cms::cuda::allocate_host(sizeof(int8_t) * nModules, stream);
+    module_moduleType = (ModuleType*)cms::cuda::allocate_host(sizeof(ModuleType) * nModules, stream);
 
     cudaMemcpyAsync(module_layers,modulesInGPU->layers,nModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     cudaMemcpyAsync(module_subdet,modulesInGPU->subdets,nModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
@@ -1012,28 +1019,28 @@ cudaStreamSynchronize(stream);
     cudaMemcpyAsync(hitsInGPU->hitRangesnUpper,module_hitRangesnUpper,nModules*sizeof(int8_t),cudaMemcpyHostToDevice,stream);// value can't correctly be set in hit allocation
 cudaStreamSynchronize(stream);
 
-    cudaFreeHost(host_rts);
-    cudaFreeHost(host_phis);
-    cudaFreeHost(host_etas);
-    cudaFreeHost(host_moduleIndex);
-    cudaFreeHost(host_highEdgeXs);
-    cudaFreeHost(host_highEdgeYs);
-    cudaFreeHost(host_lowEdgeXs);
-    cudaFreeHost(host_lowEdgeYs);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_subdet);
-    cudaFreeHost(module_partnerModuleIndices);
-    cudaFreeHost(module_hitRanges);
-    cudaFreeHost(module_hitRangesLower);
-    cudaFreeHost(module_hitRangesUpper);
-    cudaFreeHost(module_hitRangesnLower);
-    cudaFreeHost(module_hitRangesnUpper);
-    cudaFreeHost(module_moduleType);
-    cudaFreeHost(host_x);
-    cudaFreeHost(host_y);
-    cudaFreeHost(host_z);
-    cudaFreeHost(host_detId);
-    cudaFreeHost(host_idxs);
+    cms::cuda::free_host(host_rts);
+    cms::cuda::free_host(host_phis);
+    cms::cuda::free_host(host_etas);
+    cms::cuda::free_host(host_moduleIndex);
+    cms::cuda::free_host(host_highEdgeXs);
+    cms::cuda::free_host(host_highEdgeYs);
+    cms::cuda::free_host(host_lowEdgeXs);
+    cms::cuda::free_host(host_lowEdgeYs);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_subdet);
+    cms::cuda::free_host(module_partnerModuleIndices);
+    cms::cuda::free_host(module_hitRanges);
+    cms::cuda::free_host(module_hitRangesLower);
+    cms::cuda::free_host(module_hitRangesUpper);
+    cms::cuda::free_host(module_hitRangesnLower);
+    cms::cuda::free_host(module_hitRangesnUpper);
+    cms::cuda::free_host(module_moduleType);
+    cms::cuda::free_host(host_x);
+    cms::cuda::free_host(host_y);
+    cms::cuda::free_host(host_z);
+    cms::cuda::free_host(host_detId);
+    cms::cuda::free_host(host_idxs);
 
 }
 __global__ void addPixelSegmentToEventKernel(unsigned int* hitIndices0,unsigned int* hitIndices1,unsigned int* hitIndices2,unsigned int* hitIndices3, float* dPhiChange, float* ptIn, float* ptErr, float* px, float* py, float* pz, float* eta, float* etaErr,float* phi, uint16_t pixelModuleIndex, struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU,const int size, int* superbin, int8_t* pixelType, short* isQuad)
@@ -1084,7 +1091,7 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
 {
     if(mdsInGPU == nullptr)
     {
-        cudaMallocHost(&mdsInGPU, sizeof(SDL::miniDoublets));
+        mdsInGPU = (SDL::miniDoublets*)cms::cuda::allocate_host(sizeof(SDL::miniDoublets), stream);
         //hardcoded range numbers for this will come from studies!
         unsigned int nTotalMDs;
         createMDArrayRanges(*modulesInGPU, *rangesInGPU, nLowerModules, nTotalMDs, stream, N_MAX_MD_PER_MODULES, N_MAX_PIXEL_MD_PER_MODULES);
@@ -1100,7 +1107,7 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     }
     if(segmentsInGPU == nullptr)
     {
-        cudaMallocHost(&segmentsInGPU, sizeof(SDL::segments));
+        segmentsInGPU = (SDL::segments*)cms::cuda::allocate_host(sizeof(SDL::segments), stream);
         //hardcoded range numbers for this will come from studies!
         unsigned int nTotalSegments;
         createSegmentArrayRanges(*modulesInGPU, *rangesInGPU, *mdsInGPU, nLowerModules, nTotalSegments, stream, N_MAX_SEGMENTS_PER_MODULE, N_MAX_PIXEL_SEGMENTS_PER_MODULE);
@@ -1151,7 +1158,6 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     int* superbin_dev;
     int8_t* pixelType_dev;
     short* isQuad_dev;
-
     cudaMalloc(&hitIndices0_dev,size*sizeof(unsigned int));
     cudaMalloc(&hitIndices1_dev,size*sizeof(unsigned int));
     cudaMalloc(&hitIndices2_dev,size*sizeof(unsigned int));
@@ -1186,7 +1192,6 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     cudaMemcpyAsync(pixelType_dev,pixelType_host,size*sizeof(int8_t),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(isQuad_dev,isQuad_host,size*sizeof(short),cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
-
     unsigned int nThreads = 256;
     unsigned int nBlocks =  MAX_BLOCKS;//size % nThreads == 0 ? size/nThreads : size/nThreads + 1;
 
@@ -1269,25 +1274,25 @@ void SDL::Event::addMiniDoubletsToEventExplicit()
     uint16_t nLowerModules;
     cudaMemcpyAsync(&nLowerModules,modulesInGPU->nLowerModules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
     unsigned int* nMDsCPU;
-    cudaMallocHost(&nMDsCPU, nLowerModules * sizeof(unsigned int));
+    nMDsCPU = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
     cudaMemcpyAsync(nMDsCPU,mdsInGPU->nMDs,nLowerModules*sizeof(unsigned int),cudaMemcpyDeviceToHost,stream);
     cudaStreamSynchronize(stream);
 
     short* module_subdets;
-    cudaMallocHost(&module_subdets, nLowerModules* sizeof(short));
+    module_subdets = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
     cudaMemcpyAsync(module_subdets,modulesInGPU->subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     int* module_mdRanges;
-    cudaMallocHost(&module_mdRanges, nLowerModules* 2*sizeof(int));
+    module_mdRanges = (int*)cms::cuda::allocate_host(nLowerModules* 2*sizeof(int), stream);
     cudaMemcpyAsync(module_mdRanges,rangesInGPU->mdRanges,nLowerModules*2*sizeof(int),cudaMemcpyDeviceToHost,stream);
     short* module_layers;
-    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
+    module_layers = (short*)cms::cuda::allocate_host(nLowerModules * sizeof(short), stream);
     cudaMemcpyAsync(module_layers,modulesInGPU->layers,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     int* module_hitRanges;
-    cudaMallocHost(&module_hitRanges, nLowerModules* 2*sizeof(int));
+    module_hitRanges = (int*)cms::cuda::allocate_host(nLowerModules* 2*sizeof(int), stream);
     cudaMemcpyAsync(module_hitRanges,hitsInGPU->hitRanges,nLowerModules*2*sizeof(int),cudaMemcpyDeviceToHost,stream);
 
     int* module_miniDoubletModuleIndices;
-    cudaMallocHost(&module_miniDoubletModuleIndices, nLowerModules * sizeof(int));
+    module_miniDoubletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(int), stream);
     cudaMemcpyAsync(module_miniDoubletModuleIndices, rangesInGPU->miniDoubletModuleIndices, nLowerModules * sizeof(int), cudaMemcpyDeviceToHost, stream);
     cudaStreamSynchronize(stream);
 
@@ -1316,12 +1321,12 @@ void SDL::Event::addMiniDoubletsToEventExplicit()
     }
     cudaMemcpyAsync(rangesInGPU->mdRanges,module_mdRanges,nLowerModules*2*sizeof(int),cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
-    cudaFreeHost(nMDsCPU);
-    cudaFreeHost(module_subdets);
-    cudaFreeHost(module_mdRanges);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_hitRanges);
-    cudaFreeHost(module_miniDoubletModuleIndices);
+    cms::cuda::free_host(nMDsCPU);
+    cms::cuda::free_host(module_subdets);
+    cms::cuda::free_host(module_mdRanges);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_hitRanges);
+    cms::cuda::free_host(module_miniDoubletModuleIndices);
 }
 void SDL::Event::addSegmentsToEvent()
 {
@@ -1356,21 +1361,21 @@ void SDL::Event::addSegmentsToEventExplicit()
     cudaStreamSynchronize(stream);
 
     unsigned int* nSegmentsCPU;
-    cudaMallocHost(&nSegmentsCPU, nLowerModules * sizeof(unsigned int));
+    nSegmentsCPU = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
     cudaMemcpyAsync(nSegmentsCPU,segmentsInGPU->nSegments,nLowerModules*sizeof(unsigned int),cudaMemcpyDeviceToHost,stream);
 
     short* module_subdets;
-    cudaMallocHost(&module_subdets, nLowerModules* sizeof(short));
+    module_subdets = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
     cudaMemcpyAsync(module_subdets,modulesInGPU->subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     int* module_segmentRanges;
-    cudaMallocHost(&module_segmentRanges, nLowerModules* 2*sizeof(int));
+    module_segmentRanges = (int*)cms::cuda::allocate_host(nLowerModules* 2*sizeof(int), stream);
     cudaMemcpyAsync(module_segmentRanges,rangesInGPU->segmentRanges,nLowerModules*2*sizeof(int),cudaMemcpyDeviceToHost,stream);
     short* module_layers;
-    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
+    module_layers = (short*)cms::cuda::allocate_host(nLowerModules * sizeof(short), stream);
     cudaMemcpyAsync(module_layers,modulesInGPU->layers,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
 
     int* module_segmentModuleIndices;
-    cudaMallocHost(&module_segmentModuleIndices, nLowerModules * sizeof(int));
+    module_segmentModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(int), stream);
     cudaMemcpyAsync(module_segmentModuleIndices, rangesInGPU->segmentModuleIndices, nLowerModules * sizeof(int), cudaMemcpyDeviceToHost, stream);
     cudaStreamSynchronize(stream);
     for(unsigned int i = 0; i<nLowerModules; i++)
@@ -1398,11 +1403,11 @@ void SDL::Event::addSegmentsToEventExplicit()
     cudaMemcpyAsync(rangesInGPU->segmentRanges, module_segmentRanges, nLowerModules * 2 * sizeof(int), cudaMemcpyHostToDevice, stream);
     cudaStreamSynchronize(stream);
 
-    cudaFreeHost(nSegmentsCPU);
-    cudaFreeHost(module_subdets);
-    cudaFreeHost(module_segmentRanges);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_segmentModuleIndices);
+    cms::cuda::free_host(nSegmentsCPU);
+    cms::cuda::free_host(module_subdets);
+    cms::cuda::free_host(module_segmentRanges);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_segmentModuleIndices);
 }
 
 void SDL::Event::createMiniDoublets()
@@ -1417,7 +1422,7 @@ void SDL::Event::createMiniDoublets()
 
     if(mdsInGPU == nullptr)
     {
-        cudaMallocHost(&mdsInGPU, sizeof(SDL::miniDoublets));
+        mdsInGPU = (SDL::miniDoublets*)cms::cuda::allocate_host(sizeof(SDL::miniDoublets), stream);
 #ifdef Explicit_MD
         //FIXME: Add memory locations for pixel MDs
         createMDsInExplicitMemory(*mdsInGPU, nTotalMDs, nLowerModules, N_MAX_PIXEL_MD_PER_MODULES, stream);
@@ -1432,16 +1437,16 @@ void SDL::Event::createMiniDoublets()
     int maxThreadsPerModule=0;
 #ifdef Explicit_Module
     int* module_hitRanges;
-    cudaMallocHost(&module_hitRanges, nModules* 2*sizeof(int));
+    module_hitRanges = (int*)cms::cuda::allocate_host(nModules* 2*sizeof(int), stream);
     cudaMemcpyAsync(module_hitRanges,hitsInGPU->hitRanges,nModules*2*sizeof(int),cudaMemcpyDeviceToHost,stream);
     bool* module_isLower;
-    cudaMallocHost(&module_isLower, nModules*sizeof(bool));
+    module_isLower = (bool*)cms::cuda::allocate_host(nModules*sizeof(bool), stream);
     cudaMemcpyAsync(module_isLower,modulesInGPU->isLower,nModules*sizeof(bool),cudaMemcpyDeviceToHost,stream);
     bool* module_isInverted;
-    cudaMallocHost(&module_isInverted, nModules*sizeof(bool));
+    module_isInverted = (bool*)cms::cuda::allocate_host(nModules*sizeof(bool), stream);
     cudaMemcpyAsync(module_isInverted,modulesInGPU->isInverted,nModules*sizeof(bool),cudaMemcpyDeviceToHost,stream);
     int* module_partnerModuleIndices;
-    cudaMallocHost(&module_partnerModuleIndices, nLowerModules * sizeof(unsigned int));
+    module_partnerModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
     cudaMemcpyAsync(module_partnerModuleIndices, modulesInGPU->partnerModuleIndices, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaStreamSynchronize(stream);
 
@@ -1457,10 +1462,10 @@ void SDL::Event::createMiniDoublets()
             maxThreadsPerModule = maxThreadsPerModule > (nLowerHits*nUpperHits) ? maxThreadsPerModule : nLowerHits*nUpperHits;
         }
     }
-    cudaFreeHost(module_hitRanges);
-    cudaFreeHost(module_partnerModuleIndices);
-    cudaFreeHost(module_isLower);
-    cudaFreeHost(module_isInverted);
+    cms::cuda::free_host(module_hitRanges);
+    cms::cuda::free_host(module_partnerModuleIndices);
+    cms::cuda::free_host(module_isLower);
+    cms::cuda::free_host(module_isInverted);
 #else
     for (int i=0; i<nLowerModules; i++) 
     {
@@ -1512,7 +1517,7 @@ void SDL::Event::createSegmentsWithModuleMap()
     cudaStreamSynchronize(stream);
     if(segmentsInGPU == nullptr)
     {
-        cudaMallocHost(&segmentsInGPU, sizeof(SDL::segments));
+        segmentsInGPU = (SDL::segments*)cms::cuda::allocate_host(sizeof(SDL::segments), stream);
 #ifdef Explicit_Seg
         createSegmentsInExplicitMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nLowerModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE,stream);
 #else
@@ -1602,7 +1607,7 @@ void SDL::Event::createTriplets()
 
     if(tripletsInGPU == nullptr)
     {
-        cudaMallocHost(&tripletsInGPU, sizeof(SDL::triplets));
+        tripletsInGPU = (SDL::triplets*)cms::cuda::allocate_host(sizeof(SDL::triplets), stream);
         unsigned int maxTriplets;
         createTripletArrayRanges(*modulesInGPU, *rangesInGPU, *segmentsInGPU, nLowerModules, maxTriplets, stream, N_MAX_TRIPLETS_PER_MODULE);
 #ifdef Explicit_Trips
@@ -1626,7 +1631,7 @@ void SDL::Event::createTriplets()
 
 #ifdef Explicit_Module
     uint16_t* module_nConnectedModules;
-    cudaMallocHost(&module_nConnectedModules, nLowerModules* sizeof(uint16_t));
+    module_nConnectedModules = (uint16_t*)cms::cuda::allocate_host(nLowerModules* sizeof(uint16_t), stream);
     cudaMemcpyAsync(module_nConnectedModules,modulesInGPU->nConnectedModules,nLowerModules*sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
     cudaStreamSynchronize(stream);
 
@@ -1641,7 +1646,7 @@ void SDL::Event::createTriplets()
         }
         max_InnerSeg = max(max_InnerSeg, nInnerSegments);
     }
-    cudaFreeHost(module_nConnectedModules);
+    cms::cuda::free_host(module_nConnectedModules);
 #else
     for (uint16_t innerLowerModuleIndex = 0; innerLowerModuleIndex < nLowerModules; innerLowerModuleIndex++) 
     {
@@ -1685,7 +1690,7 @@ void SDL::Event::createTrackCandidates()
     if(trackCandidatesInGPU == nullptr)
     {
         //printf("did this run twice?\n");
-        cudaMallocHost(&trackCandidatesInGPU, sizeof(SDL::trackCandidates));
+        trackCandidatesInGPU = (SDL::trackCandidates*)cms::cuda::allocate_host(sizeof(SDL::trackCandidates), stream);
 #ifdef Explicit_Track
         createTrackCandidatesInExplicitMemory(*trackCandidatesInGPU, N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES,stream);
 #else
@@ -1751,6 +1756,7 @@ void SDL::Event::createExtendedTracks()
 {
     if(trackExtensionsInGPU == nullptr)
     {
+        //trackExtensionsInGPU = (SDL::trackExtensions*)cms::cuda::allocate_host(sizeof(SDL::trackExtensions), stream);
         cudaMallocHost(&trackExtensionsInGPU, sizeof(SDL::trackExtensions));
     }
 
@@ -1816,6 +1822,7 @@ void SDL::Event::createPixelTriplets()
 
     if(pixelTripletsInGPU == nullptr)
     {
+        //pixelTripletsInGPU = (SDL::pixelTriplets*)cms::cuda::allocate_host(sizeof(SDL::pixelTriplets), stream);
         cudaMallocHost(&pixelTripletsInGPU, sizeof(SDL::pixelTriplets));
     }
 #ifdef Explicit_PT3
@@ -1830,25 +1837,25 @@ void SDL::Event::createPixelTriplets()
     unsigned int *nTriplets;
     unsigned int nInnerSegments = 0;
     cudaMemcpyAsync(&nInnerSegments, &(segmentsInGPU->nSegments[pixelModuleIndex]), sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-
-    cudaMallocHost(&nTriplets, nLowerModules * sizeof(unsigned int));
+    nTriplets = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
     cudaMemcpyAsync(nTriplets, tripletsInGPU->nTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-
-    cudaMallocHost(&superbins,N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int));
-    cudaMallocHost(&pixelTypes,N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int8_t));
+    superbins = (int*)cms::cuda::allocate_host(N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int), stream);
+    pixelTypes = (int8_t*)cms::cuda::allocate_host(N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int8_t), stream);
 
     cudaMemcpyAsync(superbins,segmentsInGPU->superbin,N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int),cudaMemcpyDeviceToHost,stream);
     cudaMemcpyAsync(pixelTypes,segmentsInGPU->pixelType,N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int8_t),cudaMemcpyDeviceToHost,stream);
 
     unsigned int* connectedPixelSize_host;
     unsigned int* connectedPixelIndex_host;
-    cudaMallocHost(&connectedPixelSize_host, nInnerSegments* sizeof(unsigned int));
-    cudaMallocHost(&connectedPixelIndex_host, nInnerSegments* sizeof(unsigned int));
+    connectedPixelSize_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+    connectedPixelIndex_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+
     unsigned int* connectedPixelSize_dev;
     unsigned int* connectedPixelIndex_dev;
-    cudaMalloc(&connectedPixelSize_dev, nInnerSegments* sizeof(unsigned int));
-    cudaMalloc(&connectedPixelIndex_dev, nInnerSegments* sizeof(unsigned int));
-    //unsigned int max_size =0;
+    connectedPixelSize_dev = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+    connectedPixelIndex_dev = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+
+    // unsigned int max_size =0;
     int threadSize = 1000000;
     unsigned int *segs_pix = (unsigned int*)malloc(2*threadSize*sizeof(unsigned int));
     unsigned int *segs_pix_offset = segs_pix+threadSize;
@@ -1930,15 +1937,15 @@ cudaStreamSynchronize(stream);
 
     }cudaStreamSynchronize(stream);
     //}cudaDeviceSynchronize();
-    cudaFreeHost(connectedPixelSize_host);
-    cudaFreeHost(connectedPixelIndex_host);
+    cms::cuda::free_host(connectedPixelSize_host);
+    cms::cuda::free_host(connectedPixelIndex_host);
     cudaFree(connectedPixelSize_dev);
     cudaFree(connectedPixelIndex_dev);
     //cudaFreeAsync(connectedPixelSize_dev,stream);
     //cudaFreeAsync(connectedPixelIndex_dev,stream);
-    cudaFreeHost(superbins);
-    cudaFreeHost(pixelTypes);
-    cudaFreeHost(nTriplets);
+    cms::cuda::free_host(superbins);
+    cms::cuda::free_host(pixelTypes);
+    cms::cuda::free_host(nTriplets);
     free(segs_pix);
     //cudaFreeAsync(segs_pix_gpu,stream);
     cudaFree(segs_pix_gpu);
@@ -1973,7 +1980,7 @@ cudaStreamSynchronize(stream);
 
     if(quintupletsInGPU == nullptr)
     {
-        cudaMallocHost(&quintupletsInGPU, sizeof(SDL::quintuplets));
+        quintupletsInGPU = (SDL::quintuplets*)cms::cuda::allocate_host(sizeof(SDL::quintuplets), stream);
 #ifdef Explicit_T5
         createQuintupletsInExplicitMemory(*quintupletsInGPU, N_MAX_QUINTUPLETS_PER_MODULE, nLowerModules, nEligibleT5Modules,stream);
 #else
@@ -2078,7 +2085,7 @@ void SDL::Event::createPixelQuintuplets()
 
     if(pixelQuintupletsInGPU == nullptr)
     {
-        cudaMallocHost(&pixelQuintupletsInGPU, sizeof(SDL::pixelQuintuplets));
+        pixelQuintupletsInGPU = (SDL::pixelQuintuplets*)cms::cuda::allocate_host(sizeof(SDL::pixelQuintuplets), stream);
 #ifdef Explicit_PT5
     createPixelQuintupletsInExplicitMemory(*pixelQuintupletsInGPU, N_MAX_PIXEL_QUINTUPLETS,stream);
 #else
@@ -2087,7 +2094,7 @@ void SDL::Event::createPixelQuintuplets()
     }
    if(trackCandidatesInGPU == nullptr)
     {
-        cudaMallocHost(&trackCandidatesInGPU, sizeof(SDL::trackCandidates));
+        trackCandidatesInGPU = (SDL::trackCandidates*)cms::cuda::allocate_host(sizeof(SDL::trackCandidates), stream);
 #ifdef Explicit_Track
         createTrackCandidatesInExplicitMemory(*trackCandidatesInGPU, N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES,stream);
 #else
@@ -2106,11 +2113,11 @@ void SDL::Event::createPixelQuintuplets()
     unsigned int* connectedPixelSize_dev;
     unsigned int* connectedPixelIndex_dev;
 
-    cudaMallocHost(&nQuintuplets, nLowerModules * sizeof(unsigned int));
+    nQuintuplets = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
     cudaMemcpyAsync(nQuintuplets, quintupletsInGPU->nQuintuplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 
-    cudaMallocHost(&superbins,N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int));
-    cudaMallocHost(&pixelTypes,N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int8_t));
+    superbins = (int*)cms::cuda::allocate_host(N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int), stream);
+    pixelTypes = (int8_t*)cms::cuda::allocate_host(N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int8_t), stream);
 
     cudaMemcpyAsync(superbins,segmentsInGPU->superbin,N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int),cudaMemcpyDeviceToHost,stream);
     cudaMemcpyAsync(pixelTypes,segmentsInGPU->pixelType,N_MAX_PIXEL_SEGMENTS_PER_MODULE*sizeof(int8_t),cudaMemcpyDeviceToHost,stream);
@@ -2120,9 +2127,8 @@ void SDL::Event::createPixelQuintuplets()
     unsigned int nInnerSegments = 0;
     cudaMemcpyAsync(&nInnerSegments, &(segmentsInGPU->nSegments[pixelModuleIndex]), sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 
-
-    cudaMallocHost(&connectedPixelSize_host, nInnerSegments* sizeof(unsigned int));
-    cudaMallocHost(&connectedPixelIndex_host, nInnerSegments* sizeof(unsigned int));
+    connectedPixelSize_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+    connectedPixelIndex_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
     cudaMalloc(&connectedPixelSize_dev, nInnerSegments* sizeof(unsigned int));
     cudaMalloc(&connectedPixelIndex_dev, nInnerSegments* sizeof(unsigned int));
 
@@ -2207,13 +2213,13 @@ cudaStreamSynchronize(stream);
 
     }
     cudaStreamSynchronize(stream);
-    cudaFreeHost(connectedPixelSize_host);
-    cudaFreeHost(connectedPixelIndex_host);
+    cms::cuda::free_host(connectedPixelSize_host);
+    cms::cuda::free_host(connectedPixelIndex_host);
     cudaFree(connectedPixelSize_dev);
     cudaFree(connectedPixelIndex_dev);
-    cudaFreeHost(superbins);
-    cudaFreeHost(pixelTypes);
-    cudaFreeHost(nQuintuplets);
+    cms::cuda::free_host(superbins);
+    cms::cuda::free_host(pixelTypes);
+    cms::cuda::free_host(nQuintuplets);
     free(segs_pix);
     cudaFree(segs_pix_gpu);
 
@@ -2283,20 +2289,21 @@ void SDL::Event::addQuintupletsToEventExplicit()
     cudaStreamSynchronize(stream);
 
     unsigned int* nQuintupletsCPU;
-    cudaMallocHost(&nQuintupletsCPU, nLowerModules * sizeof(unsigned int));
+    nQuintupletsCPU = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
+
     cudaMemcpyAsync(nQuintupletsCPU,quintupletsInGPU->nQuintuplets,nLowerModules*sizeof(unsigned int),cudaMemcpyDeviceToHost,stream);
 
     short* module_subdets;
-    cudaMallocHost(&module_subdets, nModules* sizeof(short));
+    module_subdets = (short*)cms::cuda::allocate_host(nModules* sizeof(short), stream);
     cudaMemcpyAsync(module_subdets,modulesInGPU->subdets,nModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     int* module_quintupletRanges;
-    cudaMallocHost(&module_quintupletRanges, nLowerModules* 2*sizeof(int));
+    module_quintupletRanges = (int*)cms::cuda::allocate_host(nLowerModules* 2*sizeof(int), stream);
     cudaMemcpyAsync(module_quintupletRanges,rangesInGPU->quintupletRanges,nLowerModules*2*sizeof(int),cudaMemcpyDeviceToHost,stream);
     short* module_layers;
-    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
+    module_layers = (short*)cms::cuda::allocate_host(nLowerModules * sizeof(short), stream);
     cudaMemcpyAsync(module_layers,modulesInGPU->layers,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     int* module_quintupletModuleIndices;
-    cudaMallocHost(&module_quintupletModuleIndices, nLowerModules * sizeof(int));
+    module_quintupletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(int), stream);
     cudaMemcpyAsync(module_quintupletModuleIndices, rangesInGPU->quintupletModuleIndices, nLowerModules * sizeof(int), cudaMemcpyDeviceToHost,stream);
 cudaStreamSynchronize(stream);
     for(uint16_t i = 0; i<nLowerModules; i++)
@@ -2321,11 +2328,11 @@ cudaStreamSynchronize(stream);
             }
         }
     }
-    cudaFreeHost(nQuintupletsCPU);
-    cudaFreeHost(module_quintupletRanges);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_subdets);
-    cudaFreeHost(module_quintupletModuleIndices);
+    cms::cuda::free_host(nQuintupletsCPU);
+    cms::cuda::free_host(module_quintupletRanges);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_subdets);
+    cms::cuda::free_host(module_quintupletModuleIndices);
 
 }
 
@@ -2362,21 +2369,21 @@ void SDL::Event::addTripletsToEventExplicit()
     cudaStreamSynchronize(stream);
 
     unsigned int* nTripletsCPU;
-    cudaMallocHost(&nTripletsCPU, nLowerModules * sizeof(unsigned int));
+    nTripletsCPU = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
     cudaMemcpyAsync(nTripletsCPU,tripletsInGPU->nTriplets,nLowerModules*sizeof(unsigned int),cudaMemcpyDeviceToHost,stream);
 
     short* module_subdets;
-    cudaMallocHost(&module_subdets, nLowerModules* sizeof(short));
+    module_subdets = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
     cudaMemcpyAsync(module_subdets,modulesInGPU->subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     int* module_tripletRanges;
-    cudaMallocHost(&module_tripletRanges, nLowerModules* 2*sizeof(int));
+    module_tripletRanges = (int*)cms::cuda::allocate_host(nLowerModules* 2*sizeof(int), stream);
     cudaMemcpyAsync(module_tripletRanges,rangesInGPU->tripletRanges,nLowerModules*2*sizeof(int),cudaMemcpyDeviceToHost,stream);
     short* module_layers;
-    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
+    module_layers = (short*)cms::cuda::allocate_host(nLowerModules * sizeof(short), stream);
     cudaMemcpyAsync(module_layers,modulesInGPU->layers,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
 
     int* module_tripletModuleIndices;
-    cudaMallocHost(&module_tripletModuleIndices, nLowerModules * sizeof(int));
+    module_tripletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(int), stream);
     cudaMemcpyAsync(module_tripletModuleIndices, rangesInGPU->tripletModuleIndices, nLowerModules * sizeof(int), cudaMemcpyDeviceToHost, stream);
 
     cudaStreamSynchronize(stream);
@@ -2406,11 +2413,11 @@ void SDL::Event::addTripletsToEventExplicit()
     cudaMemcpyAsync(rangesInGPU->tripletRanges, module_tripletRanges, nLowerModules * 2 * sizeof(int), cudaMemcpyDeviceToHost, stream);
     cudaStreamSynchronize(stream);
 
-    cudaFreeHost(nTripletsCPU);
-    cudaFreeHost(module_tripletRanges);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_subdets);
-    cudaFreeHost(module_tripletModuleIndices);
+    cms::cuda::free_host(nTripletsCPU);
+    cms::cuda::free_host(module_tripletRanges);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_subdets);
+    cms::cuda::free_host(module_tripletModuleIndices);
 }
 
 unsigned int SDL::Event::getNumberOfHits()

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1852,8 +1852,8 @@ void SDL::Event::createPixelTriplets()
 
     unsigned int* connectedPixelSize_dev;
     unsigned int* connectedPixelIndex_dev;
-    connectedPixelSize_dev = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
-    connectedPixelIndex_dev = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+    cudaMalloc(&connectedPixelSize_dev, nInnerSegments* sizeof(unsigned int));
+    cudaMalloc(&connectedPixelIndex_dev, nInnerSegments* sizeof(unsigned int));
 
     // unsigned int max_size =0;
     int threadSize = 1000000;

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -24,18 +24,18 @@ void SDL::createMDArrayRanges(struct modules& modulesInGPU, struct objectRanges&
         write code here that will deal with importing module parameters to CPU, and get the relevant occupancies for a given module!*/
 
     int *module_miniDoubletModuleIndices;
-    cudaMallocHost(&module_miniDoubletModuleIndices, (nLowerModules + 1) * sizeof(unsigned int));
+    module_miniDoubletModuleIndices = (int*)cms::cuda::allocate_host((nLowerModules + 1) * sizeof(unsigned int), stream);
     short* module_subdets;
-    cudaMallocHost(&module_subdets, nLowerModules* sizeof(short));
+    module_subdets = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
     cudaMemcpyAsync(module_subdets,modulesInGPU.subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     short* module_layers;
-    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
+    module_layers = (short*)cms::cuda::allocate_host(nLowerModules * sizeof(short), stream);
     cudaMemcpyAsync(module_layers,modulesInGPU.layers,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
     short* module_rings;
-    cudaMallocHost(&module_rings, nLowerModules * sizeof(short));
+    module_rings = (short*)cms::cuda::allocate_host(nLowerModules * sizeof(short), stream);
     cudaMemcpyAsync(module_rings,modulesInGPU.rings,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
     float* module_eta;
-    cudaMallocHost(&module_eta, nLowerModules * sizeof(float));
+    module_eta = (float*)cms::cuda::allocate_host(nLowerModules * sizeof(float), stream);
     cudaMemcpyAsync(module_eta,modulesInGPU.eta,nLowerModules * sizeof(float),cudaMemcpyDeviceToHost,stream);
 
     cudaStreamSynchronize(stream);
@@ -79,11 +79,11 @@ void SDL::createMDArrayRanges(struct modules& modulesInGPU, struct objectRanges&
 
     cudaMemcpyAsync(rangesInGPU.miniDoubletModuleIndices, module_miniDoubletModuleIndices,  (nLowerModules + 1) * sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
     cudaStreamSynchronize(stream);
-    cudaFreeHost(module_miniDoubletModuleIndices);
-    cudaFreeHost(module_subdets);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_rings);
-    cudaFreeHost(module_eta);
+    cms::cuda::free_host(module_miniDoubletModuleIndices);
+    cms::cuda::free_host(module_subdets);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_rings);
+    cms::cuda::free_host(module_eta);
 }
 
 void SDL::createMDsInUnifiedMemory(struct miniDoublets& mdsInGPU, unsigned int nMemoryLocations, uint16_t nLowerModules, unsigned int maxPixelMDs,cudaStream_t stream)

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -1,4 +1,4 @@
-# include "Module.cuh"
+#include "Module.cuh"
 #include "ModuleConnectionMap.h"
 #include "allocate.h"
 std::map <unsigned int, uint16_t> *SDL::detIdToIndex;
@@ -257,12 +257,12 @@ void SDL::freeModulesCache(struct modules& modulesInGPU,struct pixelMap& pixelMa
   cms::cuda::free_managed(modulesInGPU.moduleLayerType);
   cms::cuda::free_managed(modulesInGPU.connectedPixels);
 #endif
-  cudaFreeHost(pixelMapping.connectedPixelsSizes);
-  cudaFreeHost(pixelMapping.connectedPixelsSizesPos);
-  cudaFreeHost(pixelMapping.connectedPixelsSizesNeg);
-  cudaFreeHost(pixelMapping.connectedPixelsIndex);
-  cudaFreeHost(pixelMapping.connectedPixelsIndexPos);
-  cudaFreeHost(pixelMapping.connectedPixelsIndexNeg);
+  cms::cuda::free_host(pixelMapping.connectedPixelsSizes);
+  cms::cuda::free_host(pixelMapping.connectedPixelsSizesPos);
+  cms::cuda::free_host(pixelMapping.connectedPixelsSizesNeg);
+  cms::cuda::free_host(pixelMapping.connectedPixelsIndex);
+  cms::cuda::free_host(pixelMapping.connectedPixelsIndexPos);
+  cms::cuda::free_host(pixelMapping.connectedPixelsIndexNeg);
 }
 void SDL::freeModules(struct modules& modulesInGPU, struct pixelMap& pixelMapping,cudaStream_t stream)
 {
@@ -296,6 +296,12 @@ void SDL::freeModules(struct modules& modulesInGPU, struct pixelMap& pixelMappin
   cudaFreeHost(pixelMapping.connectedPixelsIndex);
   cudaFreeHost(pixelMapping.connectedPixelsIndexPos);
   cudaFreeHost(pixelMapping.connectedPixelsIndexNeg);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsSizes);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsSizesPos);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsSizesNeg);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsIndex);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsIndexPos);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsIndexNeg);
 }
 
 void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, uint16_t& nLowerModules, struct pixelMap& pixelMapping,cudaStream_t stream, const char* moduleMetaDataFilePath)
@@ -370,23 +376,23 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, 
     float* host_drdzs;
     uint16_t* host_partnerModuleIndices;
 
-    cudaMallocHost(&host_detIds,sizeof(unsigned int)*nModules);
-    cudaMallocHost(&host_layers,sizeof(short)*nModules);
-    cudaMallocHost(&host_rings,sizeof(short)*nModules);
-    cudaMallocHost(&host_rods,sizeof(short)*nModules);
-    cudaMallocHost(&host_modules,sizeof(short)*nModules);
-    cudaMallocHost(&host_subdets,sizeof(short)*nModules);
-    cudaMallocHost(&host_sides,sizeof(short)*nModules);
-    cudaMallocHost(&host_eta,sizeof(float)*nModules);
-    cudaMallocHost(&host_r,sizeof(float)*nModules);
-    cudaMallocHost(&host_isInverted,sizeof(bool)*nModules);
-    cudaMallocHost(&host_isLower,sizeof(bool)*nModules);
-    cudaMallocHost(&host_isAnchor, sizeof(bool) * nModules);
-    cudaMallocHost(&host_moduleType,sizeof(ModuleType)*nModules);
-    cudaMallocHost(&host_moduleLayerType,sizeof(ModuleLayerType)*nModules);
-    cudaMallocHost(&host_slopes,sizeof(float)*nModules);
-    cudaMallocHost(&host_drdzs,sizeof(float)*nModules);
-    cudaMallocHost(&host_partnerModuleIndices, sizeof(uint16_t) * nModules);
+    host_detIds = (unsigned int*)cms::cuda::allocate_host(sizeof(unsigned int)*nModules, stream);
+    host_layers = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    host_rings = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    host_rods = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    host_modules = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    host_subdets = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    host_sides = (short*)cms::cuda::allocate_host(sizeof(short)*nModules, stream);
+    host_eta = (float*)cms::cuda::allocate_host(sizeof(float)*nModules, stream);
+    host_r = (float*)cms::cuda::allocate_host(sizeof(float)*nModules, stream);
+    host_isInverted = (bool*)cms::cuda::allocate_host(sizeof(bool)*nModules, stream);
+    host_isLower = (bool*)cms::cuda::allocate_host(sizeof(bool)*nModules, stream);
+    host_isAnchor = (bool*)cms::cuda::allocate_host(sizeof(bool)*nModules, stream);
+    host_moduleType = (ModuleType*)cms::cuda::allocate_host(sizeof(ModuleType)*nModules, stream);
+    host_moduleLayerType = (ModuleLayerType*)cms::cuda::allocate_host(sizeof(ModuleLayerType)*nModules, stream);
+    host_slopes = (float*)cms::cuda::allocate_host(sizeof(float)*nModules, stream);
+    host_drdzs = (float*)cms::cuda::allocate_host(sizeof(float)*nModules, stream);
+    host_partnerModuleIndices = (uint16_t*)cms::cuda::allocate_host(sizeof(uint16_t) * nModules, stream);
     
     //reassign detIdToIndex indices here
     nLowerModules = (nModules - 1) / 2;
@@ -526,23 +532,21 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, 
     cudaMemcpyAsync(modulesInGPU.partnerModuleIndices, host_partnerModuleIndices, sizeof(uint16_t) * nModules, cudaMemcpyHostToDevice, stream);
     cudaStreamSynchronize(stream);
 
-    cudaFreeHost(host_detIds);
-    cudaFreeHost(host_layers);
-    cudaFreeHost(host_rings);
-    cudaFreeHost(host_rods);
-    cudaFreeHost(host_modules);
-    cudaFreeHost(host_subdets);
-    cudaFreeHost(host_sides);
-    cudaFreeHost(host_eta);
-    cudaFreeHost(host_r);
-    cudaFreeHost(host_isInverted);
-    cudaFreeHost(host_isLower);
-    cudaFreeHost(host_isAnchor);
-    cudaFreeHost(host_moduleType);
-    cudaFreeHost(host_moduleLayerType);
-    cudaFreeHost(host_slopes);
-    cudaFreeHost(host_drdzs);
-    cudaFreeHost(host_partnerModuleIndices);
+    cms::cuda::free_host(host_detIds);
+    cms::cuda::free_host(host_layers);
+    cms::cuda::free_host(host_rings);
+    cms::cuda::free_host(host_rods);
+    cms::cuda::free_host(host_modules);
+    cms::cuda::free_host(host_subdets);
+    cms::cuda::free_host(host_sides);
+    cms::cuda::free_host(host_isInverted);
+    cms::cuda::free_host(host_isLower);
+    cms::cuda::free_host(host_isAnchor);
+    cms::cuda::free_host(host_moduleType);
+    cms::cuda::free_host(host_moduleLayerType);
+    cms::cuda::free_host(host_slopes);
+    cms::cuda::free_host(host_drdzs);
+    cms::cuda::free_host(host_partnerModuleIndices);
     std::cout<<"number of lower modules (without fake pixel module)= "<<lowerModuleCounter<<std::endl;
     fillConnectedModuleArrayExplicit(modulesInGPU,nModules,stream);
     fillPixelMap(modulesInGPU,pixelMapping,stream);
@@ -699,12 +703,13 @@ void SDL::fillPixelMap(struct modules& modulesInGPU, struct pixelMap& pixelMappi
     //unsigned int* connectedPixelsSizes;
     //unsigned int* connectedPixelsSizesPos;
     //unsigned int* connectedPixelsSizesNeg;
-    cudaMallocHost(&pixelMapping.connectedPixelsIndex,size_superbins * sizeof(unsigned int));
-    cudaMallocHost(&pixelMapping.connectedPixelsSizes,size_superbins * sizeof(unsigned int));
-    cudaMallocHost(&pixelMapping.connectedPixelsIndexPos,size_superbins * sizeof(unsigned int));
-    cudaMallocHost(&pixelMapping.connectedPixelsSizesPos,size_superbins * sizeof(unsigned int));
-    cudaMallocHost(&pixelMapping.connectedPixelsIndexNeg,size_superbins * sizeof(unsigned int));
-    cudaMallocHost(&pixelMapping.connectedPixelsSizesNeg,size_superbins * sizeof(unsigned int));
+
+    pixelMapping.connectedPixelsIndex = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    pixelMapping.connectedPixelsSizes = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    pixelMapping.connectedPixelsIndexPos = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    pixelMapping.connectedPixelsSizesPos = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    pixelMapping.connectedPixelsIndexNeg = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    pixelMapping.connectedPixelsSizesNeg = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
     int totalSizes=0;
     int totalSizes_pos=0;
     int totalSizes_neg=0;
@@ -796,7 +801,7 @@ void SDL::fillPixelMap(struct modules& modulesInGPU, struct pixelMap& pixelMappi
     }
 
     unsigned int* connectedPixels;
-    cudaMallocHost(&connectedPixels,(totalSizes+totalSizes_pos+totalSizes_neg) * sizeof(unsigned int));
+    connectedPixels = (unsigned int*)cms::cuda::allocate_host((totalSizes+totalSizes_pos+totalSizes_neg) * sizeof(unsigned int), stream);
 #ifdef Explicit_Module
     cudaMalloc(&modulesInGPU.connectedPixels,(totalSizes+totalSizes_pos+totalSizes_neg)* sizeof(unsigned int));
 #else
@@ -815,15 +820,15 @@ void SDL::fillPixelMap(struct modules& modulesInGPU, struct pixelMap& pixelMappi
     cudaMemcpyAsync(modulesInGPU.connectedPixels,connectedPixels,(totalSizes+totalSizes_pos+totalSizes_neg)*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
 
-    cudaFreeHost(connectedPixels);
+    cms::cuda::free_host(connectedPixels);
 }
 
 void SDL::fillConnectedModuleArrayExplicit(struct modules& modulesInGPU, unsigned int nModules,cudaStream_t stream)
 {
     uint16_t* moduleMap;
     uint16_t* nConnectedModules;
-    cudaMallocHost(&moduleMap,nModules * 40 * sizeof(uint16_t));
-    cudaMallocHost(&nConnectedModules,nModules * sizeof(uint16_t));
+    moduleMap = (uint16_t*)cms::cuda::allocate_host(nModules * 40 * sizeof(uint16_t), stream);
+    nConnectedModules = (uint16_t*)cms::cuda::allocate_host(nModules * sizeof(uint16_t), stream);
     for(auto it = (*detIdToIndex).begin(); it != (*detIdToIndex).end(); ++it)
     {
         unsigned int detId = it->first;
@@ -838,8 +843,8 @@ void SDL::fillConnectedModuleArrayExplicit(struct modules& modulesInGPU, unsigne
     cudaMemcpyAsync(modulesInGPU.moduleMap,moduleMap,nModules*40*sizeof(uint16_t),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(modulesInGPU.nConnectedModules,nConnectedModules,nModules*sizeof(uint16_t),cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
-    cudaFreeHost(moduleMap);
-    cudaFreeHost(nConnectedModules);
+    cms::cuda::free_host(moduleMap);
+    cms::cuda::free_host(nConnectedModules);
 }
 
 void SDL::setDerivedQuantities(unsigned int detId, unsigned short& layer, unsigned short& ring, unsigned short& rod, unsigned short& module, unsigned short& subdet, unsigned short& side, float m_x, float m_y, float m_z, float& eta, float& r)

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -539,6 +539,8 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, 
     cms::cuda::free_host(host_modules);
     cms::cuda::free_host(host_subdets);
     cms::cuda::free_host(host_sides);
+    cms::cuda::free_host(host_eta);
+    cms::cuda::free_host(host_r);
     cms::cuda::free_host(host_isInverted);
     cms::cuda::free_host(host_isLower);
     cms::cuda::free_host(host_isAnchor);

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -133,18 +133,18 @@ void SDL::createEligibleModulesListForQuintuplets(struct modules& modulesInGPU,s
     cudaMemsetAsync(rangesInGPU.quintupletModuleIndices, -1, sizeof(int) * (nLowerModules),stream);
 
     short* module_subdets;
-    cudaMallocHost(&module_subdets, nLowerModules* sizeof(short));
+    module_subdets = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
     cudaMemcpyAsync(module_subdets,modulesInGPU.subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     short* module_layers;
-    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
+    module_layers = (short*)cms::cuda::allocate_host(nLowerModules * sizeof(short), stream);
     cudaMemcpyAsync(module_layers,modulesInGPU.layers,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
 
     int* module_quintupletModuleIndices;
-    cudaMallocHost(&module_quintupletModuleIndices, nLowerModules * sizeof(int));
+    module_quintupletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(int), stream);
     cudaMemcpyAsync(module_quintupletModuleIndices,rangesInGPU.quintupletModuleIndices,nLowerModules *sizeof(int),cudaMemcpyDeviceToHost,stream);
 
     unsigned int* nTriplets;
-    cudaMallocHost(&nTriplets, nLowerModules * sizeof(unsigned int));
+    nTriplets = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
     cudaMemcpyAsync(nTriplets, tripletsInGPU.nTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 cudaStreamSynchronize(stream);
 
@@ -164,10 +164,10 @@ cudaStreamSynchronize(stream);
     cudaMemcpyAsync(rangesInGPU.quintupletModuleIndices,module_quintupletModuleIndices,nLowerModules*sizeof(int),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(rangesInGPU.nEligibleT5Modules,&nEligibleModules,sizeof(uint16_t),cudaMemcpyHostToDevice,stream);
 cudaStreamSynchronize(stream);
-    cudaFreeHost(module_subdets);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_quintupletModuleIndices);
-    cudaFreeHost(nTriplets);
+    cms::cuda::free_host(module_subdets);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_quintupletModuleIndices);
+    cms::cuda::free_host(nTriplets);
 }
 
 

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -32,10 +32,10 @@ void SDL::createSegmentArrayRanges(struct modules& modulesInGPU, struct objectRa
         write code here that will deal with importing module parameters to CPU, and get the relevant occupancies for a given module!*/
 
     int *module_segmentModuleIndices;
-    cudaMallocHost(&module_segmentModuleIndices, (nLowerModules + 1) * sizeof(unsigned int));
+    module_segmentModuleIndices = (int*)cms::cuda::allocate_host((nLowerModules + 1) * sizeof(unsigned int), stream);
     module_segmentModuleIndices[0] = 0;
     uint16_t* module_nConnectedModules;
-    cudaMallocHost(&module_nConnectedModules, nLowerModules * sizeof(uint16_t));
+    module_nConnectedModules = (uint16_t*)cms::cuda::allocate_host(nLowerModules * sizeof(uint16_t), stream);
     cudaMemcpyAsync(module_nConnectedModules,modulesInGPU.nConnectedModules,nLowerModules*sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
     cudaStreamSynchronize(stream);
 
@@ -62,8 +62,8 @@ void SDL::createSegmentArrayRanges(struct modules& modulesInGPU, struct objectRa
     }
     cudaMemcpyAsync(rangesInGPU.segmentModuleIndices, module_segmentModuleIndices,  (nLowerModules + 1) * sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
     cudaStreamSynchronize(stream);
-    cudaFreeHost(module_segmentModuleIndices);
-    cudaFreeHost(module_nConnectedModules);
+    cms::cuda::free_host(module_segmentModuleIndices);
+    cms::cuda::free_host(module_nConnectedModules);
 }
 
 void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned int nMemoryLocations, uint16_t nLowerModules, unsigned int maxPixelSegments,cudaStream_t stream)

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -19,9 +19,9 @@ void SDL::triplets::resetMemory(unsigned int maxTriplets, unsigned int nLowerMod
 void SDL::createTripletArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct segments& segmentsInGPU, uint16_t& nLowerModules, unsigned int& nTotalTriplets, cudaStream_t stream, const uint16_t& maxTripletsPerModule)
 {
     int* module_tripletModuleIndices;
-    cudaMallocHost(&module_tripletModuleIndices, nLowerModules * sizeof(unsigned int));
+    module_tripletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
     unsigned int* nSegments;
-    cudaMallocHost(&nSegments, nLowerModules * sizeof(unsigned int));
+    nSegments = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
     cudaMemcpyAsync(nSegments, segmentsInGPU.nSegments, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaStreamSynchronize(stream);
     module_tripletModuleIndices[0] = 0; 
@@ -38,8 +38,8 @@ void SDL::createTripletArrayRanges(struct modules& modulesInGPU, struct objectRa
     }
     cudaMemcpyAsync(rangesInGPU.tripletModuleIndices, module_tripletModuleIndices, nLowerModules * sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
     cudaStreamSynchronize(stream);
-    cudaFreeHost(module_tripletModuleIndices);
-    cudaFreeHost(nSegments);
+    cms::cuda::free_host(module_tripletModuleIndices);
+    cms::cuda::free_host(nSegments);
 }
 
 void SDL::createTripletsInUnifiedMemory(struct triplets& tripletsInGPU, unsigned int maxTriplets, uint16_t nLowerModules,cudaStream_t stream)


### PR DESCRIPTION
This pull request replaces most of the CudaMallocHost calls in the code with the host caching allocator that is already present in the codebase.

See the new timing below
![full_new](https://user-images.githubusercontent.com/25272611/166325697-9602033e-ddf3-445c-b420-0b7cbe129870.png)

Compared to a run from the current version of the code
![current_full](https://user-images.githubusercontent.com/25272611/166325802-02bc265c-158f-4e21-a65a-1c01f826d9c4.png)

From what I have seen over multiple timing runs, the host allocator gives a little over 10% speedup for s=2,4,6, and 8.