### PR TITLE
Second pass T5 duplicate removal

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1617,6 +1617,8 @@ void SDL::Event::createTriplets()
 
 void SDL::Event::createTrackCandidates()
 {
+    uint16_t nEligibleModules;
+    cudaMemcpyAsync(&nEligibleModules,rangesInGPU->nEligibleT5Modules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
     if(trackCandidatesInGPU == nullptr)
     {
         //printf("did this run twice?\n");
@@ -1653,12 +1655,12 @@ void SDL::Event::createTrackCandidates()
 #endif
 
 #ifdef FINAL_T5
-    //dim3 dupThreads(64,16,1);
-    //dim3 dupBlocks(1,MAX_BLOCKS,1);
-    dim3 dupThreads(32,16,2);
-    dim3 dupBlocks(1,1,MAX_BLOCKS);
+    //dim3 dupThreads(32,16,2);
+    //dim3 dupBlocks(1,1,MAX_BLOCKS);
+    dim3 dupThreads(32,16,1);
+    dim3 dupBlocks(nEligibleModules/32,nEligibleModules/16,1);
 
-    removeDupQuintupletsInGPUv2<<<dupBlocks,dupThreads,0,stream>>>(*modulesInGPU, *quintupletsInGPU,true,*rangesInGPU);
+    removeDupQuintupletsInGPUv2<<<dupBlocks,dupThreads,0,stream>>>(*quintupletsInGPU,*rangesInGPU);
     //cudaDeviceSynchronize();
     cudaStreamSynchronize(stream);
     dim3 nThreads(32,1,32);

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -332,8 +332,9 @@ __global__ void removeDupQuintupletsInGPUv2(struct SDL::modules& modulesInGPU, s
     int blockxSize = blockDim.x*gridDim.x;
     int blockySize = blockDim.y*gridDim.y;
     int blockzSize = blockDim.z*gridDim.z;
-    for(unsigned int lowmod1=blockIdx.z*blockDim.z+threadIdx.z; lowmod1<nLowerModules;lowmod1+=blockzSize)
+    for(unsigned int lowmodIdx1=blockIdx.z*blockDim.z+threadIdx.z; lowmodIdx1<*(rangesInGPU.nEligibleT5Modules);lowmodIdx1+=blockzSize)
     {
+        uint16_t lowmod1 = rangesInGPU.indicesOfEligibleT5Modules[lowmodIdx1];
         int nQuintuplets_lowmod1 = quintupletsInGPU.nQuintuplets[lowmod1];
         int quintupletModuleIndices_lowmod1 = rangesInGPU.quintupletModuleIndices[lowmod1];
         for(unsigned int ix1=blockIdx.y*blockDim.y+threadIdx.y; ix1<nQuintuplets_lowmod1; ix1+=blockySize)
@@ -348,8 +349,10 @@ __global__ void removeDupQuintupletsInGPUv2(struct SDL::modules& modulesInGPU, s
             float phi1 = __H2F(quintupletsInGPU.phi[ix]);
             //bool isDup = false;
 	          float score_rphisum1 = __H2F(quintupletsInGPU.score_rphisum[ix]);
-            for(unsigned int lowmod=blockIdx.x*blockDim.x+threadIdx.x; lowmod<nLowerModules;lowmod+=blockxSize)
+            for(unsigned int lowmodIdx=blockIdx.x*blockDim.x+threadIdx.x; lowmodIdx<*(rangesInGPU.nEligibleT5Modules);lowmodIdx+=blockxSize)
             {
+                    uint16_t lowmod = rangesInGPU.indicesOfEligibleT5Modules[lowmodIdx];
+
 	              int nQuintuplets_lowmod = quintupletsInGPU.nQuintuplets[lowmod];
                 int quintupletModuleIndices_lowmod = rangesInGPU.quintupletModuleIndices[lowmod];
                 for(unsigned int jx1=0; jx1<nQuintuplets_lowmod; jx1++)

--- a/SDL/Kernels.cuh
+++ b/SDL/Kernels.cuh
@@ -46,7 +46,7 @@ __global__ void checkHitspLS(struct SDL::modules& modulesInGPU, struct SDL::obje
 
 __device__ void scoreT5(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,unsigned int innerTrip,unsigned int outerTrip, int layer, float* scores);
 __global__ void removeDupQuintupletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::quintuplets& quintupletsInGPU, bool secondPass, struct SDL::objectRanges& rangesInGPU);
-__global__ void removeDupQuintupletsInGPUv2(struct SDL::modules& modulesInGPU, struct SDL::quintuplets& quintupletsInGPU, bool secondPass, struct SDL::objectRanges& rangesInGPU);
+__global__ void removeDupQuintupletsInGPUv2(struct SDL::quintuplets& quintupletsInGPU, struct SDL::objectRanges& rangesInGPU);
 
 __global__ void testMiniDoublets(struct SDL::miniDoublets& mdsInGPU);
 __global__ void createMiniDoubletsInGPU(struct SDL::modules& modulesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::objectRanges& rangesInGPU);

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -165,6 +165,7 @@ void SDL::objectRanges::freeMemoryCache()//struct objectRanges& rangesInGPU)
   cms::cuda::free_device(dev,trackCandidateRanges);
   cms::cuda::free_device(dev,quintupletRanges);
   cms::cuda::free_device(dev,nEligibleT5Modules);
+  cms::cuda::free_device(dev, indicesOfEligibleT5Modules);
   cms::cuda::free_device(dev,quintupletModuleIndices);
   cms::cuda::free_device(dev, hitRangesLower);
   cms::cuda::free_device(dev, hitRangesUpper);
@@ -182,6 +183,7 @@ void SDL::objectRanges::freeMemoryCache()//struct objectRanges& rangesInGPU)
   cms::cuda::free_managed(trackCandidateRanges);
   cms::cuda::free_managed(quintupletRanges);
   cms::cuda::free_managed(nEligibleT5Modules);
+  cms::cuda::free_managed(indicesOfEligibleT5Modules);
   cms::cuda::free_managed(quintupletModuleIndices);
   cms::cuda::free_managed(hitRangesLower);
   cms::cuda::free_managed(hitRangesUpper);
@@ -207,6 +209,8 @@ void SDL::objectRanges::freeMemory()
   cudaFree(trackCandidateRanges);
   cudaFree(quintupletRanges);
   cudaFree(nEligibleT5Modules);
+  cudaFree(indicesOfEligibleT5Modules);
+  cudaFree(indicesOfEligibleT5Modules);
   cudaFree(quintupletModuleIndices);
   cudaFree(miniDoubletModuleIndices);
   cudaFree(segmentModuleIndices);

--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -61,6 +61,7 @@ namespace SDL
         int* quintupletRanges;
 
         uint16_t *nEligibleT5Modules; //This number is just nEligibleModules - 1, but still we want this to be independent of the TC kernel
+        uint16_t* indicesOfEligibleT5Modules;// will be allocated in createQuintuplets kernel!!!!
         //to store different starting points for variable occupancy stuff
         int *quintupletModuleIndices;
         int *miniDoubletModuleIndices;


### PR DESCRIPTION
rearranges loop order. Changes loops over lower modules to loops over eligible T5 modules (results in more T5s i think). 
I found that only 1 thread in the inner most loops actually worked the best so I took off the parallelism there and moved it to the outer most loops with the modules. This seems to have given the best result. 