### PR TITLE
Removal of tracking algo iterations

### DIFF
--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -1706,11 +1706,11 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
 
         bool good_seed_type = false;
         if (trk.see_algo()[iSeed] == 4) good_seed_type = true;
-        if (trk.see_algo()[iSeed] == 5) good_seed_type = true;
-        if (trk.see_algo()[iSeed] == 7) good_seed_type = true;
+        //if (trk.see_algo()[iSeed] == 5) good_seed_type = true;
+        //if (trk.see_algo()[iSeed] == 7) good_seed_type = true;
         if (trk.see_algo()[iSeed] == 22) good_seed_type = true;
-        if (trk.see_algo()[iSeed] == 23) good_seed_type = true;
-        if (trk.see_algo()[iSeed] == 24) good_seed_type = true;
+        //if (trk.see_algo()[iSeed] == 23) good_seed_type = true;
+        //if (trk.see_algo()[iSeed] == 24) good_seed_type = true;
         if (not good_seed_type) continue;
 
         TVector3 p3LH(trk.see_stateTrajGlbPx()[iSeed], trk.see_stateTrajGlbPy()[iSeed], trk.see_stateTrajGlbPz()[iSeed]);


### PR DESCRIPTION
This PR removes all tracking algorithm iterations except initialStep and highPtTripletStep, to be compatible with what's being used for HLT Tracking @ Phase 2. The removal of the extra iterations (lowPtTripletStep, lowPtQuadStep, detachedTripletStep and detachedQuadStep) leads to small reduction of the efficiency (percent level reduction in some bins low/medium pT bins) but also cuts the fake rate at higher |η| almost by half. Validation plots can  be found here:
https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/trkIterAlgoComp/eff_comparison_plots__1d99f25noOtherSteps_explicit_cache_1d99f25allSteps_explicit_cache_PU200/