### PR TITLE
Fix for maximum number of objects

### DIFF
--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -759,8 +759,8 @@ __global__ void createT3T3ExtendedTracksInGPU(struct SDL::modules& modulesInGPU,
 
         if(success and nLayerOverlaps[0] == 2)
         {
-            atomicAdd(&trackExtensionsInGPU.totOccupancyTrackExtensions[nTrackCandidates], 1);
-            if(trackExtensionsInGPU.nTrackExtensions[nTrackCandidates] >= N_MAX_T3T3_TRACK_EXTENSIONS)
+            unsigned int totOccupancyTrackExtensions = atomicAdd(&trackExtensionsInGPU.totOccupancyTrackExtensions[nTrackCandidates], 1);
+            if(totOccupancyTrackExtensions >= N_MAX_T3T3_TRACK_EXTENSIONS)
             {
 #ifdef Warnings
                 printf("T3T3 track extensions overflow!\n");
@@ -798,8 +798,8 @@ __global__ void createT3T3ExtendedTracksInGPU(struct SDL::modules& modulesInGPU,
 
         if(success and nLayerOverlaps[0] == 1 and nHitOverlaps[0] != 2)        
         {
-            atomicAdd(&trackExtensionsInGPU.totOccupancyTrackExtensions[nTrackCandidates], 1);
-            if(trackExtensionsInGPU.nTrackExtensions[nTrackCandidates] >= N_MAX_T3T3_TRACK_EXTENSIONS)
+            unsigned int totOccupancyTrackExtensions = atomicAdd(&trackExtensionsInGPU.totOccupancyTrackExtensions[nTrackCandidates], 1);
+            if(totOccupancyTrackExtensions >= N_MAX_T3T3_TRACK_EXTENSIONS)
             {
 #ifdef Warnings
                 printf("T3T3 track extensions overflow!\n");

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -1032,8 +1032,8 @@ __global__ void SDL::createMiniDoubletsInGPUv2(struct SDL::modules& modulesInGPU
             bool success = runMiniDoubletDefaultAlgo(modulesInGPU, lowerModuleIndex, upperModuleIndex, lowerHitArrayIndex, upperHitArrayIndex, dz, dphi, dphichange, shiftedX, shiftedY, shiftedZ, noShiftedDz, noShiftedDphi, noShiftedDphiChange, xLower,yLower,zLower,rtLower,xUpper,yUpper,zUpper,rtUpper);
 if(success)
             {
-                atomicAdd(&mdsInGPU.totOccupancyMDs[lowerModuleIndex],1);
-                if(mdsInGPU.nMDs[lowerModuleIndex] >= (rangesInGPU.miniDoubletModuleIndices[lowerModuleIndex + 1] - rangesInGPU.miniDoubletModuleIndices[lowerModuleIndex]))
+                unsigned int totOccupancyMDs = atomicAdd(&mdsInGPU.totOccupancyMDs[lowerModuleIndex],1);
+                if(totOccupancyMDs >= (rangesInGPU.miniDoubletModuleIndices[lowerModuleIndex + 1] - rangesInGPU.miniDoubletModuleIndices[lowerModuleIndex]))
                 {
 #ifdef Warnings
                     printf("Mini-doublet excess alert! Module index =  %d\n",lowerModuleIndex);

--- a/SDL/PixelTriplet.cu
+++ b/SDL/PixelTriplet.cu
@@ -883,8 +883,8 @@ __global__ void SDL::createPixelTripletsInGPUFromMapv2(struct SDL::modules& modu
                 float phi_pix = segmentsInGPU.phi[pixelSegmentArrayIndex];
                 float pt = segmentsInGPU.ptIn[pixelSegmentArrayIndex];
                 float score = rPhiChiSquared+rPhiChiSquaredInwards;
-                atomicAdd(pixelTripletsInGPU.totOccupancyPixelTriplets, 1);
-                if(*pixelTripletsInGPU.nPixelTriplets >= N_MAX_PIXEL_TRIPLETS)
+                unsigned int totOccupancyPixelTriplets = atomicAdd(pixelTripletsInGPU.totOccupancyPixelTriplets, 1);
+                if(totOccupancyPixelTriplets >= N_MAX_PIXEL_TRIPLETS)
                 {
 #ifdef Warnings
                     printf("Pixel Triplet excess alert!\n");
@@ -2423,8 +2423,8 @@ __global__ void SDL::createPixelQuintupletsInGPUFromMapv2(struct SDL::modules& m
             bool success = runPixelQuintupletDefaultAlgo(modulesInGPU, rangesInGPU, mdsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, pixelSegmentIndex, quintupletIndex, rzChiSquared, rPhiChiSquared, rPhiChiSquaredInwards, pixelRadius, quintupletRadius, centerX, centerY);
             if(success)
             {
-                atomicAdd(pixelQuintupletsInGPU.totOccupancyPixelQuintuplets, 1);
-                if(*pixelQuintupletsInGPU.nPixelQuintuplets >= N_MAX_PIXEL_QUINTUPLETS)
+                unsigned int totOccupancyPixelQuintuplets = atomicAdd(pixelQuintupletsInGPU.totOccupancyPixelQuintuplets, 1);
+                if(totOccupancyPixelQuintuplets >= N_MAX_PIXEL_QUINTUPLETS)
                 {
 #ifdef Warnings
                     printf("Pixel Quintuplet excess alert!\n");

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -1412,8 +1412,8 @@ __global__ void SDL::createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU,
                 {
                     return;
                 } // ignore anything else TODO: move this to start, before object is made (faster)
-                atomicAdd(&quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1);
-                if(quintupletsInGPU.nQuintuplets[lowerModule1] >= N_MAX_QUINTUPLETS_PER_MODULE)
+                unsigned int totOccupancyQuintuplets = atomicAdd(&quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1);
+                if(totOccupancyQuintuplets >= N_MAX_QUINTUPLETS_PER_MODULE)
                 {
 #ifdef Warnings
                     printf("Quintuplet excess alert! Module index = %d\n", lowerModule1);

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -953,8 +953,8 @@ __global__ void SDL::createSegmentsInGPUv2(struct SDL::modules& modulesInGPU, st
 
             if(pass)
             {
-                atomicAdd(&segmentsInGPU.totOccupancySegments[innerLowerModuleIndex],1);
-                if(segmentsInGPU.nSegments[innerLowerModuleIndex] >= N_MAX_SEGMENTS_PER_MODULE)
+                unsigned int totOccupancySegments = atomicAdd(&segmentsInGPU.totOccupancySegments[innerLowerModuleIndex],1);
+                if(totOccupancySegments >= N_MAX_SEGMENTS_PER_MODULE)
                 {
 #ifdef Warnings
                     printf("Segment excess alert! Module index = %d\n",innerLowerModuleIndex);

--- a/SDL/TrackExtensions.cu
+++ b/SDL/TrackExtensions.cu
@@ -3513,8 +3513,8 @@ __global__ void SDL::createExtendedTracksInGPUv2(struct SDL::modules& modulesInG
     bool success = runTrackExtensionDefaultAlgo(modulesInGPU, hitsInGPU, mdsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, pixelTripletsInGPU, pixelQuintupletsInGPU, trackCandidatesInGPU, tcIdx, t3Idx, tcType, 3, outerT3Index, layerOverlap, constituentTCType, constituentTCIndex, nLayerOverlaps, nHitOverlaps, rPhiChiSquared, rzChiSquared, regressionRadius, innerRadius, outerRadius);
     if(success)
     {
-        atomicAdd(&trackExtensionsInGPU.totOccupancyTrackExtensions[tcIdx], 1);
-        if(trackExtensionsInGPU.nTrackExtensions[tcIdx] >= N_MAX_TRACK_EXTENSIONS_PER_TC)
+        unsigned int totOccupancyTrackExtensions = atomicAdd(&trackExtensionsInGPU.totOccupancyTrackExtensions[tcIdx], 1);
+        if(totOccupancyTrackExtensions >= N_MAX_TRACK_EXTENSIONS_PER_TC)
         {
 #ifdef Warnings
             printf("Track extensions overflow for TC index = %d\n", tcIdx);

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -684,8 +684,8 @@ __global__ void SDL::createTripletsInGPUv2(struct SDL::modules& modulesInGPU, st
         bool success = runTripletDefaultAlgo(modulesInGPU, mdsInGPU, segmentsInGPU, innerInnerLowerModuleIndex, middleLowerModuleIndex, outerOuterLowerModuleIndex, innerSegmentIndex, outerSegmentIndex, zOut, rtOut, deltaPhiPos, deltaPhi, betaIn, betaOut, pt_beta, zLo, zHi, rtLo, rtHi, zLoPointed, zHiPointed, sdlCut, betaInCut, betaOutCut, deltaBetaCut, kZ);
 
         if(success) {
-          atomicAdd(&tripletsInGPU.totOccupancyTriplets[innerInnerLowerModuleIndex], 1);
-          if(tripletsInGPU.nTriplets[innerInnerLowerModuleIndex] >= N_MAX_TRIPLETS_PER_MODULE) {
+          unsigned int totOccupancyTriplets = atomicAdd(&tripletsInGPU.totOccupancyTriplets[innerInnerLowerModuleIndex], 1);
+          if(totOccupancyTriplets >= N_MAX_TRIPLETS_PER_MODULE) {
 #ifdef Warnings
             printf("Triplet excess alert! Module index = %d\n",innerInnerLowerModuleIndex);
 #endif

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -98,12 +98,10 @@ void SDL::createTripletsInUnifiedMemory(struct triplets& tripletsInGPU, unsigned
     cudaMemsetAsync(tripletsInGPU.nTriplets,0,nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(tripletsInGPU.totOccupancyTriplets,0,nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(tripletsInGPU.partOfPT5,0,maxTriplets * sizeof(bool),stream);
-
-#ifdef TRACK_EXTENSIONS
     cudaMemsetAsync(tripletsInGPU.partOfPT3,0,maxTriplets * sizeof(bool),stream);
     cudaMemsetAsync(tripletsInGPU.partOfT5,0,maxTriplets * sizeof(bool),stream);
     cudaMemsetAsync(tripletsInGPU.partOfExtension,0,maxTriplets * sizeof(bool),stream);
-#endif
+
     cudaStreamSynchronize(stream);
 }
 void SDL::createTripletsInExplicitMemory(struct triplets& tripletsInGPU, unsigned int maxTriplets, uint16_t nLowerModules, cudaStream_t stream)


### PR DESCRIPTION
This PR properly applies the maximum number of objects, as tested by printouts.

**Timing**
Master:
<img width="1101" alt="timing_master" src="https://user-images.githubusercontent.com/15358704/167292162-c67ba976-7861-44ac-ab33-19cfc34315fb.png">

This PR:
<img width="1101" alt="timing_fixObjectMaxNumber" src="https://user-images.githubusercontent.com/15358704/167292180-7e87fd6a-e570-4cc3-bc16-47d6d990677a.png">

**Validation**
Master:
https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/fixObjectMaxNumber/eff_plots__GPU_explicit_cache_1cad1b0_PU200/

This PR:
https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/fixObjectMaxNumber/eff_plots__GPU_explicit_cache_84a74b2_PU200_fixObjectMaxNumber/

The efficiency is slightly lower (<1%) for this PR, which makes sense since we are now properly cropping the number of objects.

