### PR TITLE
Host Allocator Cleanup

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -808,7 +808,8 @@ std::vector<std::vector<short>>&    out_isQuad_vec
     for(int evt=0; evt < static_cast<int>(out_trkX.size()); evt++)
     {
         struct SDL::hits* hitsInGPU_event;
-        hitsInGPU_event = (struct SDL::hits*)cms::cuda::allocate_host(sizeof(struct SDL::hits), modStream);
+        //hitsInGPU_event = (struct SDL::hits*)cms::cuda::allocate_host(sizeof(struct SDL::hits), modStream);
+        cudaMallocHost(&hitsInGPU_event, sizeof(struct SDL::hits));
         #ifdef Explicit_Hit
         createHitsInExplicitMemory(*hitsInGPU_event, hitOffset.at(evt+1),modStream,1); //unclear why but this has to be 2*loopsize to avoid crashing later (reported in tracklet allocation). seems to do with nHits values as well. this allows nhits to be set to the correct value of loopsize to get correct results without crashing. still beats the "max hits" so i think this is fine.
         #else
@@ -844,8 +845,8 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
     }
     if(hitsInGPU == nullptr)
     {
-        //cudaMallocHost(&hitsInGPU, sizeof(SDL::hits));
-        hitsInGPU = (SDL::hits*)cms::cuda::allocate_host(sizeof(SDL::hits), stream);
+        cudaMallocHost(&hitsInGPU, sizeof(SDL::hits));
+        //hitsInGPU = (SDL::hits*)cms::cuda::allocate_host(sizeof(SDL::hits), stream);
         #ifdef Explicit_Hit
     	  createHitsInExplicitMemory(*hitsInGPU, 2*loopsize,stream,1); //unclear why but this has to be 2*loopsize to avoid crashing later (reported in tracklet allocation). seems to do with nHits values as well. this allows nhits to be set to the correct value of loopsize to get correct results without crashing. still beats the "max hits" so i think this is fine.
         #else

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -261,12 +261,18 @@ void SDL::freeModulesCache(struct modules& modulesInGPU,struct pixelMap& pixelMa
   cms::cuda::free_managed(modulesInGPU.moduleLayerType);
   cms::cuda::free_managed(modulesInGPU.connectedPixels);
 #endif
-  cms::cuda::free_host(pixelMapping.connectedPixelsSizes);
-  cms::cuda::free_host(pixelMapping.connectedPixelsSizesPos);
-  cms::cuda::free_host(pixelMapping.connectedPixelsSizesNeg);
-  cms::cuda::free_host(pixelMapping.connectedPixelsIndex);
-  cms::cuda::free_host(pixelMapping.connectedPixelsIndexPos);
-  cms::cuda::free_host(pixelMapping.connectedPixelsIndexNeg);
+  cudaFreeHost(pixelMapping.connectedPixelsSizes);
+  cudaFreeHost(pixelMapping.connectedPixelsSizesPos);
+  cudaFreeHost(pixelMapping.connectedPixelsSizesNeg);
+  cudaFreeHost(pixelMapping.connectedPixelsIndex);
+  cudaFreeHost(pixelMapping.connectedPixelsIndexPos);
+  cudaFreeHost(pixelMapping.connectedPixelsIndexNeg);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsSizes);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsSizesPos);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsSizesNeg);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsIndex);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsIndexPos);
+  //cms::cuda::free_host(pixelMapping.connectedPixelsIndexNeg);
 }
 void SDL::freeModules(struct modules& modulesInGPU, struct pixelMap& pixelMapping,cudaStream_t stream)
 {
@@ -703,19 +709,24 @@ void SDL::fillPixelMap(struct modules& modulesInGPU, struct pixelMap& pixelMappi
     std::vector<unsigned int> connectedModuleDetIds;
     std::vector<unsigned int> connectedModuleDetIds_pos;
     std::vector<unsigned int> connectedModuleDetIds_neg;
-    //unsigned int* connectedPixelsIndex;
-    //unsigned int* connectedPixelsIndexPos;
-    //unsigned int* connectedPixelsIndexNeg;
-    //unsigned int* connectedPixelsSizes;
-    //unsigned int* connectedPixelsSizesPos;
-    //unsigned int* connectedPixelsSizesNeg;
-
-    pixelMapping.connectedPixelsIndex = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
-    pixelMapping.connectedPixelsSizes = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
-    pixelMapping.connectedPixelsIndexPos = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
-    pixelMapping.connectedPixelsSizesPos = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
-    pixelMapping.connectedPixelsIndexNeg = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
-    pixelMapping.connectedPixelsSizesNeg = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    unsigned int* connectedPixelsIndex;
+    unsigned int* connectedPixelsIndexPos;
+    unsigned int* connectedPixelsIndexNeg;
+    unsigned int* connectedPixelsSizes;
+    unsigned int* connectedPixelsSizesPos;
+    unsigned int* connectedPixelsSizesNeg;
+    cudaMallocHost(&pixelMapping.connectedPixelsIndex,size_superbins * sizeof(unsigned int));
+    cudaMallocHost(&pixelMapping.connectedPixelsSizes,size_superbins * sizeof(unsigned int));
+    cudaMallocHost(&pixelMapping.connectedPixelsIndexPos,size_superbins * sizeof(unsigned int));
+    cudaMallocHost(&pixelMapping.connectedPixelsSizesPos,size_superbins * sizeof(unsigned int));
+    cudaMallocHost(&pixelMapping.connectedPixelsIndexNeg,size_superbins * sizeof(unsigned int));
+    cudaMallocHost(&pixelMapping.connectedPixelsSizesNeg,size_superbins * sizeof(unsigned int));
+    //pixelMapping.connectedPixelsIndex = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    //pixelMapping.connectedPixelsSizes = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    //pixelMapping.connectedPixelsIndexPos = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    //pixelMapping.connectedPixelsSizesPos = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    //pixelMapping.connectedPixelsIndexNeg = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
+    //pixelMapping.connectedPixelsSizesNeg = (unsigned int*)cms::cuda::allocate_host(size_superbins * sizeof(unsigned int), stream);
     int totalSizes=0;
     int totalSizes_pos=0;
     int totalSizes_neg=0;


### PR DESCRIPTION
This PR removes a few variables from the host caching allocator that were being freed by cudaFreeHost(). These variables all throw errors if you try to free them with the host caching allocator. Since all of these specific variables are only allocated/freed once, this should not affect the timing, but it's not clear how cudaFreeHost() is handling these cases (and so they should be removed).