### PR TITLE
speedup in startup and hit loading

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -695,7 +695,7 @@ cudaStreamSynchronize(stream);
       if(module_subdet[this_index] == Endcap && module_moduleType[this_index] == TwoS)
       {
           float xhigh, yhigh, xlow, ylow;
-          getEdgeHits(iDetId,ihit_x,ihit_x+ihit_y,xhigh,yhigh,xlow,ylow);
+          getEdgeHits(iDetId,ihit_x,ihit_y,xhigh,yhigh,xlow,ylow);
           host_highEdgeXs[ihit] = xhigh;
           host_highEdgeYs[ihit] = yhigh;
           host_lowEdgeXs[ihit] = xlow;
@@ -945,7 +945,7 @@ cudaStreamSynchronize(stream);
       if(module_subdet[this_index] == Endcap && module_moduleType[this_index] == TwoS)
       {
           float xhigh, yhigh, xlow, ylow;
-          getEdgeHits(iDetId,ihit_x,ihit_x+ihit_y,xhigh,yhigh,xlow,ylow);
+          getEdgeHits(iDetId,ihit_x,ihit_y,xhigh,yhigh,xlow,ylow);
           host_highEdgeXs[ihit] = xhigh;
           host_highEdgeYs[ihit] = yhigh;
           host_lowEdgeXs[ihit] = xlow;

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -915,28 +915,37 @@ cudaStreamSynchronize(stream);
     cudaStreamSynchronize(stream);
 
 
+   unsigned int lastDetId = 0;
+   uint16_t lastModuleIndex = 0;
   for (int ihit=0; ihit<loopsize;ihit++){
-    host_x[ihit] = x.at(ihit); // convert from std::vector to host array easily since vectors are ordered
-    host_y[ihit] = y.at(ihit);
-    host_z[ihit] = z.at(ihit);
-    host_detId[ihit] = detId.at(ihit);
+    float ihit_x = x[ihit];
+    float ihit_y = y[ihit];
+    float ihit_z = z[ihit];
+    host_x[ihit] = ihit_x; // convert from std::vector to host array easily since vectors are ordered
+    host_y[ihit] = ihit_y;
+    host_z[ihit] = ihit_z;
+    auto iDetId = detId[ihit];
+    if (lastDetId != iDetId) { //hits are mostly ordered by module
+      lastDetId = iDetId;
+      lastModuleIndex = (*detIdToIndex)[iDetId];
+    }
+    host_detId[ihit] = iDetId;
     host_idxs[ihit] = idxInNtuple.at(ihit);
 
-    auto moduleIndex = (*detIdToIndex)[host_detId[ihit]];
-    unsigned int moduleLayer = module_layers[moduleIndex];
-    unsigned int subdet = module_subdet[moduleIndex];
-    host_moduleIndex[ihit] = moduleIndex; //module indices appropriately done
+    unsigned int moduleLayer = module_layers[lastModuleIndex];
+    unsigned int subdet = module_subdet[lastModuleIndex];
+    host_moduleIndex[ihit] = lastModuleIndex; //module indices appropriately done
 
 
-      host_rts[ihit] = sqrt(host_x[ihit]*host_x[ihit] + host_y[ihit]*host_y[ihit]);
-      host_phis[ihit] = phi(host_x[ihit],host_y[ihit],host_z[ihit]);
-      host_etas[ihit] = ((host_z[ihit]>0)-(host_z[ihit]<0))* std::acosh(sqrt(host_x[ihit]*host_x[ihit]+host_y[ihit]*host_y[ihit]+host_z[ihit]*host_z[ihit])/host_rts[ihit]);
+      host_rts[ihit] = sqrt(ihit_x*ihit_x + ihit_y*ihit_y);
+      host_phis[ihit] = phi(ihit_x,ihit_y,ihit_z);
+      host_etas[ihit] = ((ihit_z>0)-(ihit_z<0))* std::acosh(sqrt(ihit_x*ihit_x+ihit_y*ihit_y+ihit_z*ihit_z)/host_rts[ihit]);
 //// This part i think has a race condition. so this is not run in parallel.
-      unsigned int this_index = host_moduleIndex[ihit];
+      unsigned int this_index = lastModuleIndex;
       if(module_subdet[this_index] == Endcap && module_moduleType[this_index] == TwoS)
       {
           float xhigh, yhigh, xlow, ylow;
-          getEdgeHits(host_detId[ihit],host_x[ihit],host_y[ihit],xhigh,yhigh,xlow,ylow);
+          getEdgeHits(iDetId,ihit_x,ihit_x+ihit_y,xhigh,yhigh,xlow,ylow);
           host_highEdgeXs[ihit] = xhigh;
           host_highEdgeYs[ihit] = yhigh;
           host_lowEdgeXs[ihit] = xlow;

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -1,10 +1,10 @@
 #include "Module.cuh"
 #include "ModuleConnectionMap.h"
 #include "allocate.h"
-std::map <unsigned int, uint16_t> *SDL::detIdToIndex;
-std::map <unsigned int, float> *SDL::module_x;
-std::map <unsigned int, float> *SDL::module_y;
-std::map <unsigned int, float> *SDL::module_z;
+std::unordered_map <unsigned int, uint16_t> *SDL::detIdToIndex;
+std::unordered_map <unsigned int, float> *SDL::module_x;
+std::unordered_map <unsigned int, float> *SDL::module_y;
+std::unordered_map <unsigned int, float> *SDL::module_z;
 
 void SDL::createRangesInUnifiedMemory(struct objectRanges& rangesInGPU,unsigned int nModules,cudaStream_t stream, unsigned int nLowerModules)
 {
@@ -306,10 +306,10 @@ void SDL::freeModules(struct modules& modulesInGPU, struct pixelMap& pixelMappin
 
 void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, uint16_t& nLowerModules, struct pixelMap& pixelMapping,cudaStream_t stream, const char* moduleMetaDataFilePath)
 {
-    detIdToIndex = new std::map<unsigned int, uint16_t>;
-    module_x = new std::map<unsigned int, float>;
-    module_y = new std::map<unsigned int, float>;
-    module_z = new std::map<unsigned int, float>;
+    detIdToIndex = new std::unordered_map<unsigned int, uint16_t>;
+    module_x = new std::unordered_map<unsigned int, float>;
+    module_y = new std::unordered_map<unsigned int, float>;
+    module_z = new std::unordered_map<unsigned int, float>;
 
     /*modules structure object will be created in Event.cu*/
     /* Load the whole text file into the unordered_map first*/

--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -8,7 +8,7 @@
 #endif
 
 #include <iostream>
-#include <map>
+#include <unordered_map>
 #include "MiniDoublet.cuh"
 #include "Hit.cuh"
 #include "TiltedGeometry.h"
@@ -133,10 +133,10 @@ namespace SDL
         int* pixelType;
     };
 
-    extern std::map <unsigned int, uint16_t>* detIdToIndex;
-    extern std::map <unsigned int, float> *module_x;
-    extern std::map <unsigned int, float> *module_y;
-    extern std::map <unsigned int, float> *module_z;
+    extern std::unordered_map <unsigned int, uint16_t>* detIdToIndex;
+    extern std::unordered_map <unsigned int, float> *module_x;
+    extern std::unordered_map <unsigned int, float> *module_y;
+    extern std::unordered_map <unsigned int, float> *module_z;
 
     //functions
     void loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules,uint16_t& nLowerModules,struct pixelMap& pixelMapping,cudaStream_t stream, const char* moduleMetaDataFilePath="data/centroid.txt");

--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -1359,19 +1359,20 @@ std::vector<std::vector<short>>&    out_isQuad_vec
 //    my_timer.Start();
 
     unsigned int count = 0;
-    std::vector<float> px_vec;
-    std::vector<float> py_vec;
-    std::vector<float> pz_vec;
-    std::vector<unsigned int> hitIndices_vec0;
-    std::vector<unsigned int> hitIndices_vec1;
-    std::vector<unsigned int> hitIndices_vec2;
-    std::vector<unsigned int> hitIndices_vec3;
-    std::vector<float> ptIn_vec;
-    std::vector<float> ptErr_vec;
-    std::vector<float> etaErr_vec;
-    std::vector<float> eta_vec;
-    std::vector<float> phi_vec;
-    std::vector<float> deltaPhi_vec;
+    auto n_see = trk.see_stateTrajGlbPx().size();
+    std::vector<float> px_vec; px_vec.reserve(n_see);
+    std::vector<float> py_vec; py_vec.reserve(n_see);
+    std::vector<float> pz_vec; pz_vec.reserve(n_see);
+    std::vector<unsigned int> hitIndices_vec0; hitIndices_vec0.reserve(n_see);
+    std::vector<unsigned int> hitIndices_vec1; hitIndices_vec1.reserve(n_see);
+    std::vector<unsigned int> hitIndices_vec2; hitIndices_vec2.reserve(n_see);
+    std::vector<unsigned int> hitIndices_vec3; hitIndices_vec3.reserve(n_see);
+    std::vector<float> ptIn_vec;   ptIn_vec.reserve(n_see);
+    std::vector<float> ptErr_vec;  ptErr_vec.reserve(n_see);
+    std::vector<float> etaErr_vec; etaErr_vec.reserve(n_see);
+    std::vector<float> eta_vec;    eta_vec.reserve(n_see);
+    std::vector<float> phi_vec;    phi_vec.reserve(n_see);
+    std::vector<float> deltaPhi_vec; deltaPhi_vec.reserve(n_see);
     std::vector<float> trkX = trk.ph2_x();
     std::vector<float> trkY = trk.ph2_y();
     std::vector<float> trkZ = trk.ph2_z();
@@ -1424,12 +1425,6 @@ std::vector<std::vector<short>>&    out_isQuad_vec
         // if (std::find(trk.see_simTrkIdx()[iSeed].begin(), trk.see_simTrkIdx()[iSeed].end(), selected_trk) == trk.see_simTrkIdx()[iSeed].end())
         //     continue;
 
-        TVector3 p3LH(trk.see_stateTrajGlbPx()[iSeed], trk.see_stateTrajGlbPy()[iSeed], trk.see_stateTrajGlbPz()[iSeed]);
-        TVector3 r3LH(trk.see_stateTrajGlbX()[iSeed], trk.see_stateTrajGlbY()[iSeed], trk.see_stateTrajGlbZ()[iSeed]);
-        TVector3 p3PCA(trk.see_px()[iSeed], trk.see_py()[iSeed], trk.see_pz()[iSeed]);
-        TVector3 r3PCA(calculateR3FromPCA(p3PCA, trk.see_dxy()[iSeed], trk.see_dz()[iSeed]));
-        //auto const &seedHitsV = trk.see_hitIdx()[iSeed];
-        //auto const &seedHitTypesV = trk.see_hitType()[iSeed];
 
         bool good_seed_type = false;
         if (trk.see_algo()[iSeed] == 4) good_seed_type = true;
@@ -1439,6 +1434,23 @@ std::vector<std::vector<short>>&    out_isQuad_vec
         if (trk.see_algo()[iSeed] == 23) good_seed_type = true;
         if (trk.see_algo()[iSeed] == 24) good_seed_type = true;
         if (not good_seed_type) continue;
+
+        TVector3 p3LH(trk.see_stateTrajGlbPx()[iSeed], trk.see_stateTrajGlbPy()[iSeed], trk.see_stateTrajGlbPz()[iSeed]);
+        float ptIn = p3LH.Pt();
+        float eta = p3LH.Eta();
+        float ptErr = trk.see_ptErr()[iSeed];
+
+#ifdef PT0P8
+        if ((ptIn > 0.8 - 2 * ptErr))
+#else
+        if ((ptIn > 1 - 2 * ptErr) and (fabs(eta) < 3))
+#endif
+        {
+        TVector3 r3LH(trk.see_stateTrajGlbX()[iSeed], trk.see_stateTrajGlbY()[iSeed], trk.see_stateTrajGlbZ()[iSeed]);
+        TVector3 p3PCA(trk.see_px()[iSeed], trk.see_py()[iSeed], trk.see_pz()[iSeed]);
+        TVector3 r3PCA(calculateR3FromPCA(p3PCA, trk.see_dxy()[iSeed], trk.see_dz()[iSeed]));
+        //auto const &seedHitsV = trk.see_hitIdx()[iSeed];
+        //auto const &seedHitTypesV = trk.see_hitType()[iSeed];
 
         //int nHits = seedHitsV.size();
 
@@ -1473,21 +1485,11 @@ std::vector<std::vector<short>>&    out_isQuad_vec
         //float seedSD_zeta = seedSD_p3.Pt() / seedSD_p3.Z();
 
         float pixelSegmentDeltaPhiChange = r3LH.DeltaPhi(p3LH);
-        float ptIn = p3LH.Pt();
-        float ptErr = trk.see_ptErr()[iSeed];
         float etaErr = trk.see_etaErr()[iSeed];
         float px = p3LH.X();
         float py = p3LH.Y();
         float pz = p3LH.Z();
-        float eta = p3LH.Eta();
-        float phi = p3LH.Phi();
         //extra bit
-#ifdef PT0P8
-        if ((ptIn > 0.8 - 2 * ptErr))
-#else
-        if ((ptIn > 1 - 2 * ptErr) and (fabs(eta) < 3))
-#endif
-        {
             // get pixel superbin
             //int ptbin = -1;
             int pixtype =-1;
@@ -1497,8 +1499,8 @@ std::vector<std::vector<short>>&    out_isQuad_vec
             //  if (pixelSegmentDeltaPhiChange >= 0){pixtype=1;}
             //  else{pixtype=2;}
             //}
-            if (p3LH.Pt() >= 2.0){ /*ptbin = 1;*/pixtype=0;}
-            else if (p3LH.Pt() >= 0.9 and p3LH.Pt() < 2.0){ 
+            if (ptIn >= 2.0){ /*ptbin = 1;*/pixtype=0;}
+            else if (ptIn >= 0.9 and ptIn < 2.0){ 
               //ptbin = 0;
               if (pixelSegmentDeltaPhiChange >= 0){pixtype=1;}
               else{pixtype=2;}
@@ -1530,8 +1532,10 @@ std::vector<std::vector<short>>&    out_isQuad_vec
             trkY.push_back(r3PCA.Y());
             trkZ.push_back(r3PCA.Z());
             trkX.push_back(p3PCA.Pt());
-            trkY.push_back(p3PCA.Eta());
-            trkZ.push_back(p3PCA.Phi());
+            float p3PCA_Eta = p3PCA.Eta();
+            trkY.push_back(p3PCA_Eta);
+            float p3PCA_Phi = p3PCA.Phi();
+            trkZ.push_back(p3PCA_Phi);
             trkX.push_back(r3LH.X());
             trkY.push_back(r3LH.Y());
             trkZ.push_back(r3LH.Z());
@@ -1557,6 +1561,7 @@ std::vector<std::vector<short>>&    out_isQuad_vec
             ptErr_vec.push_back(ptErr);
             etaErr_vec.push_back(etaErr);
             eta_vec.push_back(eta);
+            float phi = p3LH.Phi();
             phi_vec.push_back(phi);
             deltaPhi_vec.push_back(pixelSegmentDeltaPhiChange);
 
@@ -1574,8 +1579,8 @@ std::vector<std::vector<short>>&    out_isQuad_vec
             float neta = 25.;
             float nphi = 72.;
             float nz = 25.;
-            int etabin = (p3PCA.Eta() + 2.6) / ((2*2.6)/neta);
-            int phibin = (p3PCA.Phi() + 3.14159265358979323846) / ((2.*3.14159265358979323846) / nphi);
+            int etabin = (p3PCA_Eta + 2.6) / ((2*2.6)/neta);
+            int phibin = (p3PCA_Phi + 3.14159265358979323846) / ((2.*3.14159265358979323846) / nphi);
             int dzbin = (trk.see_dz()[iSeed] + 30) / (2*30 / nz);
             int isuperbin = /*(nz * nphi * neta) * ptbin + (removed since pt bin is determined by pixelType)*/ (nz * nphi) * etabin + (nz) * phibin + dzbin;
             //if(isuperbin<0 || isuperbin>=44900){printf("isuperbin %d %d %d %d %f\n",isuperbin,etabin,phibin,dzbin,p3PCA.Eta());}
@@ -1588,7 +1593,7 @@ std::vector<std::vector<short>>&    out_isQuad_vec
 
         }
 
-    }
+    } // iter::enumerate(trk.see_stateTrajGlbPx
 
 //    event.addHitToEvent(trkX, trkY, trkZ, hitId,hitIdxs); // TODO : Need to fix the hitIdxs
 //    event.addPixelSegmentToEvent(hitIndices_vec0, hitIndices_vec1, hitIndices_vec2, hitIndices_vec3, deltaPhi_vec, ptIn_vec, ptErr_vec, px_vec, py_vec, pz_vec, eta_vec, etaErr_vec, phi_vec, superbin_vec, pixelType_vec,isQuad_vec);
@@ -1699,13 +1704,6 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
     for (auto &&[iSeed, _] : iter::enumerate(trk.see_stateTrajGlbPx()))
     {
 
-        TVector3 p3LH(trk.see_stateTrajGlbPx()[iSeed], trk.see_stateTrajGlbPy()[iSeed], trk.see_stateTrajGlbPz()[iSeed]);
-        TVector3 r3LH(trk.see_stateTrajGlbX()[iSeed], trk.see_stateTrajGlbY()[iSeed], trk.see_stateTrajGlbZ()[iSeed]);
-        TVector3 p3PCA(trk.see_px()[iSeed], trk.see_py()[iSeed], trk.see_pz()[iSeed]);
-        TVector3 r3PCA(calculateR3FromPCA(p3PCA, trk.see_dxy()[iSeed], trk.see_dz()[iSeed]));
-        //auto const &seedHitsV = trk.see_hitIdx()[iSeed];
-        //auto const &seedHitTypesV = trk.see_hitType()[iSeed];
-
         bool good_seed_type = false;
         if (trk.see_algo()[iSeed] == 4) good_seed_type = true;
         if (trk.see_algo()[iSeed] == 5) good_seed_type = true;
@@ -1714,6 +1712,23 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
         if (trk.see_algo()[iSeed] == 23) good_seed_type = true;
         if (trk.see_algo()[iSeed] == 24) good_seed_type = true;
         if (not good_seed_type) continue;
+
+        TVector3 p3LH(trk.see_stateTrajGlbPx()[iSeed], trk.see_stateTrajGlbPy()[iSeed], trk.see_stateTrajGlbPz()[iSeed]);
+        float ptIn = p3LH.Pt();
+        float ptErr = trk.see_ptErr()[iSeed];
+        float eta = p3LH.Eta();
+
+#ifdef PT0P8
+        if ((ptIn > 0.8 - 2 * ptErr))
+#else
+        if ((ptIn > 1 - 2 * ptErr) and (fabs(eta) < 3))
+#endif
+        {
+        TVector3 r3LH(trk.see_stateTrajGlbX()[iSeed], trk.see_stateTrajGlbY()[iSeed], trk.see_stateTrajGlbZ()[iSeed]);
+        TVector3 p3PCA(trk.see_px()[iSeed], trk.see_py()[iSeed], trk.see_pz()[iSeed]);
+        TVector3 r3PCA(calculateR3FromPCA(p3PCA, trk.see_dxy()[iSeed], trk.see_dz()[iSeed]));
+        //auto const &seedHitsV = trk.see_hitIdx()[iSeed];
+        //auto const &seedHitTypesV = trk.see_hitType()[iSeed];
 
         //int nHits = seedHitsV.size();
 
@@ -1748,22 +1763,13 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
         //float seedSD_zeta = seedSD_p3.Pt() / seedSD_p3.Z();
 
         float pixelSegmentDeltaPhiChange = r3LH.DeltaPhi(p3LH);
-        float ptIn = p3LH.Pt();
-        float ptErr = trk.see_ptErr()[iSeed];
         float etaErr = trk.see_etaErr()[iSeed];
         float px = p3LH.X();
         float py = p3LH.Y();
         float pz = p3LH.Z();
-        float eta = p3LH.Eta();
         float phi = p3LH.Phi();
         //extra bit
 	
-#ifdef PT0P8
-        if ((ptIn > 0.8 - 2 * ptErr))
-#else
-        if ((ptIn > 1 - 2 * ptErr) and (fabs(eta) < 3))
-#endif
-        {
             // get pixel superbin
             //int ptbin = -1;
             int pixtype =-1;
@@ -1773,9 +1779,9 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
             //  if (pixelSegmentDeltaPhiChange >= 0){pixtype=1;}
             //  else{pixtype=2;}
             //}
-            if (p3LH.Pt() >= 2.0){ /*ptbin = 1;*/pixtype=0;}
+            if (ptIn >= 2.0){ /*ptbin = 1;*/pixtype=0;}
             // else if (p3LH.Pt() >= 0.9 and p3LH.Pt() < 2.0){ 
-            else if (p3LH.Pt() >= 0.8 and p3LH.Pt() < 2.0){ 
+            else if (ptIn >= 0.8 and ptIn < 2.0){ 
               //ptbin = 0;
               if (pixelSegmentDeltaPhiChange >= 0){pixtype=1;}
               else{pixtype=2;}
@@ -1807,8 +1813,10 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
             trkY.push_back(r3PCA.Y());
             trkZ.push_back(r3PCA.Z());
             trkX.push_back(p3PCA.Pt());
-            trkY.push_back(p3PCA.Eta());
-            trkZ.push_back(p3PCA.Phi());
+            float p3PCA_Eta = p3PCA.Eta();
+            trkY.push_back(p3PCA_Eta);
+            float p3PCA_Phi = p3PCA.Phi();
+            trkZ.push_back(p3PCA_Phi);
             trkX.push_back(r3LH.X());
             trkY.push_back(r3LH.Y());
             trkZ.push_back(r3LH.Z());
@@ -1851,8 +1859,8 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
             float neta = 25.;
             float nphi = 72.;
             float nz = 25.;
-            int etabin = (p3PCA.Eta() + 2.6) / ((2*2.6)/neta);
-            int phibin = (p3PCA.Phi() + 3.14159265358979323846) / ((2.*3.14159265358979323846) / nphi);
+            int etabin = (p3PCA_Eta + 2.6) / ((2*2.6)/neta);
+            int phibin = (p3PCA_Phi + 3.14159265358979323846) / ((2.*3.14159265358979323846) / nphi);
             int dzbin = (trk.see_dz()[iSeed] + 30) / (2*30 / nz);
             int isuperbin = /*(nz * nphi * neta) * ptbin + (removed since pt bin is determined by pixelType)*/ (nz * nphi) * etabin + (nz) * phibin + dzbin;
             //if(isuperbin<0 || isuperbin>=44900){printf("isuperbin %d %d %d %d %f\n",isuperbin,etabin,phibin,dzbin,p3PCA.Eta());}


### PR DESCRIPTION
for 20 events one stream
Real Time (as of 3dbc4c3) :      23.9 s->  13.1 s.

From igprof report https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/sdl/ig.pp.3dbc4c3.rerun2 vs https://slava77sk.web.cern.ch/slava77sk/reco/cgi-bin/igprof-navigator/sdl/ig.pp.16776d3-addInputs2.m8clx (in perf counts, which I think are about the same as seconds)
- `addInputsToLineSegmentTrackingPreLoad`: 2.31 -> 1.95
- `SDL::initModules`: 3.46 -> 2.07
- `SDL::initHits`: 10.27 -> 1.43


