### PR TITLE
2D duplicate kernels + Improved segment launching grid 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ movetoweb.sh
 *.log
 
 *.nfs*
+.directoryhash

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1572,7 +1572,7 @@ void SDL::Event::createSegmentsWithModuleMap()
 //        sq_max_nMDs = sq_max_nMDs > limit_local ? sq_max_nMDs : limit_local;
 //    }
 //  #endif
-    dim3 nThreads(32,16,1);
+    dim3 nThreads(1024,1,1);
     dim3 nBlocks(1,1,MAX_BLOCKS);
 
     createSegmentsInGPU<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *rangesInGPU);
@@ -1951,8 +1951,9 @@ cudaStreamSynchronize(stream);
 
     //pT3s can be cleaned here because they're not used in making pT5s!
 #ifdef DUP_pT3
-    dim3 nThreads_dup(160,1,1);
-    dim3 nBlocks_dup(MAX_BLOCKS,1,1);
+    //dim3 nThreads_dup(160,1,1);
+    dim3 nThreads_dup(32,32,1);
+    dim3 nBlocks_dup(1,MAX_BLOCKS,1);
     removeDupPixelTripletsInGPUFromMap<<<nBlocks_dup,nThreads_dup,0,stream>>>(*pixelTripletsInGPU,false);
 cudaStreamSynchronize(stream);
 #endif
@@ -2217,8 +2218,8 @@ cudaStreamSynchronize(stream);
     free(segs_pix);
     cudaFree(segs_pix_gpu);
 
-    dim3 nThreads_dup(256,1,1);
-    dim3 nBlocks_dup(MAX_BLOCKS,1,1);
+    dim3 nThreads_dup(32,32,1);
+    dim3 nBlocks_dup(1,MAX_BLOCKS,1);
 #ifdef DUP_pT5
     //printf("run dup pT5\n");
     removeDupPixelQuintupletsInGPUFromMap<<<nBlocks_dup,nThreads_dup,0,stream>>>(*pixelQuintupletsInGPU, false);

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -1187,12 +1187,11 @@ __device__ int duplicateCounter_pT3 =0;
 
 __global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::pixelTriplets& pixelTripletsInGPU, bool secondPass)
 {
-    int dup_count=0;
-    for (unsigned int ix=blockIdx.x*blockDim.x+threadIdx.x; ix<*pixelTripletsInGPU.nPixelTriplets; ix+=blockDim.x*gridDim.x)
+    for (unsigned int ix=blockIdx.y*blockDim.y+threadIdx.y; ix<*pixelTripletsInGPU.nPixelTriplets; ix+=blockDim.y*gridDim.y)
     {
         //bool isDup = false;
         float score1 = __H2F(pixelTripletsInGPU.score[ix]);
-        for (unsigned int jx=0; jx<*pixelTripletsInGPU.nPixelTriplets; jx++)
+        for(unsigned int jx=blockIdx.x * blockDim.x + threadIdx.x; jx < *pixelTripletsInGPU.nPixelTriplets; jx += blockDim.x * gridDim.x)
         {
             float score2 = __H2F(pixelTripletsInGPU.score[jx]);
             if(ix==jx)
@@ -1203,14 +1202,12 @@ __global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::pixelTriplets& pi
             checkHitspT3(ix,jx,pixelTripletsInGPU,nMatched);
             if(((nMatched[0] + nMatched[1]) >= 5) )
             {
-                dup_count++;
                 //check the layers
                 if(pixelTripletsInGPU.logicalLayers[5*jx+2] < pixelTripletsInGPU.logicalLayers[5*ix+2])
                 {
                     rmPixelTripletToMemory(pixelTripletsInGPU, ix);
                     break;
                 }
-
                 else if( pixelTripletsInGPU.logicalLayers[5*ix+2] == pixelTripletsInGPU.logicalLayers[5*jx+2] && __H2F(pixelTripletsInGPU.score[ix]) > __H2F(pixelTripletsInGPU.score[jx]))
                 {
                     rmPixelTripletToMemory(pixelTripletsInGPU,ix);
@@ -1226,7 +1223,7 @@ __global__ void removeDupPixelTripletsInGPUFromMap(struct SDL::pixelTriplets& pi
     }
 }
 
-__global__ void removeDupPixelQuintupletsInGPUFromMap( struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, bool secondPass)
+/*__global__ void removeDupPixelQuintupletsInGPUFromMap( struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, bool secondPass)
 {
     //printf("running pT5 duprm\n");
     int dup_count=0;
@@ -1269,7 +1266,44 @@ __global__ void removeDupPixelQuintupletsInGPUFromMap( struct SDL::pixelQuintupl
             }
         }
     }
+}*/
+
+
+__global__ void removeDupPixelQuintupletsInGPUFromMap(struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, bool secondPass)
+{
+    int nPixelQuintuplets = *pixelQuintupletsInGPU.nPixelQuintuplets;
+
+    for(unsigned int ix = blockIdx.y * blockDim.y + threadIdx.y; ix < nPixelQuintuplets; ix += blockDim.y * gridDim.y)
+    {
+        if(secondPass && pixelQuintupletsInGPU.isDup[ix])
+        {
+            continue;
+        }
+	    float score1 = __H2F(pixelQuintupletsInGPU.score[ix]);
+        for(unsigned int jx = blockIdx.x * blockDim.x + threadIdx.x; jx < nPixelQuintuplets; jx += blockDim.x * gridDim.x)
+        {
+            if(ix == jx)
+            {
+                continue;
+            }
+            if(secondPass && pixelQuintupletsInGPU.isDup[jx])
+            {
+                continue;
+            }
+            int nMatched = checkHitspT5(ix, jx, pixelQuintupletsInGPU);
+            float score2 = __H2F(pixelQuintupletsInGPU.score[jx]);
+            if(nMatched >= 7)
+            {
+                if(score1 > score2 or ((score1 == score2) and (ix > jx)))
+                {
+                    rmPixelQuintupletToMemory(pixelQuintupletsInGPU, ix);
+                    break;
+                }
+            }
+        }
+    }
 }
+
 
 __global__ void checkHitspLS(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::hits& hitsInGPU,bool secondpass)
 {


### PR DESCRIPTION
![temp_timing](https://user-images.githubusercontent.com/40841444/166531971-5b292fbd-cbfc-4c08-bbf4-4340730d884c.png)

For segments, going to one extreme (thread dimensions 1024, 1, 1) seems to help with memory coalescing, given that our cache hit rate is now 95% (from 67% previously). In addition, I've implemented Matt's suggestions albeit for pT3 and pT5 duplicate cleaning kernels.