### PR TITLE
T5 cpu functions moved to GPU

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1922,7 +1922,7 @@ cudaStreamSynchronize(stream);
 #endif
     cudaMemsetAsync(rangesInGPU->quintupletModuleIndices, -1, sizeof(int) * (nLowerModules),stream);
 cudaStreamSynchronize(stream);
-    createEligibleModulesListForQuintupletsGPU<<<1,1,0,stream>>>(*modulesInGPU, *tripletsInGPU, N_MAX_QUINTUPLETS_PER_MODULE,stream,*rangesInGPU);
+    createEligibleModulesListForQuintupletsGPU<<<1,1024,0,stream>>>(*modulesInGPU, *tripletsInGPU, N_MAX_QUINTUPLETS_PER_MODULE,stream,*rangesInGPU);
     //createEligibleModulesListForQuintuplets(*modulesInGPU, *tripletsInGPU, nEligibleT5Modules, indicesOfEligibleModules, N_MAX_QUINTUPLETS_PER_MODULE, maxTriplets,stream,*rangesInGPU);
 cudaStreamSynchronize(stream);
     cudaMemcpyAsync(&nEligibleT5Modules,rangesInGPU->nEligibleT5Modules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1945,7 +1945,7 @@ cudaStreamSynchronize(stream);
 
 
     dim3 nThreads(32, 8, 1);
-    dim3 nBlocks(1,1,nEligibleT5Modules);
+    dim3 nBlocks(1,1,max(nEligibleT5Modules,1));
 
     SDL::createQuintupletsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *quintupletsInGPU, *rangesInGPU,nEligibleT5Modules);
     cudaError_t cudaerr = cudaGetLastError();

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1803,10 +1803,10 @@ void SDL::Event::createPixelTriplets()
 
     unsigned int* connectedPixelSize_host;
     unsigned int* connectedPixelIndex_host;
-    cudaMallocHost(&connectedPixelSize_host, nInnerSegments* sizeof(unsigned int));
-    cudaMallocHost(&connectedPixelIndex_host, nInnerSegments* sizeof(unsigned int));
-    //connectedPixelSize_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
-    //connectedPixelIndex_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+    //cudaMallocHost(&connectedPixelSize_host, nInnerSegments* sizeof(unsigned int));
+    //cudaMallocHost(&connectedPixelIndex_host, nInnerSegments* sizeof(unsigned int));
+    connectedPixelSize_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+    connectedPixelIndex_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
 
     unsigned int* connectedPixelSize_dev;
     unsigned int* connectedPixelIndex_dev;
@@ -1857,10 +1857,10 @@ void SDL::Event::createPixelTriplets()
     cudaMemcpyAsync(connectedPixelIndex_dev, connectedPixelIndex_host, nInnerSegments*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
 
-    cudaFreeHost(connectedPixelSize_host);
-    cudaFreeHost(connectedPixelIndex_host);
-    //cms::cuda::free_host(connectedPixelSize_host);
-    //cms::cuda::free_host(connectedPixelIndex_host);
+    //cudaFreeHost(connectedPixelSize_host);
+    //cudaFreeHost(connectedPixelIndex_host);
+    cms::cuda::free_host(connectedPixelSize_host);
+    cms::cuda::free_host(connectedPixelIndex_host);
     cms::cuda::free_host(superbins);
     cms::cuda::free_host(pixelTypes);
     cms::cuda::free_host(nTriplets);
@@ -2086,10 +2086,12 @@ void SDL::Event::createPixelQuintuplets()
     unsigned int nInnerSegments = 0;
     cudaMemcpyAsync(&nInnerSegments, &(segmentsInGPU->nSegments[pixelModuleIndex]), sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 
-    cudaMallocHost(&connectedPixelSize_host, nInnerSegments* sizeof(unsigned int));
-    cudaMallocHost(&connectedPixelIndex_host, nInnerSegments* sizeof(unsigned int));
-    //connectedPixelSize_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
-    //connectedPixelIndex_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+    //cudaMallocHost(&connectedPixelSize_host, nInnerSegments* sizeof(unsigned int));
+    //cudaMallocHost(&connectedPixelIndex_host, nInnerSegments* sizeof(unsigned int));
+    connectedPixelSize_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+    connectedPixelIndex_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
+    //connectedPixelSize_dev = (unsigned int*)cms::cuda::allocate_device(dev,nInnerSegments* sizeof(unsigned int),stream);
+    //connectedPixelSize_dev = (unsigned int*)cms::cuda::allocate_device(dev,nInnerSegments* sizeof(unsigned int),stream);
     cudaMalloc(&connectedPixelSize_dev, nInnerSegments* sizeof(unsigned int));
     cudaMalloc(&connectedPixelIndex_dev, nInnerSegments* sizeof(unsigned int));
     cudaStreamSynchronize(stream);
@@ -2146,10 +2148,10 @@ cudaStreamSynchronize(stream);
 
     }
     cudaStreamSynchronize(stream);
-    cudaFreeHost(connectedPixelSize_host);
-    cudaFreeHost(connectedPixelIndex_host);
-    //cms::cuda::free_host(connectedPixelSize_host);
-    //cms::cuda::free_host(connectedPixelIndex_host);
+    //cudaFreeHost(connectedPixelSize_host);
+    //cudaFreeHost(connectedPixelIndex_host);
+    cms::cuda::free_host(connectedPixelSize_host);
+    cms::cuda::free_host(connectedPixelIndex_host);
     cudaFree(connectedPixelSize_dev);
     cudaFree(connectedPixelIndex_dev);
     cms::cuda::free_host(superbins);

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1921,76 +1921,77 @@ cudaStreamSynchronize(stream);
 #ifdef Explicit_T5
         createQuintupletsInExplicitMemory(*quintupletsInGPU, N_MAX_QUINTUPLETS_PER_MODULE, nLowerModules, nEligibleT5Modules,stream);
 
-#ifdef CACHE_ALLOC 
-        int dev;
-        cudaGetDevice(&dev);
-        rangesInGPU->indicesOfEligibleT5Modules = (uint16_t*)cms::cuda::allocate_device(dev, nEligibleT5Modules * sizeof(uint16_t), stream);
-#else
-        cudaMalloc(&(rangesInGPU->indicesOfEligibleT5Modules), nEligibleT5Modules * sizeof(uint16_t));
-#endif
+//#ifdef CACHE_ALLOC 
+//        int dev;
+//        cudaGetDevice(&dev);
+//        rangesInGPU->indicesOfEligibleT5Modules = (uint16_t*)cms::cuda::allocate_device(dev, nEligibleT5Modules * sizeof(uint16_t), stream);
+//#else
+//        cudaMalloc(&(rangesInGPU->indicesOfEligibleT5Modules), nEligibleT5Modules * sizeof(uint16_t));
+//#endif
 
 #else
         createQuintupletsInUnifiedMemory(*quintupletsInGPU, N_MAX_QUINTUPLETS_PER_MODULE, nLowerModules, nEligibleT5Modules,stream);
 
-#ifdef CACHE_ALLOC
-        rangesInGPU->indicesOfEligibleT5Modules = (uint16_t*)cms::cuda::allocate_managed(nEligibleT5Modules * sizeof(uint16_t), stream);
-#else
-        cudaMalloc(&(rangesInGPU->indicesOfEligibleT5Modules), nEligibleT5Modules * sizeof(uint16_t));
-#endif
+//#ifdef CACHE_ALLOC
+//        rangesInGPU->indicesOfEligibleT5Modules = (uint16_t*)cms::cuda::allocate_managed(nEligibleT5Modules * sizeof(uint16_t), stream);
+//#else
+//        cudaMalloc(&(rangesInGPU->indicesOfEligibleT5Modules), nEligibleT5Modules * sizeof(uint16_t));
+//#endif
 
 #endif
     }
 cudaStreamSynchronize(stream);
 
 
-    int threadSize=N_MAX_TOTAL_TRIPLETS;
-    unsigned int *threadIdx = (unsigned int*)malloc(2*threadSize*sizeof(unsigned int));
-    unsigned int *threadIdx_offset = threadIdx+threadSize;
-    unsigned int *threadIdx_gpu;
-    unsigned int *threadIdx_gpu_offset;
-    cudaMalloc((void **)&threadIdx_gpu, 2*threadSize*sizeof(unsigned int));
-    //cudaMallocAsync((void **)&threadIdx_gpu, 2*threadSize*sizeof(unsigned int),stream);
-    cudaMemsetAsync(threadIdx_gpu, nLowerModules, threadSize*sizeof(unsigned int),stream);
+//    int threadSize=N_MAX_TOTAL_TRIPLETS;
+//    unsigned int *threadIdx = (unsigned int*)malloc(2*threadSize*sizeof(unsigned int));
+//    unsigned int *threadIdx_offset = threadIdx+threadSize;
+//    unsigned int *threadIdx_gpu;
+//    unsigned int *threadIdx_gpu_offset;
+//    cudaMalloc((void **)&threadIdx_gpu, 2*threadSize*sizeof(unsigned int));
+//    //cudaMallocAsync((void **)&threadIdx_gpu, 2*threadSize*sizeof(unsigned int),stream);
+//    cudaMemsetAsync(threadIdx_gpu, nLowerModules, threadSize*sizeof(unsigned int),stream);
 
-    unsigned int *nTriplets = (unsigned int*)malloc(nLowerModules*sizeof(unsigned int));
-    cudaMemcpyAsync(nTriplets, tripletsInGPU->nTriplets, nLowerModules*sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-cudaStreamSynchronize(stream);
-    threadIdx_gpu_offset = threadIdx_gpu + threadSize;
+//    unsigned int *nTriplets = (unsigned int*)malloc(nLowerModules*sizeof(unsigned int));
+//    cudaMemcpyAsync(nTriplets, tripletsInGPU->nTriplets, nLowerModules*sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
+//cudaStreamSynchronize(stream);
+//    threadIdx_gpu_offset = threadIdx_gpu + threadSize;
 
-    int nTotalTriplets = 0;
-    for (int i=0; i<nEligibleT5Modules; i++) 
-    {
-        int index = indicesOfEligibleModules[i];
-        unsigned int nInnerTriplets = nTriplets[index];
-        if (nInnerTriplets !=0) 
-        {
-            for (int j=0; j<static_cast<int>(nInnerTriplets); j++) 
-            {
-                threadIdx[nTotalTriplets + j] = index;
-                threadIdx_offset[nTotalTriplets + j] = j;
-            }
-            nTotalTriplets += nInnerTriplets;
-        }
-    }
-    //printf("T5: nTotalTriplets=%d nEligibleT5Modules=%d\n", nTotalTriplets, nEligibleT5Modules);
+//    int nTotalTriplets = 0;
+//    for (int i=0; i<nEligibleT5Modules; i++) 
+//    {
+//        int index = indicesOfEligibleModules[i];
+//        unsigned int nInnerTriplets = nTriplets[index];
+//        if (nInnerTriplets !=0) 
+//        {
+////            for (int j=0; j<static_cast<int>(nInnerTriplets); j++) 
+////            {
+////                threadIdx[nTotalTriplets + j] = index;
+////                threadIdx_offset[nTotalTriplets + j] = j;
+////            }
+//            nTotalTriplets += nInnerTriplets;
+//        }
+//    }
+//    printf("T5: nTotalTriplets=%d nEligibleT5Modules=%d\n", nTotalTriplets, nEligibleT5Modules);
     // nTotTrips: 36551, nEligibleT5: 1707
-    if (threadSize < nTotalTriplets) 
-    {
-        printf("threadSize=%d nTotalTriplets=%d: Increase buffer size for threadIdx in createQuintuplets\n", threadSize, nTotalTriplets);
-        exit(1);
-    }
-    cudaMemcpyAsync(threadIdx_gpu, threadIdx, threadSize*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(threadIdx_gpu_offset, threadIdx_offset, threadSize*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
-cudaStreamSynchronize(stream);
-    cudaMemcpyAsync(rangesInGPU->indicesOfEligibleT5Modules, indicesOfEligibleModules, nEligibleT5Modules * sizeof(uint16_t), cudaMemcpyHostToDevice, stream);
-    cudaStreamSynchronize(stream);
+//    if (threadSize < nTotalTriplets) 
+//    {
+//        printf("threadSize=%d nTotalTriplets=%d: Increase buffer size for threadIdx in createQuintuplets\n", threadSize, nTotalTriplets);
+//        exit(1);
+//    }
+//    cudaMemcpyAsync(threadIdx_gpu, threadIdx, threadSize*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
+//    cudaMemcpyAsync(threadIdx_gpu_offset, threadIdx_offset, threadSize*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
+//cudaStreamSynchronize(stream);
+//    cudaMemcpyAsync(rangesInGPU->indicesOfEligibleT5Modules, indicesOfEligibleModules, nEligibleT5Modules * sizeof(uint16_t), cudaMemcpyHostToDevice, stream);
+//    cudaStreamSynchronize(stream);
 
     dim3 nThreads(32, 8, 1);
-    dim3 nBlocks(1,5000,1);
+    dim3 nBlocks(1,1,nEligibleT5Modules);
+    //dim3 nBlocks(1,5000,1);
     //dim3 nThreads(16, 16, 1);
     //dim3 nBlocks(1,MAX_BLOCKS,1);
 
-    SDL::createQuintupletsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *quintupletsInGPU, threadIdx_gpu, threadIdx_gpu_offset, nTotalTriplets,*rangesInGPU);
+    SDL::createQuintupletsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *quintupletsInGPU, /*threadIdx_gpu, threadIdx_gpu_offset, nTotalTriplets,*/ *rangesInGPU,nEligibleT5Modules);
     //createQuintupletsInGPU<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *quintupletsInGPU, threadIdx_gpu, threadIdx_gpu_offset, nTotalTriplets,*rangesInGPU);
     cudaError_t cudaerr = cudaGetLastError();
     if(cudaerr != cudaSuccess)
@@ -1998,9 +1999,9 @@ cudaStreamSynchronize(stream);
 	    std::cout<<"sync failed with error : "<<cudaGetErrorString(cudaerr)<<std::endl;
     }
     cudaStreamSynchronize(stream);
-    free(threadIdx);
-    free(nTriplets);
-    cudaFree(threadIdx_gpu);
+//    free(threadIdx);
+//    free(nTriplets);
+//    cudaFree(threadIdx_gpu);
     free(indicesOfEligibleModules);
 
 #ifdef DUP_T5

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1920,13 +1920,16 @@ cudaStreamSynchronize(stream);
 #else
         cudaMalloc(&(rangesInGPU->indicesOfEligibleT5Modules), nLowerModules * sizeof(uint16_t));
 #endif
+    cudaMemsetAsync(rangesInGPU->quintupletModuleIndices, -1, sizeof(int) * (nLowerModules),stream);
 cudaStreamSynchronize(stream);
-    createEligibleModulesListForQuintupletsGPU(*modulesInGPU, *tripletsInGPU, nEligibleT5Modules, indicesOfEligibleModules, N_MAX_QUINTUPLETS_PER_MODULE, maxTriplets,stream,*rangesInGPU);
+    createEligibleModulesListForQuintupletsGPU<<<1,1,0,stream>>>(*modulesInGPU, *tripletsInGPU, N_MAX_QUINTUPLETS_PER_MODULE,stream,*rangesInGPU);
     //createEligibleModulesListForQuintuplets(*modulesInGPU, *tripletsInGPU, nEligibleT5Modules, indicesOfEligibleModules, N_MAX_QUINTUPLETS_PER_MODULE, maxTriplets,stream,*rangesInGPU);
 cudaStreamSynchronize(stream);
-    cudaMemcpyAsync(rangesInGPU->nEligibleT5Modules,&nEligibleT5Modules,sizeof(uint16_t),cudaMemcpyHostToDevice,stream);
-cudaMemcpyAsync(rangesInGPU->indicesOfEligibleT5Modules, indicesOfEligibleModules, nEligibleT5Modules * sizeof(uint16_t), cudaMemcpyHostToDevice, stream);
+    cudaMemcpyAsync(&nEligibleT5Modules,rangesInGPU->nEligibleT5Modules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
+//    cudaMemcpyAsync(rangesInGPU->nEligibleT5Modules,&nEligibleT5Modules,sizeof(uint16_t),cudaMemcpyHostToDevice,stream);
+//cudaMemcpyAsync(rangesInGPU->indicesOfEligibleT5Modules, indicesOfEligibleModules, nEligibleT5Modules * sizeof(uint16_t), cudaMemcpyHostToDevice, stream);
 cudaStreamSynchronize(stream);
+//    printf("nEligible %u\n",nEligibleT5Modules);
 
     if(quintupletsInGPU == nullptr)
     {

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -122,35 +122,6 @@ void SDL::quintuplets::freeMemory(cudaStream_t stream)
 #endif
 cudaStreamSynchronize(stream);
 }
-__device__ uint16_t atomicAddShort(uint16_t* address, short val)
-
-{
-
-    unsigned int *base_address = (unsigned int *)((size_t)address & ~2);
-
-    val = val ^ 0x8000; // 2's complement to biased
-
-    unsigned int long_val = ((size_t)address & 2) ? ((unsigned int)val << 16) : (unsigned short)val;
-
-unsigned int long_old = atomicAdd(base_address, long_val);
-
-    if((size_t)address & 2) {
-
-        return (short)((long_old >> 16) ^ 0x8000);  // biased to 2's complement
-
-    } else {
-
-        unsigned int overflow = ((long_old & 0xffff) + long_val) & 0xffff0000;
-
-        if (overflow)
-
-            atomicSub(base_address, 1);
-
-        return (short)((long_old & 0xffff) ^ 0x8000);  // biased to 2's complement
-
-    }
-
-}
 //TODO:Reuse the track candidate one instead of this!
 __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU,struct triplets& tripletsInGPU, unsigned int maxQuintuplets, cudaStream_t stream,struct objectRanges& rangesInGPU)
 {

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -1418,7 +1418,7 @@ __device__ float SDL::computeChiSquared(int nPoints, float* xs, float* ys, float
     return chiSquared; 
 }
 
-__global__ void SDL::createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU, /*unsigned int* threadIdx_gpu, unsigned int* threadIdx_gpu_offset, int nTotalTriplets,*/ struct SDL::objectRanges& rangesInGPU, uint16_t nEligibleT5Modules)
+__global__ void SDL::createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU, struct SDL::objectRanges& rangesInGPU, uint16_t nEligibleT5Modules)
 {
     int gidy = blockIdx.y * blockDim.y + threadIdx.y;
     int npy = gridDim.y * blockDim.y;
@@ -1430,19 +1430,8 @@ __global__ void SDL::createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU,
     for (int iter=gidz; iter < nEligibleT5Modules; iter+=npz){
       uint16_t lowerModule1 = rangesInGPU.indicesOfEligibleT5Modules[iter];
 
-    //for (int iter=gidy; iter < nTotalTriplets; iter+=np)
-    //{
-    //    uint16_t lowerModule1 = threadIdx_gpu[iter];
-
-    //    //this if statement never gets executed!
-    //    if(lowerModule1  >= *modulesInGPU.nLowerModules) continue;
 
         unsigned int nInnerTriplets = tripletsInGPU.nTriplets[lowerModule1];
-        //printf("nInnerTriplets: %u\n",nInnerTriplets);
-
-        //unsigned int innerTripletArrayIndex = threadIdx_gpu_offset[iter];
-
-        //if(innerTripletArrayIndex >= nInnerTriplets) continue;
         for( unsigned int innerTripletArrayIndex =gidy; innerTripletArrayIndex < nInnerTriplets; innerTripletArrayIndex+=npy){
 
         unsigned int innerTripletIndex = rangesInGPU.tripletModuleIndices[lowerModule1] + innerTripletArrayIndex;
@@ -1450,7 +1439,6 @@ __global__ void SDL::createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU,
         uint16_t lowerModule2 = tripletsInGPU.lowerModuleIndices[3 * innerTripletIndex + 1];
         uint16_t lowerModule3 = tripletsInGPU.lowerModuleIndices[3 * innerTripletIndex + 2];
         unsigned int nOuterTriplets = tripletsInGPU.nTriplets[lowerModule3];
-        //printf("nOuterTriplets %d\n",nOuterTriplets);
         for (int outerTripletArrayIndex=gidx; outerTripletArrayIndex < nOuterTriplets; outerTripletArrayIndex+=npx)
         {
             unsigned int outerTripletIndex = rangesInGPU.tripletModuleIndices[lowerModule3] + outerTripletArrayIndex;
@@ -1507,10 +1495,8 @@ __global__ void SDL::createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU,
 #else
                         addQuintupletToMemory(tripletsInGPU, quintupletsInGPU, innerTripletIndex, outerTripletIndex, lowerModule1, lowerModule2, lowerModule3, lowerModule4, lowerModule5, innerRadius, outerRadius, regressionG, regressionF, regressionRadius, pt,eta,phi,scores,layer,quintupletIndex);
 #endif
-//#ifdef  TRACK_EXTENSIONS
                         tripletsInGPU.partOfT5[quintupletsInGPU.tripletIndices[2 * quintupletIndex]] = true;
                         tripletsInGPU.partOfT5[quintupletsInGPU.tripletIndices[2 * quintupletIndex + 1]] = true;
-//#endif
 
                     }
                 }

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -156,7 +156,9 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
 {
     //uint16_t nLowerModules= *modulesInGPU.nLowerModules;
   //  unsigned int maxTriplets = 0;
-    uint16_t nEligibleT5Modules =0;
+    __shared__ int nEligibleT5Modulesx;
+    //__shared__ uint16_t nEligibleT5Modules;
+    nEligibleT5Modulesx =-1;
     //cudaMemcpyAsync(&nLowerModules,modulesInGPU.nLowerModules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
 
 
@@ -187,14 +189,15 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
         if(((modulesInGPU.subdets[i] == SDL::Barrel and modulesInGPU.layers[i] < 3) or (modulesInGPU.subdets[i] == SDL::Endcap and modulesInGPU.layers[i] == 1)) and tripletsInGPU.nTriplets[i] != 0)
         {
     //printf("test\n");
+            int nEligibleT5Modules = atomicAdd(&nEligibleT5Modulesx,1);
             rangesInGPU.quintupletModuleIndices[i] = nEligibleT5Modules * maxQuintuplets; //for variable occupancy change this to module_quintupletModuleIndices[i-1] + blah
             rangesInGPU.indicesOfEligibleT5Modules[nEligibleT5Modules] = i;
-            nEligibleT5Modules++;
+            //nEligibleT5Modules++;
             //maxTriplets = max(tripletsInGPU.nTriplets[i], maxTriplets);
         }
     }
     //printf("test %u\n",nEligibleT5Modules);
-    *rangesInGPU.nEligibleT5Modules = nEligibleT5Modules;
+    *rangesInGPU.nEligibleT5Modules = static_cast<uint16_t>(nEligibleT5Modulesx);
 //    cudaMemcpyAsync(rangesInGPU.quintupletModuleIndices,module_quintupletModuleIndices,nLowerModules*sizeof(int),cudaMemcpyHostToDevice,stream);
 //    cms::cuda::free_host(module_subdets);
 //    cms::cuda::free_host(module_layers);

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -141,7 +141,7 @@ CUDA_DEV bool matchRadiiBBBEE34578(const float& innerRadius, const float& bridge
     CUDA_DEV bool runQuintupletDefaultAlgo(struct SDL::modules& modulesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, uint16_t& innerInnerLowerModuleIndex, uint16_t& innerOuterLowerModuleIndex, uint16_t& outerInnerLowerModuleIndex, uint16_t& outerOuterLowerModuleIndex, unsigned int& innerSegmentIndex, unsigned int& outerSegmentIndex, unsigned int& firstMDIndex, unsigned int& secondMDIndex, unsigned int& thirdMDIndex, unsigned int& fourthMDIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float& betaOut, float& pt_beta, float& zLo, float& zHi, float& rtLo, float& rtHi, float& zLoPointed, float& zHiPointed, float& sdlCut, float& betaInCut, float& betaOutCut, float& deltaBetaCut, float& kZ);
 
 
-    __global__ void createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU,/* unsigned int* threadIdx_gpu, unsigned int* threadIdx_gpu_offset, int nTotalTriplets,*/ struct SDL::objectRanges& rangesInGPU,uint16_t nEligibleT5Modules);
+    __global__ void createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU, struct SDL::objectRanges& rangesInGPU,uint16_t nEligibleT5Modules);
 
 }
 #endif

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -77,6 +77,7 @@ namespace SDL
     void createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& maxQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream);
 
     void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int maxQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
+    void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int maxQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
 
 //  CUDA_DEV void rmQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int quintupletIndex);
 

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -140,7 +140,7 @@ CUDA_DEV bool matchRadiiBBBEE34578(const float& innerRadius, const float& bridge
     CUDA_DEV bool runQuintupletDefaultAlgo(struct SDL::modules& modulesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, uint16_t& innerInnerLowerModuleIndex, uint16_t& innerOuterLowerModuleIndex, uint16_t& outerInnerLowerModuleIndex, uint16_t& outerOuterLowerModuleIndex, unsigned int& innerSegmentIndex, unsigned int& outerSegmentIndex, unsigned int& firstMDIndex, unsigned int& secondMDIndex, unsigned int& thirdMDIndex, unsigned int& fourthMDIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float& betaOut, float& pt_beta, float& zLo, float& zHi, float& rtLo, float& rtHi, float& zLoPointed, float& zHiPointed, float& sdlCut, float& betaInCut, float& betaOutCut, float& deltaBetaCut, float& kZ);
 
 
-    __global__ void createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU, unsigned int* threadIdx_gpu, unsigned int* threadIdx_gpu_offset, int nTotalTriplets,struct SDL::objectRanges& rangesInGPU);
+    __global__ void createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU, struct SDL::quintuplets& quintupletsInGPU,/* unsigned int* threadIdx_gpu, unsigned int* threadIdx_gpu_offset, int nTotalTriplets,*/ struct SDL::objectRanges& rangesInGPU,uint16_t nEligibleT5Modules);
 
 }
 #endif

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -77,7 +77,7 @@ namespace SDL
     void createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& maxQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream);
 
     void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int maxQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
-    void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int maxQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
+    __global__ void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, unsigned int maxQuintuplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
 
 //  CUDA_DEV void rmQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int quintupletIndex);
 


### PR DESCRIPTION
moves setup and implementation of eligible T5 modules from cpu functions to gpu functions and within the T5 creation kernel. results in no speedup overall but everything is now on the GPU.
This implementation only works for 1 block. It could be modified to run with multiple blocks. However, the timing running 1 block with 32 threads is about the same as running with 1024 threads, so I don't see how multiple blocks would really help much.