### PR TITLE
Blocked createSegmentsInGPUv2 version

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1485,10 +1485,13 @@ void SDL::Event::createSegmentsWithModuleMap()
         createSegmentsInUnifiedMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nLowerModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE,stream);
 #endif
     }
-    dim3 nThreads(512,1,1);
-    dim3 nBlocks(1,1,MAX_BLOCKS);
 
-    SDL::createSegmentsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *rangesInGPU);
+//HERE
+    dim3 cSnThreads(64,1,1);
+    uint32_t blks = nLowerModules;
+//printf("HERE Num nLowerModules=%d Blks=%d\n",nLowerModules,blks);
+    dim3 cSnBlocks(blks,1,1);
+    SDL::createSegmentsInGPUv2<<<cSnBlocks,cSnThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *rangesInGPU);
     cudaError_t cudaerr = cudaGetLastError();
     if(cudaerr != cudaSuccess)
     {

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -18,9 +18,9 @@ LIB=sdl.so
 
 # AMD Opteron and Intel EM64T (64 bit mode) Linux with gcc 3.x
 CXX                  = nvcc
-CXXFLAGS             =  -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 -I/mnt/data1/dsr/cub --use_fast_math --default-stream per-thread
+CXXFLAGS             = -O3 --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_80 -I/mnt/data1/dsr/cub --use_fast_math --default-stream per-thread
 LD                   = nvcc 
-SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70 -code=sm_72
+SOFLAGS              = -O3 -shared --compiler-options -fPIC --cudart shared -arch=compute_80 -code=sm_80
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
 FINALSTATE           = -DFINAL_pT5 -DFINAL_pT3 -DFINAL_T5 -DFINAL_pLS
 DUPLICATES           = -DDUP_pLS -DDUP_T5 -DDUP_pT5 -DDUP_pT3 -DCrossclean_T5 -DCrossclean_pT3 -DFP16_Base -DFP16_dPhi #-DFP16_circle -DFP16_seg -DFP16_T5

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -915,14 +915,15 @@ __device__ float SDL::moduleGapSize_seg(struct modules& modulesInGPU, unsigned i
 }
 __global__ void SDL::createSegmentsInGPUv2(struct SDL::modules& modulesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::objectRanges& rangesInGPU)
 {
-    int blockxSize = blockDim.x*gridDim.x;
-    int blockySize = blockDim.y*gridDim.y;
-    int blockzSize = blockDim.z*gridDim.z;
-    for(uint16_t innerLowerModuleIndex = blockIdx.z * blockDim.z + threadIdx.z; innerLowerModuleIndex< (*modulesInGPU.nLowerModules); innerLowerModuleIndex += blockzSize){
+    int blockxSize = gridDim.x;
+    int blockySize = blockDim.y;
+    int blockzSize = blockDim.x;
+    for(uint16_t innerLowerModuleIndex = blockIdx.x ; innerLowerModuleIndex< (*modulesInGPU.nLowerModules); innerLowerModuleIndex += blockxSize){
 
     unsigned int nConnectedModules = modulesInGPU.nConnectedModules[innerLowerModuleIndex];
+//printf("HERE:  %d nConnectedModules = %d\n", innerLowerModuleIndex, nConnectedModules);
 
-    for(uint16_t outerLowerModuleArrayIdx = blockIdx.y * blockDim.y + threadIdx.y; outerLowerModuleArrayIdx< nConnectedModules; outerLowerModuleArrayIdx += blockySize){
+    for(uint16_t outerLowerModuleArrayIdx = threadIdx.y; outerLowerModuleArrayIdx< nConnectedModules; outerLowerModuleArrayIdx += blockySize){
 
         uint16_t outerLowerModuleIndex = modulesInGPU.moduleMap[innerLowerModuleIndex * MAX_CONNECTED_MODULES + outerLowerModuleArrayIdx];
 
@@ -930,8 +931,10 @@ __global__ void SDL::createSegmentsInGPUv2(struct SDL::modules& modulesInGPU, st
         unsigned int nOuterMDs = mdsInGPU.nMDs[outerLowerModuleIndex];
 
         int limit = nInnerMDs*nOuterMDs;
+//printf("HERE:  %d %d limit %d\n", innerLowerModuleIndex, outerLowerModuleArrayIdx, limit);
+
         if (limit == 0) continue;
-        for(int hitIndex = blockIdx.x * blockDim.x + threadIdx.x; hitIndex< limit; hitIndex += blockxSize)
+        for(int hitIndex = threadIdx.x; hitIndex< limit; hitIndex += blockzSize)
         {
             int innerMDArrayIdx = hitIndex / nOuterMDs;
             int outerMDArrayIdx = hitIndex % nOuterMDs;


### PR DESCRIPTION

Use blockIdx.x on outer loop, threadidx.y on the middle loop, and thread.x on the inner loop.  

Experimentation on an A100 shows the optimal schedule is a block size of 64x1x1 with block.x == nLowerModules.  Est. duration ~.84us vs ~4.8ms on the original version