### PR TITLE
use ptIn >= 0.8 - 2*ptErr  in addInputsToLineSegmentTracking*

### DIFF
--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -1500,7 +1500,7 @@ std::vector<std::vector<short>>&    out_isQuad_vec
             //  else{pixtype=2;}
             //}
             if (ptIn >= 2.0){ /*ptbin = 1;*/pixtype=0;}
-            else if (ptIn >= 0.8 and ptIn < 2.0){ 
+            else if (ptIn >= (0.8 - 2 * ptErr) and ptIn < 2.0){ 
               //ptbin = 0;
               if (pixelSegmentDeltaPhiChange >= 0){pixtype=1;}
               else{pixtype=2;}
@@ -1781,7 +1781,7 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
             //}
             if (ptIn >= 2.0){ /*ptbin = 1;*/pixtype=0;}
             // else if (p3LH.Pt() >= 0.9 and p3LH.Pt() < 2.0){ 
-            else if (ptIn >= 0.8 and ptIn < 2.0){ 
+            else if (ptIn >= (0.8 - 2 * ptErr) and ptIn < 2.0){ 
               //ptbin = 0;
               if (pixelSegmentDeltaPhiChange >= 0){pixtype=1;}
               else{pixtype=2;}


### PR DESCRIPTION
[comparison vs pt](http://uaf-10.t2.ucsd.edu/~slava77/sdl/efficiencies/eff_comparison_plots__2e51c31_explicit_cache_d29a712_explicit_cache_PU200/?TCE.*ptcoarse%24) shows the additional contribution just around 0.9


http://uaf-10.t2.ucsd.edu/~slava77/sdl/efficiencies/eff_plots__GPU_explicit_cache_2e51c31_PU200/