### PR TITLE
go back to regular std::map to resolve regression in removeDupQuintupletsInGPUv2 timing

### DIFF
--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -1,10 +1,10 @@
 #include "Module.cuh"
 #include "ModuleConnectionMap.h"
 #include "allocate.h"
-std::unordered_map <unsigned int, uint16_t> *SDL::detIdToIndex;
-std::unordered_map <unsigned int, float> *SDL::module_x;
-std::unordered_map <unsigned int, float> *SDL::module_y;
-std::unordered_map <unsigned int, float> *SDL::module_z;
+std::map <unsigned int, uint16_t> *SDL::detIdToIndex;
+std::map <unsigned int, float> *SDL::module_x;
+std::map <unsigned int, float> *SDL::module_y;
+std::map <unsigned int, float> *SDL::module_z;
 
 void SDL::createRangesInUnifiedMemory(struct objectRanges& rangesInGPU,unsigned int nModules,cudaStream_t stream, unsigned int nLowerModules)
 {
@@ -306,13 +306,13 @@ void SDL::freeModules(struct modules& modulesInGPU, struct pixelMap& pixelMappin
 
 void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, uint16_t& nLowerModules, struct pixelMap& pixelMapping,cudaStream_t stream, const char* moduleMetaDataFilePath)
 {
-    detIdToIndex = new std::unordered_map<unsigned int, uint16_t>;
-    module_x = new std::unordered_map<unsigned int, float>;
-    module_y = new std::unordered_map<unsigned int, float>;
-    module_z = new std::unordered_map<unsigned int, float>;
+    detIdToIndex = new std::map<unsigned int, uint16_t>;
+    module_x = new std::map<unsigned int, float>;
+    module_y = new std::map<unsigned int, float>;
+    module_z = new std::map<unsigned int, float>;
 
     /*modules structure object will be created in Event.cu*/
-    /* Load the whole text file into the unordered_map first*/
+    /* Load the whole text file into the map first*/
 
     std::ifstream ifile;
     ifile.open(moduleMetaDataFilePath);

--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -8,7 +8,7 @@
 #endif
 
 #include <iostream>
-#include <unordered_map>
+#include <map>
 #include "MiniDoublet.cuh"
 #include "Hit.cuh"
 #include "TiltedGeometry.h"
@@ -133,10 +133,10 @@ namespace SDL
         int* pixelType;
     };
 
-    extern std::unordered_map <unsigned int, uint16_t>* detIdToIndex;
-    extern std::unordered_map <unsigned int, float> *module_x;
-    extern std::unordered_map <unsigned int, float> *module_y;
-    extern std::unordered_map <unsigned int, float> *module_z;
+    extern std::map <unsigned int, uint16_t>* detIdToIndex;
+    extern std::map <unsigned int, float> *module_x;
+    extern std::map <unsigned int, float> *module_y;
+    extern std::map  <unsigned int, float> *module_z;
 
     //functions
     void loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules,uint16_t& nLowerModules,struct pixelMap& pixelMapping,cudaStream_t stream, const char* moduleMetaDataFilePath="data/centroid.txt");


### PR DESCRIPTION
as reported in https://github.com/SegmentLinking/TrackLooper/pull/154#issuecomment-1125030693
it looks like the `removeDupQuintupletsInGPUv2` kernel slowed down by almost a factor of 2.

After printing out the modules appearing in this kernel calls, it looks like the order of modules has changed. For the original map the order of modules should follow the order of detIds. For the `unordered_map` the order can be somewhat random. It seems like this dup cleaning kernel is more effective if the modules are ordered somewhat in the direction of the detIds.

(perhaps we can find an even better order for modules at some point to make the duplicate cleaning even better)

I reverted back to using std::map. This will slow down the pixel map loading by about a factor of 2, but it's manageable.

