### PR TITLE
resize pixelTriplet kernels

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1859,10 +1859,11 @@ cudaStreamSynchronize(stream);
     free(segs_pix);
     //cudaFreeAsync(segs_pix_gpu,stream);
     cudaFree(segs_pix_gpu);
+
 #ifdef Warnings
     unsigned int nPixelTriplets;
-    cudaMemcpyAsync(&nPixelTriplets, &(pixelTripletsInGPU->nPixelTriplets),  sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-    cudaStreamSynhronize(stream);
+    cudaMemcpyAsync(&nPixelTriplets, pixelTripletsInGPU->nPixelTriplets,  sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
+    cudaStreamSynchronize(stream);
     std::cout<<"number of pixel triplets = "<<nPixelTriplets<<std::endl;
 #endif
 
@@ -1870,7 +1871,7 @@ cudaStreamSynchronize(stream);
 #ifdef DUP_pT3
     //dim3 nThreads_dup(160,1,1);
     dim3 nThreads_dup(32,32,1);
-    dim3 nBlocks_dup(1,MAX_BLOCKS,1);
+    dim3 nBlocks_dup(1,40,1); //seems like more blocks lead to conflicting writes
     removeDupPixelTripletsInGPUFromMap<<<nBlocks_dup,nThreads_dup,0,stream>>>(*pixelTripletsInGPU,false);
 cudaStreamSynchronize(stream);
 #endif

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1835,8 +1835,8 @@ cudaStreamSynchronize(stream);
     //dim3 nBlocks((totalSegs % nThreads.x == 0 ? totalSegs / nThreads.x : totalSegs / nThreads.x + 1),
     //              (max_size % nThreads.y == 0 ? max_size/nThreads.y : max_size/nThreads.y + 1),1);
     //printf("%d %d\n",totalSegs,max_size);
-    dim3 nThreads(16,16,1);
-    dim3 nBlocks(1,MAX_BLOCKS,1);
+    dim3 nThreads(32,4,1);
+    dim3 nBlocks(1,4096,1);
     //createPixelTripletsInGPUFromMap<<<nBlocks, nThreads,0,stream>>>(*modulesInGPU, *rangesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, connectedPixelSize_dev,connectedPixelIndex_dev,nInnerSegments,segs_pix_gpu,segs_pix_gpu_offset, totalSegs);
     SDL::createPixelTripletsInGPUFromMapv2<<<nBlocks, nThreads,0,stream>>>(*modulesInGPU, *rangesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, connectedPixelSize_dev,connectedPixelIndex_dev,nInnerSegments,segs_pix_gpu,segs_pix_gpu_offset, totalSegs);
 

--- a/SDL/PixelTriplet.cu
+++ b/SDL/PixelTriplet.cu
@@ -829,6 +829,7 @@ __global__ void SDL::createPixelTripletsInGPUFromMapv2(struct SDL::modules& modu
     int blockxSize = blockDim.x*gridDim.x;
     int blockySize = blockDim.y*gridDim.y;
     //unsigned int offsetIndex = blockIdx.x * blockDim.x + threadIdx.x;
+    // loop over pLS mapped to all connected inner modules (array size totalSegs is n pLS times average nConnected)
     for(int offsetIndex = blockIdx.y * blockDim.y + threadIdx.y; offsetIndex< totalSegs; offsetIndex += blockySize)
     {
 
@@ -846,7 +847,7 @@ __global__ void SDL::createPixelTripletsInGPUFromMapv2(struct SDL::modules& modu
         unsigned int nOuterTriplets = tripletsInGPU.nTriplets[tripletLowerModuleIndex];
 
         if(nOuterTriplets == 0) continue;//return;
-        if(modulesInGPU.moduleType[tripletLowerModuleIndex] == SDL::TwoS) continue;//return; //Removes 2S-2S
+        if(modulesInGPU.moduleType[tripletLowerModuleIndex] == SDL::TwoS) continue;//return; //Removes 2S-2S :FIXME: filter these out in the pixel map
 
         //fetch the triplet
         for(unsigned int outerTripletArrayIndex = blockIdx.x * blockDim.x + threadIdx.x; outerTripletArrayIndex< nOuterTriplets; outerTripletArrayIndex +=blockxSize)


### PR DESCRIPTION
for `SDL::createPixelTripletsInGPUFromMapv2` (on V100; 20 events) time reduced from  3.04ms to 1.23 ms by changing to  nThreads(32,4,1); nBlocks(1,4096,1);
- Here the outer y loop typically goes over 0.2 - to 0.5 million entries;
the innermost loop varies : 83% is below 16 (not counting zeros); around 8% goes above 32; 1% is above 128. So, there will still be some tails of lonely threads.
- Still, a factor of 2.5 speedup is almost for free
- I went up to 16384 blocks in y and down to only 32-x in block size; these had worse times


removeDupPixelTripletsInGPUFromMap has a bit odd behavior; it's a loop of N*N, where N is around 300 to 800. It writes to bool isDup[N] to the outer index.
The cost of computation inside the kernel thread seems small.
I find that the smallest time is achieved with nBlocks smaller than number of SMs.
nBlocks(1,40); nThreads(32,32) runs faster than nBlocks(1,80); nThreads(32,32): time changes from 0.117ms to 0.085ms.
- times go up by a factor of 2 with more blocks
- I'm guessing there is something with memory coherency in cache that could slow things down: either the writes happen to the same cache line but different location, or perhaps even the same location. 
We are writing only "1" in this case and it wouldn't matter which thread value makes it. Is there a way to tell it to the compiler or GPU runtime?

Since my setup is on phi3, I think that it would be better to get reference timing values from lnx/Cornell. 
