### PR TITLE
speedups in pT3 

### DIFF
--- a/SDL/Constants.cu
+++ b/SDL/Constants.cu
@@ -5,23 +5,24 @@
 #include "Constants.cuh"
 
 //defining the constant host device variables right up here
-CUDA_CONST_VAR float SDL::miniMulsPtScaleBarrel[6] = {0.0052, 0.0038, 0.0034, 0.0034, 0.0032, 0.0034};
-CUDA_CONST_VAR float SDL::miniMulsPtScaleEndcap[5] = {0.006, 0.006, 0.006, 0.006, 0.006}; 
+CUDA_CONST_VAR const float SDL::miniMulsPtScaleBarrel[6] = {0.0052, 0.0038, 0.0034, 0.0034, 0.0032, 0.0034};
+CUDA_CONST_VAR const float SDL::miniMulsPtScaleEndcap[5] = {0.006, 0.006, 0.006, 0.006, 0.006}; 
 #ifdef CMSSW12GEOM
-CUDA_CONST_VAR float SDL::miniRminMeanBarrel[6] = {25.007152356, 37.2186993757, 52.3104270826, 68.6658656666, 85.9770373007, 108.301772384};
-CUDA_CONST_VAR float SDL::miniRminMeanEndcap[5] = {130.992832231, 154.813883559, 185.352604327, 221.635123002, 265.022076742};
+CUDA_CONST_VAR const float SDL::miniRminMeanBarrel[6] = {25.007152356, 37.2186993757, 52.3104270826, 68.6658656666, 85.9770373007, 108.301772384};
+CUDA_CONST_VAR const float SDL::miniRminMeanEndcap[5] = {130.992832231, 154.813883559, 185.352604327, 221.635123002, 265.022076742};
 #else
-CUDA_CONST_VAR float SDL::miniRminMeanBarrel[6] = {21.8, 34.6, 49.6, 67.4, 87.6, 106.8};
-CUDA_CONST_VAR float SDL::miniRminMeanEndcap[5] = {131.4, 156.2, 185.6, 220.3, 261.5};
+CUDA_CONST_VAR const float SDL::miniRminMeanBarrel[6] = {21.8, 34.6, 49.6, 67.4, 87.6, 106.8};
+CUDA_CONST_VAR const float SDL::miniRminMeanEndcap[5] = {131.4, 156.2, 185.6, 220.3, 261.5};
 #endif
-CUDA_CONST_VAR float SDL::k2Rinv1GeVf = (2.99792458e-3 * 3.8) / 2;
-CUDA_CONST_VAR float SDL::sinAlphaMax = 0.95;
+CUDA_CONST_VAR const float SDL::k2Rinv1GeVf = (2.99792458e-3 * 3.8) / 2;
+CUDA_CONST_VAR const float SDL::kR1GeVf = 1./(2.99792458e-3 * 3.8);
+CUDA_CONST_VAR const float SDL::sinAlphaMax = 0.95;
 #ifdef PT0P8
-CUDA_CONST_VAR float SDL::ptCut = 0.8;
+CUDA_CONST_VAR const float SDL::ptCut = 0.8;
 #else
-CUDA_CONST_VAR float SDL::ptCut = 1.0;
+CUDA_CONST_VAR const float SDL::ptCut = 1.0;
 #endif
-CUDA_CONST_VAR float SDL::deltaZLum = 15.0;
-CUDA_CONST_VAR float SDL::pixelPSZpitch = 0.15;
-CUDA_CONST_VAR float SDL::strip2SZpitch = 5.0;
+CUDA_CONST_VAR const float SDL::deltaZLum = 15.0;
+CUDA_CONST_VAR const float SDL::pixelPSZpitch = 0.15;
+CUDA_CONST_VAR const float SDL::strip2SZpitch = 5.0;
 

--- a/SDL/Constants.cuh
+++ b/SDL/Constants.cuh
@@ -61,15 +61,16 @@ typedef float FPX_seg;
 namespace SDL
 {
     //defining the constant host device variables right up here
-    extern CUDA_CONST_VAR float miniMulsPtScaleBarrel[6];
-    extern CUDA_CONST_VAR float miniMulsPtScaleEndcap[5]; 
-    extern CUDA_CONST_VAR float miniRminMeanBarrel[6];
-    extern CUDA_CONST_VAR float miniRminMeanEndcap[5];
-    extern CUDA_CONST_VAR float k2Rinv1GeVf;
-    extern CUDA_CONST_VAR float sinAlphaMax;
-    extern CUDA_CONST_VAR float ptCut;
-    extern CUDA_CONST_VAR float deltaZLum;
-    extern CUDA_CONST_VAR float pixelPSZpitch;
-    extern CUDA_CONST_VAR float strip2SZpitch;
+    extern CUDA_CONST_VAR const float miniMulsPtScaleBarrel[6];
+    extern CUDA_CONST_VAR const float miniMulsPtScaleEndcap[5]; 
+    extern CUDA_CONST_VAR const float miniRminMeanBarrel[6];
+    extern CUDA_CONST_VAR const float miniRminMeanEndcap[5];
+    extern CUDA_CONST_VAR const float k2Rinv1GeVf;
+    extern CUDA_CONST_VAR const float kR1GeVf;
+    extern CUDA_CONST_VAR const float sinAlphaMax;
+    extern CUDA_CONST_VAR const float ptCut;
+    extern CUDA_CONST_VAR const float deltaZLum;
+    extern CUDA_CONST_VAR const float pixelPSZpitch;
+    extern CUDA_CONST_VAR const float strip2SZpitch;
 }
 #endif

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1814,26 +1814,20 @@ void SDL::Event::createPixelTriplets()
     cudaMalloc(&connectedPixelIndex_dev, nInnerSegments* sizeof(unsigned int));
 
     // unsigned int max_size =0;
-    int threadSize = 1000000;
-    unsigned int *segs_pix = (unsigned int*)malloc(2*threadSize*sizeof(unsigned int));
-    unsigned int *segs_pix_offset = segs_pix+threadSize;
-    unsigned int *segs_pix_gpu;
-    unsigned int *segs_pix_gpu_offset;
-    cudaMalloc((void **)&segs_pix_gpu, 2*threadSize*sizeof(unsigned int));
-    //cudaMallocAsync((void **)&segs_pix_gpu, 2*threadSize*sizeof(unsigned int),stream);
-    segs_pix_gpu_offset = segs_pix_gpu + threadSize;
-    cudaMemsetAsync(segs_pix_gpu, nInnerSegments, threadSize*sizeof(unsigned int),stream); // so if not set, it will pass in the kernel
-cudaStreamSynchronize(stream);
-    unsigned int totalSegs=0;
+    cudaStreamSynchronize(stream);
     int pixelIndexOffsetPos = pixelMapping->connectedPixelsIndex[44999] + pixelMapping->connectedPixelsSizes[44999];
     int pixelIndexOffsetNeg = pixelMapping->connectedPixelsIndexPos[44999] + pixelMapping->connectedPixelsSizes[44999] + pixelIndexOffsetPos;
 
-    for (int i = 0; i < static_cast<int>(nInnerSegments); i++)
+    // TODO: check if a map/reduction to just eligible pLSs would speed up the kernel
+    //   the current selection still leaves a significant fraction of unmatchable pLSs
+    for (unsigned int i = 0; i < nInnerSegments; i++)
     {// loop over # pLS
         int8_t pixelType = pixelTypes[i];// get pixel type for this pLS
         int superbin = superbins[i]; //get superbin for this pixel
         if((superbin < 0) or (superbin >= 45000) or (pixelType > 2) or (pixelType < 0))
         {
+            connectedPixelSize_host[i] = 0;
+            connectedPixelIndex_host[i] = 0;
             continue;
         }
 
@@ -1842,75 +1836,49 @@ cudaStreamSynchronize(stream);
             connectedPixelSize_host[i]  = pixelMapping->connectedPixelsSizes[superbin]; //number of connected modules to this pixel
             auto connectedIdxBase = pixelMapping->connectedPixelsIndex[superbin];
             connectedPixelIndex_host[i] = connectedIdxBase;// index to get start of connected modules for this superbin in map
-            for (int j=0; j < static_cast<int>(pixelMapping->connectedPixelsSizes[superbin]); j++)
-            { // loop over modules from the size
-                segs_pix[totalSegs+j] = i; // save the pLS index in array to be transfered to kernel
-                segs_pix_offset[totalSegs+j] = connectedIdxBase + j; // save the T2 module index among the pLS's superbin connected modules
-            }
-            totalSegs += connectedPixelSize_host[i]; // increment counter
+            // printf("i %d out of nInnerSegments %d type %d superbin %d connectedPixelIndex %d connectedPixelSize %d\n",
+            //        i, nInnerSegments, pixelType, superbin, connectedPixelIndex_host[i], connectedPixelSize_host[i]);
         }
         else if(pixelType ==1)
         {
             connectedPixelSize_host[i] = pixelMapping->connectedPixelsSizesPos[superbin]; //number of pixel connected modules
             auto connectedIdxBase = pixelMapping->connectedPixelsIndexPos[superbin]+pixelIndexOffsetPos;
             connectedPixelIndex_host[i] = connectedIdxBase;// index to get start of connected pixel modules
-            for (int j=0; j < static_cast<int>(pixelMapping->connectedPixelsSizesPos[superbin]); j++)
-            {
-                segs_pix[totalSegs+j] = i;
-                segs_pix_offset[totalSegs+j] = connectedIdxBase + j;
-            }
-            totalSegs += connectedPixelSize_host[i];
         }
         else if(pixelType ==2)
         {
             connectedPixelSize_host[i] = pixelMapping->connectedPixelsSizesNeg[superbin]; //number of pixel connected modules
             auto connectedIdxBase = pixelMapping->connectedPixelsIndexNeg[superbin] + pixelIndexOffsetNeg;
             connectedPixelIndex_host[i] = connectedIdxBase;// index to get start of connected pixel modules
-            for (int j=0; j < static_cast<int>(pixelMapping->connectedPixelsSizesNeg[superbin]); j++)
-            {
-                segs_pix[totalSegs+j] = i;
-                segs_pix_offset[totalSegs+j] = connectedIdxBase + j;
-            }
-            totalSegs += connectedPixelSize_host[i];
         }
     }
 
     cudaMemcpyAsync(connectedPixelSize_dev, connectedPixelSize_host, nInnerSegments*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(connectedPixelIndex_dev, connectedPixelIndex_host, nInnerSegments*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(segs_pix_gpu,segs_pix,threadSize*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(segs_pix_gpu_offset,segs_pix_offset,threadSize*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
-cudaStreamSynchronize(stream);
+    cudaStreamSynchronize(stream);
 
-    //less cheap method to estimate max_size for y axis
-    unsigned int max_size = *std::max_element(nTriplets, nTriplets + nLowerModules);
-    //dim3 nThreads(16,16,1);
-    //dim3 nBlocks((totalSegs % nThreads.x == 0 ? totalSegs / nThreads.x : totalSegs / nThreads.x + 1),
-    //              (max_size % nThreads.y == 0 ? max_size/nThreads.y : max_size/nThreads.y + 1),1);
-    //printf("%d %d\n",totalSegs,max_size);
+    cms::cuda::free_host(connectedPixelSize_host);
+    cms::cuda::free_host(connectedPixelIndex_host);
+    cms::cuda::free_host(superbins);
+    cms::cuda::free_host(pixelTypes);
+    cms::cuda::free_host(nTriplets);
+
     dim3 nThreads(32,4,1);
-    dim3 nBlocks(1,4096,1);
-    //createPixelTripletsInGPUFromMap<<<nBlocks, nThreads,0,stream>>>(*modulesInGPU, *rangesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, connectedPixelSize_dev,connectedPixelIndex_dev,nInnerSegments,segs_pix_gpu,segs_pix_gpu_offset, totalSegs);
-    SDL::createPixelTripletsInGPUFromMapv2<<<nBlocks, nThreads,0,stream>>>(*modulesInGPU, *rangesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, connectedPixelSize_dev,connectedPixelIndex_dev,nInnerSegments,segs_pix_gpu,segs_pix_gpu_offset, totalSegs);
+    dim3 nBlocks(1,4096,16 /* above median of connected modules*/);
+
+    SDL::createPixelTripletsInGPUFromMapv2<<<nBlocks, nThreads,0,stream>>>(*modulesInGPU, *rangesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *pixelTripletsInGPU, connectedPixelSize_dev,connectedPixelIndex_dev,nInnerSegments);
 
     cudaError_t cudaerr = cudaGetLastError();
     if(cudaerr != cudaSuccess)
     {
 	    std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
 
-    }cudaStreamSynchronize(stream);
+    }
+    cudaStreamSynchronize(stream);
     //}cudaDeviceSynchronize();
-    cms::cuda::free_host(connectedPixelSize_host);
-    cms::cuda::free_host(connectedPixelIndex_host);
     cudaFree(connectedPixelSize_dev);
     cudaFree(connectedPixelIndex_dev);
-    //cudaFreeAsync(connectedPixelSize_dev,stream);
-    //cudaFreeAsync(connectedPixelIndex_dev,stream);
-    cms::cuda::free_host(superbins);
-    cms::cuda::free_host(pixelTypes);
-    cms::cuda::free_host(nTriplets);
-    free(segs_pix);
-    //cudaFreeAsync(segs_pix_gpu,stream);
-    cudaFree(segs_pix_gpu);
+
 
 #ifdef Warnings
     unsigned int nPixelTriplets;

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1840,33 +1840,36 @@ cudaStreamSynchronize(stream);
         if(pixelType ==0)
         { // used pixel type to select correct size-index arrays
             connectedPixelSize_host[i]  = pixelMapping->connectedPixelsSizes[superbin]; //number of connected modules to this pixel
-            connectedPixelIndex_host[i] = pixelMapping->connectedPixelsIndex[superbin];// index to get start of connected modules for this superbin in map
+            auto connectedIdxBase = pixelMapping->connectedPixelsIndex[superbin];
+            connectedPixelIndex_host[i] = connectedIdxBase;// index to get start of connected modules for this superbin in map
             for (int j=0; j < static_cast<int>(pixelMapping->connectedPixelsSizes[superbin]); j++)
             { // loop over modules from the size
-                segs_pix[totalSegs+j] = i; // save the pixel index in array to be transfered to kernel
-                segs_pix_offset[totalSegs+j] = j; // save this segment in array to be transfered to kernel
+                segs_pix[totalSegs+j] = i; // save the pLS index in array to be transfered to kernel
+                segs_pix_offset[totalSegs+j] = connectedIdxBase + j; // save the T2 module index among the pLS's superbin connected modules
             }
             totalSegs += connectedPixelSize_host[i]; // increment counter
         }
         else if(pixelType ==1)
         {
             connectedPixelSize_host[i] = pixelMapping->connectedPixelsSizesPos[superbin]; //number of pixel connected modules
-            connectedPixelIndex_host[i] = pixelMapping->connectedPixelsIndexPos[superbin]+pixelIndexOffsetPos;// index to get start of connected pixel modules
+            auto connectedIdxBase = pixelMapping->connectedPixelsIndexPos[superbin]+pixelIndexOffsetPos;
+            connectedPixelIndex_host[i] = connectedIdxBase;// index to get start of connected pixel modules
             for (int j=0; j < static_cast<int>(pixelMapping->connectedPixelsSizesPos[superbin]); j++)
             {
                 segs_pix[totalSegs+j] = i;
-                segs_pix_offset[totalSegs+j] = j;
+                segs_pix_offset[totalSegs+j] = connectedIdxBase + j;
             }
             totalSegs += connectedPixelSize_host[i];
         }
         else if(pixelType ==2)
         {
             connectedPixelSize_host[i] = pixelMapping->connectedPixelsSizesNeg[superbin]; //number of pixel connected modules
-            connectedPixelIndex_host[i] =pixelMapping->connectedPixelsIndexNeg[superbin] + pixelIndexOffsetNeg;// index to get start of connected pixel modules
+            auto connectedIdxBase = pixelMapping->connectedPixelsIndexNeg[superbin] + pixelIndexOffsetNeg;
+            connectedPixelIndex_host[i] = connectedIdxBase;// index to get start of connected pixel modules
             for (int j=0; j < static_cast<int>(pixelMapping->connectedPixelsSizesNeg[superbin]); j++)
             {
                 segs_pix[totalSegs+j] = i;
-                segs_pix_offset[totalSegs+j] = j;
+                segs_pix_offset[totalSegs+j] = connectedIdxBase + j;
             }
             totalSegs += connectedPixelSize_host[i];
         }

--- a/SDL/PixelTriplet.cu
+++ b/SDL/PixelTriplet.cu
@@ -839,15 +839,22 @@ __global__ void SDL::createPixelTripletsInGPUFromMapv2(struct SDL::modules& modu
     for(int offsetIndex = blockIdx.y * blockDim.y + threadIdx.y; offsetIndex< totalSegs; offsetIndex += blockySize)
     {
 
-        int segmentModuleIndex = seg_pix_gpu_offset[offsetIndex];
+        auto segmentModuleIndex = seg_pix_gpu_offset[offsetIndex];
         int pixelSegmentArrayIndex = seg_pix_gpu[offsetIndex];
-        if(pixelSegmentArrayIndex >= nPixelSegments) continue;//sanity check
-        if(segmentModuleIndex >= connectedPixelSize[pixelSegmentArrayIndex]) continue;//sanity check
+#ifdef Warnings
+        if(pixelSegmentArrayIndex >= nPixelSegments) {
+          printf("pixelSegmentArrayIndex %d >= nPixelSegments %d\n", pixelSegmentArrayIndex, nPixelSegments);
+          continue;//sanity check
+        }
+#endif
 
-        unsigned int tempIndex = connectedPixelIndex[pixelSegmentArrayIndex] + segmentModuleIndex; //gets module array index for segment
-
-        uint16_t tripletLowerModuleIndex = modulesInGPU.connectedPixels[tempIndex]; //connected pixels will have the appopriate lower module index by default!
-        if(tripletLowerModuleIndex >= *modulesInGPU.nLowerModules) continue;//sanity check
+        uint16_t tripletLowerModuleIndex = modulesInGPU.connectedPixels[segmentModuleIndex]; //connected pixels will have the appopriate lower module index by default!
+#ifdef Warnings
+        if(tripletLowerModuleIndex >= *modulesInGPU.nLowerModules) {
+          printf("tripletLowerModuleIndex %d >= modulesInGPU.nLowerModules %d \n", tripletLowerModuleIndex, modulesInGPU.nLowerModules);
+          continue;//sanity check
+        }
+#endif
         if(modulesInGPU.moduleType[tripletLowerModuleIndex] == SDL::TwoS) continue;//return; //Removes 2S-2S :FIXME: filter these out in the pixel map
 
         uint16_t pixelModuleIndex = *modulesInGPU.nLowerModules;

--- a/SDL/PixelTriplet.cuh
+++ b/SDL/PixelTriplet.cuh
@@ -102,7 +102,7 @@ namespace SDL
 
     CUDA_DEV bool passPT3RPhiChiSquaredInwardsCuts(struct modules& modulesInGPU, uint16_t& lowerModuleIndex1, uint16_t& lowerModuleIndex2, uint16_t& lowerModuleIndex3, float& rPhiChiSquared);
 
-    __global__ void createPixelTripletsInGPUFromMapv2(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, unsigned int* connectedPixelSize, unsigned int* connectedPixelIndex, unsigned int nPixelSegments, unsigned int* seg_pix_gpu, unsigned int* seg_pix_gpu_offset, unsigned int totalSegs);
+    __global__ void createPixelTripletsInGPUFromMapv2(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, unsigned int* connectedPixelSize, unsigned int* connectedPixelIndex, unsigned int nPixelSegments);
 
    CUDA_DEV void runDeltaBetaIterationspT3(float& betaIn, float& betaOut, float& betaAv, float & pt_beta, float sdIn_dr, float sdOut_dr, float dr, float lIn); 
     CUDA_DEV float computeChiSquaredpT3(int nPoints, float* xs, float* ys, float* delta1, float* delta2, float* slopes, bool* isFlat, float g, float f, float radius);


### PR DESCRIPTION
- "massage" the implementation in `createPixelTripletsInGPUFromMapv2` and called methods to reduce the number of registers: 
    - the number of used registers as in ptxas info reduced from 138 to 124. 
        - At some point rather similar code had 118 registers, but I lost track of that version; it was not significantly faster 
    - pT3 time changed from 5.5 to 5.2 ms
    - `createPixelTripletsInGPUFromMapv2` reduced from 1.25 ms to 1.02 ms
- remove (pLS X connectedModules) remapping/flattening done on CPU and simply use another dimension in the grid to do it on the fly; this saves the cost of mem copy of about 8MB of data
    - this provides the largest improvement in timing: pT3 time (on phi3) goes from 5.2 ms to 1.7 ms (compared from 8b578a3b385 to dacd609f8)

The validation was limited: looking at just the number of produced pT3s and other objects
