### PR TITLE
T5 occupancy reduction

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1585,7 +1585,7 @@ void SDL::Event::createTriplets()
     cudaMemcpyAsync(index_gpu, index, nonZeroModules*sizeof(uint16_t), cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
 
-    dim3 nThreads(16,32,1);
+    dim3 nThreads(16,16,1);
     dim3 nBlocks(1,1,MAX_BLOCKS);
     //createTripletsInGPU<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *rangesInGPU, index_gpu,nonZeroModules);
     SDL::createTripletsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *rangesInGPU, index_gpu,nonZeroModules);
@@ -1690,7 +1690,7 @@ void SDL::Event::createTrackCandidates()
     }cudaStreamSynchronize(stream);
 #endif  
 
-    dim3 nThreads_pLS(64,16,1);
+    dim3 nThreads_pLS(32,16,1);
     dim3 nBlocks_pLS(20,4,1);
     SDL::crossCleanpLS<<<nBlocks_pLS, nThreads_pLS, 0, stream>>>(*modulesInGPU, *rangesInGPU, *pixelTripletsInGPU, *trackCandidatesInGPU, *segmentsInGPU, *mdsInGPU,*hitsInGPU, *quintupletsInGPU);
     cudaError_t cudaerr_pLS = cudaGetLastError();

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1585,7 +1585,7 @@ void SDL::Event::createTriplets()
     cudaMemcpyAsync(index_gpu, index, nonZeroModules*sizeof(uint16_t), cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
 
-    dim3 nThreads(16,16,1);
+    dim3 nThreads(16,32,1);
     dim3 nBlocks(1,1,MAX_BLOCKS);
     //createTripletsInGPU<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *rangesInGPU, index_gpu,nonZeroModules);
     SDL::createTripletsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *rangesInGPU, index_gpu,nonZeroModules);
@@ -1690,7 +1690,7 @@ void SDL::Event::createTrackCandidates()
     }cudaStreamSynchronize(stream);
 #endif  
 
-    dim3 nThreads_pLS(32,16,1);
+    dim3 nThreads_pLS(64,16,1);
     dim3 nBlocks_pLS(20,4,1);
     SDL::crossCleanpLS<<<nBlocks_pLS, nThreads_pLS, 0, stream>>>(*modulesInGPU, *rangesInGPU, *pixelTripletsInGPU, *trackCandidatesInGPU, *segmentsInGPU, *mdsInGPU,*hitsInGPU, *quintupletsInGPU);
     cudaError_t cudaerr_pLS = cudaGetLastError();
@@ -1937,7 +1937,7 @@ cudaStreamSynchronize(stream);
 
 
 #else
-        createQuintupletsInUnifiedMemory(*quintupletsInGPU, N_MAX_QUINTUPLETS_PER_MODULE, nLowerModules, nEligibleT5Modules,stream);
+        createQuintupletsInUnifiedMemory(*quintupletsInGPU, nTotalQuintuplets, nLowerModules, nEligibleT5Modules,stream);
 
 
 #endif

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1530,7 +1530,7 @@ void SDL::Event::createTriplets()
     {
         tripletsInGPU = (SDL::triplets*)cms::cuda::allocate_host(sizeof(SDL::triplets), stream);
         unsigned int maxTriplets;
-        createTripletArrayRanges(*modulesInGPU, *rangesInGPU, *segmentsInGPU, nLowerModules, maxTriplets, stream, N_MAX_TRIPLETS_PER_MODULE);
+        createTripletArrayRanges(*modulesInGPU, *rangesInGPU, *segmentsInGPU, nLowerModules, maxTriplets, stream);
 //        cout<<"nTotalTriplets: "<<maxTriplets<<std::endl; // for memory usage
 #ifdef Explicit_Trips
         createTripletsInExplicitMemory(*tripletsInGPU, maxTriplets, nLowerModules,stream);

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1933,7 +1933,7 @@ cudaStreamSynchronize(stream);
     {
         quintupletsInGPU = (SDL::quintuplets*)cms::cuda::allocate_host(sizeof(SDL::quintuplets), stream);
 #ifdef Explicit_T5
-        createQuintupletsInExplicitMemory(*quintupletsInGPU, N_MAX_QUINTUPLETS_PER_MODULE, nLowerModules, nEligibleT5Modules,stream);
+        createQuintupletsInExplicitMemory(*quintupletsInGPU, nTotalQuintuplets, nLowerModules, nEligibleT5Modules,stream);
 
 
 #else

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1923,10 +1923,13 @@ cudaStreamSynchronize(stream);
     cudaMemsetAsync(rangesInGPU->quintupletModuleIndices, -1, sizeof(int) * (nLowerModules),stream);
 cudaStreamSynchronize(stream);
     unsigned int nTotalQuintuplets;
-    createEligibleModulesListForQuintupletsGPU<<<1,1024,0,stream>>>(*modulesInGPU, *tripletsInGPU, nTotalQuintuplets,stream,*rangesInGPU);
-    cout<<"nTotalQuintuplets: "<<nTotalQuintuplets<<std::endl; // for memory usage
+    unsigned int *device_nTotalQuintuplets;
+    cudaMalloc((void **)&device_nTotalQuintuplets, sizeof(unsigned int));
+    createEligibleModulesListForQuintupletsGPU<<<1,1024,0,stream>>>(*modulesInGPU, *tripletsInGPU, device_nTotalQuintuplets, stream, *rangesInGPU);
 cudaStreamSynchronize(stream);
     cudaMemcpyAsync(&nEligibleT5Modules,rangesInGPU->nEligibleT5Modules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
+    cudaMemcpyAsync(&nTotalQuintuplets,device_nTotalQuintuplets,sizeof(unsigned int),cudaMemcpyDeviceToHost,stream);
+    cudaFree(device_nTotalQuintuplets);
 cudaStreamSynchronize(stream);
 
     if(quintupletsInGPU == nullptr)

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1922,7 +1922,9 @@ cudaStreamSynchronize(stream);
 #endif
     cudaMemsetAsync(rangesInGPU->quintupletModuleIndices, -1, sizeof(int) * (nLowerModules),stream);
 cudaStreamSynchronize(stream);
-    createEligibleModulesListForQuintupletsGPU<<<1,1024,0,stream>>>(*modulesInGPU, *tripletsInGPU, N_MAX_QUINTUPLETS_PER_MODULE,stream,*rangesInGPU);
+    unsigned int nTotalQuintuplets;
+    createEligibleModulesListForQuintupletsGPU<<<1,1024,0,stream>>>(*modulesInGPU, *tripletsInGPU, nTotalQuintuplets,stream,*rangesInGPU);
+    cout<<"nTotalQuintuplets: "<<nTotalQuintuplets<<std::endl; // for memory usage
 cudaStreamSynchronize(stream);
     cudaMemcpyAsync(&nEligibleT5Modules,rangesInGPU->nEligibleT5Modules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
 cudaStreamSynchronize(stream);

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1585,7 +1585,7 @@ void SDL::Event::createTriplets()
     cudaMemcpyAsync(index_gpu, index, nonZeroModules*sizeof(uint16_t), cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
 
-    dim3 nThreads(16,16,1);
+    dim3 nThreads(16,32,1);
     dim3 nBlocks(1,1,MAX_BLOCKS);
     //createTripletsInGPU<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *rangesInGPU, index_gpu,nonZeroModules);
     SDL::createTripletsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU, *mdsInGPU, *segmentsInGPU, *tripletsInGPU, *rangesInGPU, index_gpu,nonZeroModules);
@@ -1690,7 +1690,7 @@ void SDL::Event::createTrackCandidates()
     }cudaStreamSynchronize(stream);
 #endif  
 
-    dim3 nThreads_pLS(32,16,1);
+    dim3 nThreads_pLS(64,16,1);
     dim3 nBlocks_pLS(20,4,1);
     SDL::crossCleanpLS<<<nBlocks_pLS, nThreads_pLS, 0, stream>>>(*modulesInGPU, *rangesInGPU, *pixelTripletsInGPU, *trackCandidatesInGPU, *segmentsInGPU, *mdsInGPU,*hitsInGPU, *quintupletsInGPU);
     cudaError_t cudaerr_pLS = cudaGetLastError();

--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -67,6 +67,8 @@ namespace SDL
         int *miniDoubletModuleIndices;
         int *segmentModuleIndices;
         int *tripletModuleIndices;
+
+//        unsigned int nTotalQuintuplets;
     
         void freeMemoryCache();
         void freeMemory();

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -123,7 +123,6 @@ void SDL::quintuplets::freeMemory(cudaStream_t stream)
 cudaStreamSynchronize(stream);
 }
 //TODO:Reuse the track candidate one instead of this!
-<<<<<<< HEAD
 __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU,struct triplets& tripletsInGPU, unsigned int nTotalQuintuplets, cudaStream_t stream,struct objectRanges& rangesInGPU)
 {
     __shared__ int nEligibleT5Modulesx;
@@ -133,40 +132,6 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
     nTotalQuintuplets = 0; //start!
     unsigned int occupancy;
     unsigned int category_number, eta_number;
-=======
-//void SDL::createEligibleModulesListForQuintuplets(struct modules& modulesInGPU,struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int& maxTriplets,cudaStream_t stream,struct objectRanges& rangesInGPU)
-void SDL::createEligibleModulesListForQuintuplets(struct modules& modulesInGPU,struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int& nTotalQuintuplets, unsigned int& maxTriplets,cudaStream_t stream,struct objectRanges& rangesInGPU)
-{
-    uint16_t nLowerModules;
-    nTotalQuintuplets = 0; //start!
-    maxTriplets = 0;
-    cudaMemcpyAsync(&nLowerModules,modulesInGPU.nLowerModules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
-
-    cudaMemsetAsync(rangesInGPU.quintupletModuleIndices, -1, sizeof(int) * (nLowerModules),stream);
-
-    short* module_subdets;
-    cudaMallocHost(&module_subdets, nLowerModules* sizeof(short));
-    cudaMemcpyAsync(module_subdets,modulesInGPU.subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
-    short* module_layers;
-    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
-    cudaMemcpyAsync(module_layers,modulesInGPU.layers,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
-    short* module_rings;
-    cudaMallocHost(&module_rings, nLowerModules * sizeof(short));
-    cudaMemcpyAsync(module_rings,modulesInGPU.rings,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
-    float* module_eta;
-    cudaMallocHost(&module_eta, nLowerModules * sizeof(float));
-    cudaMemcpyAsync(module_eta,modulesInGPU.eta,nLowerModules * sizeof(float),cudaMemcpyDeviceToHost,stream);
-
-    int* module_quintupletModuleIndices;
-    module_quintupletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(int), stream);
-    cudaMemcpyAsync(module_quintupletModuleIndices,rangesInGPU.quintupletModuleIndices,nLowerModules *sizeof(int),cudaMemcpyDeviceToHost,stream);
-
-    unsigned int* nTriplets;
-    nTriplets = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
-    cudaMemcpyAsync(nTriplets, tripletsInGPU.nTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-    cudaStreamSynchronize(stream);
-
->>>>>>> add nTotalQuintuplets counter
     //start filling
     int gid = blockIdx.x * blockDim.x + threadIdx.x;
     int np = gridDim.x * blockDim.x;

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -131,7 +131,7 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
     __shared__ int nEligibleT5Modulesx;
     __shared__ unsigned int nTotalQuintupletsx;
     nTotalQuintupletsx = 0; //start!
-    nEligibleT5Modulesx =-1;
+    nEligibleT5Modulesx = 0;
     __syncthreads();
 
     unsigned int occupancy;
@@ -168,13 +168,13 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
         if (abs(eta)>1.5 && abs(eta)<2.25) eta_number=2;
         if (abs(eta)>2.25 && abs(eta)<3) eta_number=3;
 
-        if (category_number == 0 && eta_number == 0) occupancy = 152;
-        if (category_number == 0 && eta_number == 1) occupancy = 170;
-        if (category_number == 0 && eta_number == 2) occupancy = 94;
-        if (category_number == 0 && eta_number == 3) occupancy = 63;
+        if (category_number == 0 && eta_number == 0) occupancy = 336;
+        if (category_number == 0 && eta_number == 1) occupancy = 414;
+        if (category_number == 0 && eta_number == 2) occupancy = 231;
+        if (category_number == 0 && eta_number == 3) occupancy = 146;
         if (category_number == 3 && eta_number == 1) occupancy = 0;
-        if (category_number == 3 && eta_number == 2) occupancy = 70;
-        if (category_number == 3 && eta_number == 3) occupancy = 75;
+        if (category_number == 3 && eta_number == 2) occupancy = 191;
+        if (category_number == 3 && eta_number == 3) occupancy = 106;
 
         unsigned int nTotQ = atomicAdd(&nTotalQuintupletsx,occupancy);
 //        if (nTotQ == 0) printf("%u\n",occupancy);

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -132,6 +132,7 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
     nTotalQuintuplets = 0; //start!
     unsigned int occupancy;
     unsigned int category_number, eta_number;
+    unsigned int layers, subdets, eta;
     //start filling
     int gid = blockIdx.x * blockDim.x + threadIdx.x;
     int np = gridDim.x * blockDim.x;
@@ -145,17 +146,19 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
 
         int nEligibleT5Modules = atomicAdd(&nEligibleT5Modulesx,1);
         rangesInGPU.quintupletModuleIndices[i] = nTotalQuintuplets; //for variable occupancy change this to module_quintupletModuleIndices[i-1] + blah
-
-        if (module_layers[i]<=3 && module_subdets[i]==5) category_number = 0;
-        if (module_layers[i]>=4 && module_subdets[i]==5) category_number = 1;
-        if (module_layers[i]<=2 && module_subdets[i]==4 && module_rings[i]>=11) category_number = 2;
-        if (module_layers[i]>=3 && module_subdets[i]==4 && module_rings[i]>=8) category_number = 2;
-        if (module_layers[i]<=2 && module_subdets[i]==4 && module_rings[i]<=10) category_number = 3;
-        if (module_layers[i]>=3 && module_subdets[i]==4 && module_rings[i]<=7) category_number = 3;
-        if (abs(module_eta[i])<0.75) eta_number=0;
-        if (abs(module_eta[i])>0.75 && abs(module_eta[i])<1.5) eta_number=1;
-        if (abs(module_eta[i])>1.5 && abs(module_eta[i])<2.25) eta_number=2;
-        if (abs(module_eta[i])>2.25 && abs(module_eta[i])<3) eta_number=3;
+        layers = rangesInGPU.layers[i];
+        subdets = rangesInGPU.subdets[i];
+        eta = rangesInGPU.eta[i];
+        if (layers<=3 && subdets==5) category_number = 0;
+        if (layers>=4 && subdets==5) category_number = 1;
+        if (layers<=2 && subdets==4 && rings>=11) category_number = 2;
+        if (layers>=3 && subdets==4 && rings>=8) category_number = 2;
+        if (layers<=2 && subdets==4 && rings<=10) category_number = 3;
+        if (layers>=3 && subdets==4 && rings<=7) category_number = 3;
+        if (abs(eta)<0.75) eta_number=0;
+        if (abs(eta)>0.75 && abs(eta)<1.5) eta_number=1;
+        if (abs(eta)>1.5 && abs(eta)<2.25) eta_number=2;
+        if (abs(eta)>2.25 && abs(eta)<3) eta_number=3;
 
         if (category_number == 0 && eta_number == 0) occupancy = 152;
         if (category_number == 0 && eta_number == 1) occupancy = 170;

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -251,53 +251,55 @@ void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsI
     cudaStreamSynchronize(stream);
 }
 
-void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& maxQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream)
+void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& nTotalQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream)
 {
-    unsigned int nMemoryLocations = nEligibleModules * maxQuintuplets;
+    //unsigned int nMemoryLocations = nEligibleModules * maxQuintuplets;
 #ifdef CACHE_ALLOC
  //   cudaStream_t stream = 0;
     int dev;
     cudaGetDevice(&dev);
-    quintupletsInGPU.tripletIndices = (unsigned int*)cms::cuda::allocate_device(dev, 2 * nMemoryLocations * sizeof(unsigned int), stream);
-    quintupletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_device(dev, 5 * nMemoryLocations * sizeof(uint16_t), stream);
+    quintupletsInGPU.tripletIndices = (unsigned int*)cms::cuda::allocate_device(dev, 2 * nEligibleModules*513 * sizeof(unsigned int), stream);
+    quintupletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_device(dev, 5 * nTotalQuintuplets * sizeof(uint16_t), stream);
     quintupletsInGPU.nQuintuplets = (unsigned int*)cms::cuda::allocate_device(dev, nLowerModules * sizeof(unsigned int), stream);
     quintupletsInGPU.totOccupancyQuintuplets = (unsigned int*)cms::cuda::allocate_device(dev, nLowerModules * sizeof(unsigned int), stream);
-    quintupletsInGPU.innerRadius = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(FPX), stream);
-    quintupletsInGPU.outerRadius = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(FPX), stream);
-    quintupletsInGPU.pt = (FPX*)cms::cuda::allocate_device(dev, nMemoryLocations *4* sizeof(FPX), stream);
-    quintupletsInGPU.layer = (uint8_t*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(uint8_t), stream);
-    quintupletsInGPU.isDup = (bool*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(bool), stream);
-    quintupletsInGPU.partOfPT5 = (bool*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(bool), stream);
-    quintupletsInGPU.regressionRadius = (float*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(float), stream);
-    quintupletsInGPU.regressionG = (float*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(float), stream);
-    quintupletsInGPU.regressionF = (float*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(float), stream);
-    quintupletsInGPU.logicalLayers = (uint8_t*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(uint8_t) * 5, stream);
-    quintupletsInGPU.hitIndices = (unsigned int*)cms::cuda::allocate_device(dev, nMemoryLocations * sizeof(unsigned int) * 10, stream);
+    quintupletsInGPU.innerRadius = (FPX*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(FPX), stream);
+    quintupletsInGPU.outerRadius = (FPX*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(FPX), stream);
+    quintupletsInGPU.pt = (FPX*)cms::cuda::allocate_device(dev, nTotalQuintuplets *4* sizeof(FPX), stream);
+    quintupletsInGPU.layer = (uint8_t*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(uint8_t), stream);
+    quintupletsInGPU.isDup = (bool*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(bool), stream);
+    quintupletsInGPU.partOfPT5 = (bool*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(bool), stream);
+    quintupletsInGPU.regressionRadius = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.regressionG = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.regressionF = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.logicalLayers = (uint8_t*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(uint8_t) * 5, stream);
+    quintupletsInGPU.hitIndices = (unsigned int*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(unsigned int) * 10, stream);
+    //quintupletsInGPU.nMemoryLocations = (unsigned int*)cms::cuda::allocate_device(dev, sizeof(unsigned int), stream);
+
 #else
-    cudaMalloc(&quintupletsInGPU.tripletIndices, 2 * nMemoryLocations * sizeof(unsigned int));
-    cudaMalloc(&quintupletsInGPU.lowerModuleIndices, 5 * nMemoryLocations * sizeof(uint16_t));
+    cudaMalloc(&quintupletsInGPU.tripletIndices, 2 * nTotalQuintuplets * sizeof(unsigned int));
+    cudaMalloc(&quintupletsInGPU.lowerModuleIndices, 5 * nTotalQuintuplets * sizeof(uint16_t));
     cudaMalloc(&quintupletsInGPU.nQuintuplets, nLowerModules * sizeof(unsigned int));
     cudaMalloc(&quintupletsInGPU.totOccupancyQuintuplets, nLowerModules * sizeof(unsigned int));
-    cudaMalloc(&quintupletsInGPU.innerRadius, nMemoryLocations * sizeof(FPX));
-    cudaMalloc(&quintupletsInGPU.outerRadius, nMemoryLocations * sizeof(FPX));
-    cudaMalloc(&quintupletsInGPU.pt, nMemoryLocations *4* sizeof(FPX));
-    cudaMalloc(&quintupletsInGPU.isDup, nMemoryLocations * sizeof(bool));
-    cudaMalloc(&quintupletsInGPU.partOfPT5, nMemoryLocations * sizeof(bool));
-    cudaMalloc(&quintupletsInGPU.layer, nMemoryLocations * sizeof(uint8_t));
-    cudaMalloc(&quintupletsInGPU.regressionRadius, nMemoryLocations * sizeof(float));
-    cudaMalloc(&quintupletsInGPU.regressionG, nMemoryLocations * sizeof(float));
-    cudaMalloc(&quintupletsInGPU.regressionF, nMemoryLocations * sizeof(float));
-    cudaMalloc(&quintupletsInGPU.logicalLayers, nMemoryLocations * 5 * sizeof(uint8_t));
-    cudaMalloc(&quintupletsInGPU.hitIndices, nMemoryLocations * 10 * sizeof(unsigned int));
+    cudaMalloc(&quintupletsInGPU.innerRadius, nTotalQuintuplets * sizeof(FPX));
+    cudaMalloc(&quintupletsInGPU.outerRadius, nTotalQuintuplets * sizeof(FPX));
+    cudaMalloc(&quintupletsInGPU.pt, nTotalQuintuplets *4* sizeof(FPX));
+    cudaMalloc(&quintupletsInGPU.isDup, nTotalQuintuplets * sizeof(bool));
+    cudaMalloc(&quintupletsInGPU.partOfPT5, nTotalQuintuplets * sizeof(bool));
+    cudaMalloc(&quintupletsInGPU.layer, nTotalQuintuplets * sizeof(uint8_t));
+    cudaMalloc(&quintupletsInGPU.regressionRadius, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.regressionG, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.regressionF, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.logicalLayers, nTotalQuintuplets * 5 * sizeof(uint8_t));
+    cudaMalloc(&quintupletsInGPU.hitIndices, nTotalQuintuplets * 10 * sizeof(unsigned int));
 #endif
     cudaMemsetAsync(quintupletsInGPU.nQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(quintupletsInGPU.totOccupancyQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
-    cudaMemsetAsync(quintupletsInGPU.isDup,0,nMemoryLocations * sizeof(bool),stream);
-    cudaMemsetAsync(quintupletsInGPU.partOfPT5,0,nMemoryLocations * sizeof(bool),stream);
+    cudaMemsetAsync(quintupletsInGPU.isDup,0,nTotalQuintuplets * sizeof(bool),stream);
+    cudaMemsetAsync(quintupletsInGPU.partOfPT5,0,nTotalQuintuplets * sizeof(bool),stream);
     cudaStreamSynchronize(stream);
-    quintupletsInGPU.eta = quintupletsInGPU.pt + nMemoryLocations;
-    quintupletsInGPU.phi = quintupletsInGPU.pt + 2*nMemoryLocations;
-    quintupletsInGPU.score_rphisum = quintupletsInGPU.pt + 3*nMemoryLocations;
+    quintupletsInGPU.eta = quintupletsInGPU.pt + nTotalQuintuplets;
+    quintupletsInGPU.phi = quintupletsInGPU.pt + 2*nTotalQuintuplets;
+    quintupletsInGPU.score_rphisum = quintupletsInGPU.pt + 3*nTotalQuintuplets;
 }
 
 

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -123,6 +123,7 @@ void SDL::quintuplets::freeMemory(cudaStream_t stream)
 cudaStreamSynchronize(stream);
 }
 //TODO:Reuse the track candidate one instead of this!
+<<<<<<< HEAD
 __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU,struct triplets& tripletsInGPU, unsigned int nTotalQuintuplets, cudaStream_t stream,struct objectRanges& rangesInGPU)
 {
     __shared__ int nEligibleT5Modulesx;
@@ -132,6 +133,40 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
     nTotalQuintuplets = 0; //start!
     unsigned int occupancy;
     unsigned int category_number, eta_number;
+=======
+//void SDL::createEligibleModulesListForQuintuplets(struct modules& modulesInGPU,struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int& maxTriplets,cudaStream_t stream,struct objectRanges& rangesInGPU)
+void SDL::createEligibleModulesListForQuintuplets(struct modules& modulesInGPU,struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int& nTotalQuintuplets, unsigned int& maxTriplets,cudaStream_t stream,struct objectRanges& rangesInGPU)
+{
+    uint16_t nLowerModules;
+    nTotalQuintuplets = 0; //start!
+    maxTriplets = 0;
+    cudaMemcpyAsync(&nLowerModules,modulesInGPU.nLowerModules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
+
+    cudaMemsetAsync(rangesInGPU.quintupletModuleIndices, -1, sizeof(int) * (nLowerModules),stream);
+
+    short* module_subdets;
+    cudaMallocHost(&module_subdets, nLowerModules* sizeof(short));
+    cudaMemcpyAsync(module_subdets,modulesInGPU.subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
+    short* module_layers;
+    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
+    cudaMemcpyAsync(module_layers,modulesInGPU.layers,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
+    short* module_rings;
+    cudaMallocHost(&module_rings, nLowerModules * sizeof(short));
+    cudaMemcpyAsync(module_rings,modulesInGPU.rings,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
+    float* module_eta;
+    cudaMallocHost(&module_eta, nLowerModules * sizeof(float));
+    cudaMemcpyAsync(module_eta,modulesInGPU.eta,nLowerModules * sizeof(float),cudaMemcpyDeviceToHost,stream);
+
+    int* module_quintupletModuleIndices;
+    module_quintupletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(int), stream);
+    cudaMemcpyAsync(module_quintupletModuleIndices,rangesInGPU.quintupletModuleIndices,nLowerModules *sizeof(int),cudaMemcpyDeviceToHost,stream);
+
+    unsigned int* nTriplets;
+    nTriplets = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
+    cudaMemcpyAsync(nTriplets, tripletsInGPU.nTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
+    cudaStreamSynchronize(stream);
+
+>>>>>>> add nTotalQuintuplets counter
     //start filling
     int gid = blockIdx.x * blockDim.x + threadIdx.x;
     int np = gridDim.x * blockDim.x;

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -132,7 +132,8 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
     nTotalQuintuplets = 0; //start!
     unsigned int occupancy;
     unsigned int category_number, eta_number;
-    unsigned int layers, subdets, eta;
+    unsigned int layers, subdets, rings;
+    float eta;
     //start filling
     int gid = blockIdx.x * blockDim.x + threadIdx.x;
     int np = gridDim.x * blockDim.x;
@@ -146,9 +147,10 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
 
         int nEligibleT5Modules = atomicAdd(&nEligibleT5Modulesx,1);
         rangesInGPU.quintupletModuleIndices[i] = nTotalQuintuplets; //for variable occupancy change this to module_quintupletModuleIndices[i-1] + blah
-        layers = rangesInGPU.layers[i];
-        subdets = rangesInGPU.subdets[i];
-        eta = rangesInGPU.eta[i];
+        layers = modulesInGPU.layers[i];
+        subdets = modulesInGPU.subdets[i];
+        rings = modulesInGPU.rings[i];
+        eta = modulesInGPU.eta[i];
         if (layers<=3 && subdets==5) category_number = 0;
         if (layers>=4 && subdets==5) category_number = 1;
         if (layers<=2 && subdets==4 && rings>=11) category_number = 2;

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -258,7 +258,7 @@ void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintuplets
  //   cudaStream_t stream = 0;
     int dev;
     cudaGetDevice(&dev);
-    quintupletsInGPU.tripletIndices = (unsigned int*)cms::cuda::allocate_device(dev, 2 * nEligibleModules*513 * sizeof(unsigned int), stream);
+    quintupletsInGPU.tripletIndices = (unsigned int*)cms::cuda::allocate_device(dev, 2 * nTotalQuintuplets * sizeof(unsigned int), stream);
     quintupletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_device(dev, 5 * nTotalQuintuplets * sizeof(uint16_t), stream);
     quintupletsInGPU.nQuintuplets = (unsigned int*)cms::cuda::allocate_device(dev, nLowerModules * sizeof(unsigned int), stream);
     quintupletsInGPU.totOccupancyQuintuplets = (unsigned int*)cms::cuda::allocate_device(dev, nLowerModules * sizeof(unsigned int), stream);
@@ -1413,7 +1413,7 @@ __global__ void SDL::createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU,
                     return;
                 } // ignore anything else TODO: move this to start, before object is made (faster)
                 unsigned int totOccupancyQuintuplets = atomicAdd(&quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1);
-                if(totOccupancyQuintuplets >= N_MAX_QUINTUPLETS_PER_MODULE)
+                if(totOccupancyQuintuplets >= (rangesInGPU.quintupletModuleIndices[lowerModule1 + 1] - rangesInGPU.quintupletModuleIndices[lowerModule1]))
                 {
 #ifdef Warnings
                     printf("Quintuplet excess alert! Module index = %d\n", lowerModule1);

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -76,8 +76,8 @@ namespace SDL
 
     void createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& maxQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream);
 
-    void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int maxQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
-    __global__ void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, unsigned int nTotalQuintuplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
+    void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int& nTotalQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
+    __global__ void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, unsigned int& nTotalQuintuplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
 
 //  CUDA_DEV void rmQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int quintupletIndex);
 

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -77,7 +77,7 @@ namespace SDL
 
     void createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& maxQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream);
 
-    void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int& nTotalQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
+//    void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int& nTotalQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
     __global__ void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, unsigned int* nTotalQuintuplets, cudaStream_t stream, struct objectRanges& rangesInGPU);
 
 //  CUDA_DEV void rmQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int quintupletIndex);

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -28,8 +28,8 @@ namespace SDL
     {
         unsigned int* tripletIndices;
         uint16_t* lowerModuleIndices;
-        unsigned int* nQuintuplets;
-        unsigned int* totOccupancyQuintuplets;
+        unsigned int* nQuintuplets; // ?
+        unsigned int* totOccupancyQuintuplets; //?
         unsigned int* nMemoryLocations;
 
         FPX* innerRadius;
@@ -78,7 +78,7 @@ namespace SDL
     void createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& maxQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream);
 
     void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int& nTotalQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
-    __global__ void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, unsigned int& nTotalQuintuplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
+    __global__ void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, unsigned int* nTotalQuintuplets, cudaStream_t stream, struct objectRanges& rangesInGPU);
 
 //  CUDA_DEV void rmQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int quintupletIndex);
 

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -77,7 +77,7 @@ namespace SDL
     void createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& maxQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream);
 
     void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int maxQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
-    __global__ void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, unsigned int maxQuintuplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
+    __global__ void createEligibleModulesListForQuintupletsGPU(struct modules& modulesInGPU, struct triplets& tripletsInGPU, unsigned int nTotalQuintuplets,cudaStream_t stream, struct objectRanges& rangesInGPU);
 
 //  CUDA_DEV void rmQuintupletToMemory(struct SDL::quintuplets& quintupletsInGPU, unsigned int quintupletIndex);
 

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -1006,7 +1006,7 @@ __global__ void SDL::createSegmentsInGPUv2(struct SDL::modules& modulesInGPU, st
             if(pass)
             {
                 unsigned int totOccupancySegments = atomicAdd(&segmentsInGPU.totOccupancySegments[innerLowerModuleIndex],1);
-                if(totOccupancySegments >= N_MAX_SEGMENTS_PER_MODULE)
+                if(totOccupancySegments >= (rangesInGPU.segmentModuleIndices[innerLowerModuleIndex + 1] - rangesInGPU.segmentModuleIndices[innerLowerModuleIndex]))
                 {
 #ifdef Warnings
                     printf("Segment excess alert! Module index = %d\n",innerLowerModuleIndex);

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -16,7 +16,7 @@ void SDL::triplets::resetMemory(unsigned int maxTriplets, unsigned int nLowerMod
     cudaMemsetAsync(partOfPT3, 0, maxTriplets * sizeof(bool));
 }
 
-void SDL::createTripletArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct segments& segmentsInGPU, uint16_t& nLowerModules, unsigned int& nTotalTriplets, cudaStream_t stream, const uint16_t& maxTripletsPerModule)
+void SDL::createTripletArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct segments& segmentsInGPU, uint16_t& nLowerModules, unsigned int& nTotalTriplets, cudaStream_t stream)
 {
     int* module_tripletModuleIndices;
     module_tripletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -712,8 +712,8 @@ __global__ void SDL::createTripletsInGPUv2(struct SDL::modules& modulesInGPU, st
       unsigned int nOuterSegments = segmentsInGPU.nSegments[middleLowerModuleIndex];
       for(int outerSegmentArrayIndex = blockIdx.x * blockDim.x + threadIdx.x; outerSegmentArrayIndex< nOuterSegments; outerSegmentArrayIndex += blockxSize){
         //if(outerSegmentArrayIndex >= nOuterSegments) continue;
-  unsigned int outerSegmentIndex = rangesInGPU.segmentRanges[2 * middleLowerModuleIndex] + outerSegmentArrayIndex;
-
+         unsigned int outerSegmentIndex = rangesInGPU.segmentRanges[2 * middleLowerModuleIndex] + outerSegmentArrayIndex;
+    
         uint16_t outerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[outerSegmentIndex];
 
         float zOut,rtOut,deltaPhiPos,deltaPhi,betaIn,betaOut, pt_beta;
@@ -723,7 +723,7 @@ __global__ void SDL::createTripletsInGPUv2(struct SDL::modules& modulesInGPU, st
 
         if(success) {
           unsigned int totOccupancyTriplets = atomicAdd(&tripletsInGPU.totOccupancyTriplets[innerInnerLowerModuleIndex], 1);
-          if(totOccupancyTriplets >= N_MAX_TRIPLETS_PER_MODULE) {
+          if(totOccupancyTriplets >= (rangesInGPU.tripletModuleIndices[innerInnerLowerModuleIndex + 1] - rangesInGPU.tripletModuleIndices[innerInnerLowerModuleIndex])) {
 #ifdef Warnings
             printf("Triplet excess alert! Module index = %d\n",innerInnerLowerModuleIndex);
 #endif

--- a/SDL/Triplet.cuh
+++ b/SDL/Triplet.cuh
@@ -76,7 +76,7 @@ namespace SDL
         void resetMemory(unsigned int maxTriplets, unsigned int nLowerModules,cudaStream_t stream);
     };
 
-    void createTripletArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct segments& segmentsInGPU, uint16_t& nLowerModules, unsigned int& nTotalTriplets, cudaStream_t stream, const uint16_t& maxTripletsPerModule);
+    void createTripletArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct segments& segmentsInGPU, uint16_t& nLowerModules, unsigned int& nTotalTriplets, cudaStream_t stream);
 
     void createTripletsInUnifiedMemory(struct triplets& tripletsInGPU, unsigned int maxTriplets, uint16_t nLowerModules,cudaStream_t stream);
     void createTripletsInExplicitMemory(struct triplets& tripletsInGPU, unsigned int maxTriplets, uint16_t nLowerModules,cudaStream_t stream);


### PR DESCRIPTION
This is to cut the occupancy of T5 module usage. We cut the truncation of 99.99% by different regions, but the TCE efficiency actually dropped on high PT (>10GeV) by 0.5% on the final 2 bins.