### PR TITLE
Host and Device Allocator Fix

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -526,16 +526,13 @@ void SDL::initModules(const char* moduleMetaDataFilePath)
 {
     if(modulesInGPU == nullptr)
     {
-    cudaStream_t modStream;
-    cudaStreamCreate(&modStream);
-        //modulesInGPU = (SDL::modules*)cms::cuda::allocate_host(sizeof(struct SDL::modules), modStream);
+        //modulesInGPU = (SDL::modules*)cms::cuda::allocate_host(sizeof(struct SDL::modules), 0);
         cudaMallocHost(&modulesInGPU, sizeof(struct SDL::modules));
         //pixelMapping = new pixelMap;
         cudaMallocHost(&pixelMapping, sizeof(struct SDL::pixelMap));
-        //pixelMapping = (SDL::pixelMap*)cms::cuda::allocate_host(sizeof(struct SDL::pixelMap), modStream);
-        loadModulesFromFile(*modulesInGPU,nModules,nLowerModules, *pixelMapping,modStream,moduleMetaDataFilePath); //nModules gets filled here
-    cudaStreamSynchronize(modStream);
-    cudaStreamDestroy(modStream);
+        //pixelMapping = (SDL::pixelMap*)cms::cuda::allocate_host(sizeof(struct SDL::pixelMap), 0);
+        loadModulesFromFile(*modulesInGPU,nModules,nLowerModules, *pixelMapping, 0, moduleMetaDataFilePath); //nModules gets filled here
+        cudaStreamSynchronize(0);
     }
     //resetObjectRanges(*modulesInGPU,nModules,modStream);
 }
@@ -546,17 +543,12 @@ void SDL::cleanModules()
   //#ifdef CACHE_ALLOC
   //freeModulesCache(*modulesInGPU,*pixelMapping); //bug in freeing cached modules. Decided to remove module caching since it doesn't change by event.
   //#else
-    cudaStream_t modStream;
-    cudaStreamCreate(&modStream);
-    freeModules(*modulesInGPU,*pixelMapping,modStream);
-    cudaStreamSynchronize(modStream);
-    cudaStreamDestroy(modStream);
+    freeModules(*modulesInGPU, *pixelMapping);
   //#endif
     cudaFreeHost(modulesInGPU);
     cudaFreeHost(pixelMapping);
     //cms::cuda::free_host(modulesInGPU);
     //cms::cuda::free_host(pixelMapping);
-//    cudaDeviceReset(); // uncomment for leak check "cuda-memcheck --leak-check full --show-backtrace yes" does not work with caching.
 }
 
 void SDL::Event::resetObjectsInModule()

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -10,6 +10,7 @@ SDL::Event::Event(cudaStream_t estream)
 {
     int version;
     int driver;
+    int dev;
     cudaRuntimeGetVersion(&version);
     cudaDriverGetVersion(&driver);
     //printf("version: %d Driver %d\n",version, driver);
@@ -93,14 +94,10 @@ SDL::Event::~Event()
     if(tripletsInGPU!= nullptr){cms::cuda::free_host(tripletsInGPU);}
     if(trackCandidatesInGPU!= nullptr){cms::cuda::free_host(trackCandidatesInGPU);}
     if(hitsInGPU!= nullptr){cms::cuda::free_host(hitsInGPU);}
-
-    if(pixelTripletsInGPU!= nullptr){//cms::cuda::free_host(pixelTripletsInGPU);
-        cudaFreeHost(pixelTripletsInGPU);}
+    if(pixelTripletsInGPU!= nullptr){cms::cuda::free_host(pixelTripletsInGPU);}
     if(pixelQuintupletsInGPU!= nullptr){cms::cuda::free_host(pixelQuintupletsInGPU);}
-
     if(quintupletsInGPU!= nullptr){cms::cuda::free_host(quintupletsInGPU);}
-    if(trackExtensionsInGPU != nullptr){//cms::cuda::free_host(trackExtensionsInGPU);
-        cudaFreeHost(trackExtensionsInGPU);}
+    if(trackExtensionsInGPU != nullptr){cms::cuda::free_host(trackExtensionsInGPU);}
 
 #ifdef Explicit_Hit
     if(hitsInCPU != nullptr)
@@ -332,13 +329,11 @@ void SDL::Event::resetEvent()
       quintupletsInGPU = nullptr;}
     if(trackCandidatesInGPU){cms::cuda::free_host(trackCandidatesInGPU);
     trackCandidatesInGPU = nullptr;}
-    if(pixelTripletsInGPU){//cms::cuda::free_host(pixelTripletsInGPU);
-    cudaFreeHost(pixelTripletsInGPU);
+    if(pixelTripletsInGPU){cms::cuda::free_host(pixelTripletsInGPU);
     pixelTripletsInGPU = nullptr;}
     if(pixelQuintupletsInGPU){cms::cuda::free_host(pixelQuintupletsInGPU);
     pixelQuintupletsInGPU = nullptr;}
-    if(trackExtensionsInGPU){//cms::cuda::free_host(trackExtensionsInGPU);
-    cudaFreeHost(trackExtensionsInGPU);
+    if(trackExtensionsInGPU){cms::cuda::free_host(trackExtensionsInGPU);
     trackExtensionsInGPU = nullptr;}
 #ifdef Explicit_Hit
     if(hitsInCPU != nullptr)
@@ -542,6 +537,7 @@ void SDL::initModules(const char* moduleMetaDataFilePath)
 
 void SDL::cleanModules()
 {
+  //cudaStream_t default_stream = 0;
   //#ifdef CACHE_ALLOC
   //freeModulesCache(*modulesInGPU,*pixelMapping); //bug in freeing cached modules. Decided to remove module caching since it doesn't change by event.
   //#else
@@ -651,6 +647,9 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
 {
     // Use the actual number of hits instead of a max.
     const int nHits = x.size();
+
+    // Get current device for future use.
+    cudaGetDevice(&dev);
 
     // Initialize space on device/host for next event.
     if (hitsInGPU == nullptr)
@@ -807,36 +806,36 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     int* superbin_dev;
     int8_t* pixelType_dev;
     short* isQuad_dev;
-    cudaMalloc(&hitIndices0_dev,size*sizeof(unsigned int));
-    cudaMalloc(&hitIndices1_dev,size*sizeof(unsigned int));
-    cudaMalloc(&hitIndices2_dev,size*sizeof(unsigned int));
-    cudaMalloc(&hitIndices3_dev,size*sizeof(unsigned int));
-    cudaMalloc(&dPhiChange_dev,size*sizeof(unsigned int));
-    cudaMalloc(&ptIn_dev,size*sizeof(unsigned int));
-    cudaMalloc(&ptErr_dev,size*sizeof(unsigned int));
-    cudaMalloc(&px_dev,size*sizeof(unsigned int));
-    cudaMalloc(&py_dev,size*sizeof(unsigned int));
-    cudaMalloc(&pz_dev,size*sizeof(unsigned int));
-    cudaMalloc(&etaErr_dev,size*sizeof(unsigned int));
-    cudaMalloc(&eta_dev, size*sizeof(unsigned int));
-    cudaMalloc(&phi_dev, size*sizeof(unsigned int));
-    cudaMalloc(&superbin_dev,size*sizeof(int));
-    cudaMalloc(&pixelType_dev,size*sizeof(int8_t));
-    cudaMalloc(&isQuad_dev,size*sizeof(short));
+    hitIndices0_dev = (unsigned int*)cms::cuda::allocate_device(dev, size*sizeof(unsigned int), stream);
+    hitIndices1_dev = (unsigned int*)cms::cuda::allocate_device(dev, size*sizeof(unsigned int), stream);
+    hitIndices2_dev = (unsigned int*)cms::cuda::allocate_device(dev, size*sizeof(unsigned int), stream);
+    hitIndices3_dev = (unsigned int*)cms::cuda::allocate_device(dev, size*sizeof(unsigned int), stream);
+    dPhiChange_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
+    ptIn_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
+    ptErr_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
+    px_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
+    py_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
+    pz_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
+    etaErr_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
+    eta_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
+    phi_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
+    superbin_dev = (int*)cms::cuda::allocate_device(dev, size*sizeof(int), stream);
+    pixelType_dev = (int8_t*)cms::cuda::allocate_device(dev, size*sizeof(int8_t), stream);
+    isQuad_dev = (short*)cms::cuda::allocate_device(dev, size*sizeof(short), stream);
 
     cudaMemcpyAsync(hitIndices0_dev,hitIndices0_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(hitIndices1_dev,hitIndices1_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(hitIndices2_dev,hitIndices2_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(hitIndices3_dev,hitIndices3_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(dPhiChange_dev,dPhiChange_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(ptIn_dev,ptIn_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(ptErr_dev,ptErr_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(px_dev,px_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(py_dev,py_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(pz_dev,pz_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(etaErr_dev,etaErr_host,size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(eta_dev, eta_host, size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
-    cudaMemcpyAsync(phi_dev, phi_host, size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(dPhiChange_dev,dPhiChange_host,size*sizeof(float),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(ptIn_dev,ptIn_host,size*sizeof(float),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(ptErr_dev,ptErr_host,size*sizeof(float),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(px_dev,px_host,size*sizeof(float),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(py_dev,py_host,size*sizeof(float),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(pz_dev,pz_host,size*sizeof(float),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(etaErr_dev,etaErr_host,size*sizeof(float),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(eta_dev, eta_host, size*sizeof(float),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(phi_dev, phi_host, size*sizeof(float),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(superbin_dev,superbin_host,size*sizeof(int),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(pixelType_dev,pixelType_host,size*sizeof(int8_t),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(isQuad_dev,isQuad_host,size*sizeof(short),cudaMemcpyHostToDevice,stream);
@@ -873,24 +872,23 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     //cudaFreeAsync(pixelType_dev,stream);
     //cudaFreeAsync(isQuad_dev,stream);
   
-    cudaFree(hitIndices0_dev);
-    cudaFree(hitIndices1_dev);
-    cudaFree(hitIndices2_dev);
-    cudaFree(hitIndices3_dev);
-    cudaFree(dPhiChange_dev);
-    cudaFree(ptIn_dev);
-    cudaFree(ptErr_dev);
-    cudaFree(px_dev);
-    cudaFree(py_dev);
-    cudaFree(pz_dev);
-    cudaFree(etaErr_dev);
-    cudaFree(eta_dev);
-    cudaFree(phi_dev);
-    cudaFree(superbin_dev);
-    cudaFree(pixelType_dev);
-    cudaFree(isQuad_dev);
-  
-cudaStreamSynchronize(stream);
+    cms::cuda::free_device(dev, hitIndices0_dev);
+    cms::cuda::free_device(dev, hitIndices1_dev);
+    cms::cuda::free_device(dev, hitIndices2_dev);
+    cms::cuda::free_device(dev, hitIndices3_dev);
+    cms::cuda::free_device(dev, dPhiChange_dev);
+    cms::cuda::free_device(dev, ptIn_dev);
+    cms::cuda::free_device(dev, ptErr_dev);
+    cms::cuda::free_device(dev, px_dev);
+    cms::cuda::free_device(dev, py_dev);
+    cms::cuda::free_device(dev, pz_dev);
+    cms::cuda::free_device(dev, etaErr_dev);
+    cms::cuda::free_device(dev, eta_dev);
+    cms::cuda::free_device(dev, phi_dev);
+    cms::cuda::free_device(dev, superbin_dev);
+    cms::cuda::free_device(dev, pixelType_dev);
+    cms::cuda::free_device(dev, isQuad_dev);
+    cudaStreamSynchronize(stream);
 }
 
 void SDL::Event::addMiniDoubletsToEvent()
@@ -1220,7 +1218,7 @@ void SDL::Event::createTriplets()
     unsigned int max_InnerSeg=0;
     uint16_t *index = (uint16_t*)malloc(nLowerModules*sizeof(unsigned int));
     uint16_t *index_gpu;
-    cudaMalloc((void **)&index_gpu, nLowerModules*sizeof(uint16_t));
+    index_gpu = (uint16_t*)cms::cuda::allocate_device(dev, nLowerModules*sizeof(uint16_t), stream);
     unsigned int *nSegments = (unsigned int*)malloc(nLowerModules*sizeof(unsigned int));
     cudaMemcpyAsync((void *)nSegments, segmentsInGPU->nSegments, nLowerModules*sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
     cudaStreamSynchronize(stream);
@@ -1271,7 +1269,7 @@ void SDL::Event::createTriplets()
     cudaStreamSynchronize(stream);
     free(nSegments);
     free(index);
-    cudaFree(index_gpu);
+    cms::cuda::free_device(dev, index_gpu);
 
 #if defined(AddObjects)
 #ifdef Explicit_Trips
@@ -1388,8 +1386,7 @@ void SDL::Event::createExtendedTracks()
 {
     if(trackExtensionsInGPU == nullptr)
     {
-        //trackExtensionsInGPU = (SDL::trackExtensions*)cms::cuda::allocate_host(sizeof(SDL::trackExtensions), stream);
-        cudaMallocHost(&trackExtensionsInGPU, sizeof(SDL::trackExtensions));
+        trackExtensionsInGPU = (SDL::trackExtensions*)cms::cuda::allocate_host(sizeof(SDL::trackExtensions), stream);
     }
 
     unsigned int nTrackCandidates;
@@ -1455,8 +1452,7 @@ void SDL::Event::createPixelTriplets()
 
     if(pixelTripletsInGPU == nullptr)
     {
-        //pixelTripletsInGPU = (SDL::pixelTriplets*)cms::cuda::allocate_host(sizeof(SDL::pixelTriplets), stream);
-        cudaMallocHost(&pixelTripletsInGPU, sizeof(SDL::pixelTriplets));
+        pixelTripletsInGPU = (SDL::pixelTriplets*)cms::cuda::allocate_host(sizeof(SDL::pixelTriplets), stream);
     }
 #ifdef Explicit_PT3
     createPixelTripletsInExplicitMemory(*pixelTripletsInGPU, N_MAX_PIXEL_TRIPLETS,stream);
@@ -1480,15 +1476,12 @@ void SDL::Event::createPixelTriplets()
 
     unsigned int* connectedPixelSize_host;
     unsigned int* connectedPixelIndex_host;
-    //cudaMallocHost(&connectedPixelSize_host, nInnerSegments* sizeof(unsigned int));
-    //cudaMallocHost(&connectedPixelIndex_host, nInnerSegments* sizeof(unsigned int));
     connectedPixelSize_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
     connectedPixelIndex_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
-
     unsigned int* connectedPixelSize_dev;
     unsigned int* connectedPixelIndex_dev;
-    cudaMalloc(&connectedPixelSize_dev, nInnerSegments* sizeof(unsigned int));
-    cudaMalloc(&connectedPixelIndex_dev, nInnerSegments* sizeof(unsigned int));
+    connectedPixelSize_dev = (unsigned int*)cms::cuda::allocate_device(dev, nInnerSegments*sizeof(unsigned int), stream);
+    connectedPixelIndex_dev = (unsigned int*)cms::cuda::allocate_device(dev, nInnerSegments*sizeof(unsigned int), stream);
 
     // unsigned int max_size =0;
     cudaStreamSynchronize(stream);
@@ -1534,8 +1527,6 @@ void SDL::Event::createPixelTriplets()
     cudaMemcpyAsync(connectedPixelIndex_dev, connectedPixelIndex_host, nInnerSegments*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
 
-    //cudaFreeHost(connectedPixelSize_host);
-    //cudaFreeHost(connectedPixelIndex_host);
     cms::cuda::free_host(connectedPixelSize_host);
     cms::cuda::free_host(connectedPixelIndex_host);
     cms::cuda::free_host(superbins);
@@ -1555,8 +1546,8 @@ void SDL::Event::createPixelTriplets()
     }
     cudaStreamSynchronize(stream);
     //}cudaDeviceSynchronize();
-    cudaFree(connectedPixelSize_dev);
-    cudaFree(connectedPixelIndex_dev);
+    cms::cuda::free_device(dev, connectedPixelSize_dev);
+    cms::cuda::free_device(dev, connectedPixelIndex_dev);
 
 
 #ifdef Warnings
@@ -1588,8 +1579,6 @@ cudaStreamSynchronize(stream);
 
     unsigned int maxTriplets;
 #ifdef CACHE_ALLOC
-        int dev;
-        cudaGetDevice(&dev);
         rangesInGPU->indicesOfEligibleT5Modules = (uint16_t*)cms::cuda::allocate_device(dev, nLowerModules * sizeof(uint16_t), stream);
 #else
         cudaMalloc(&(rangesInGPU->indicesOfEligibleT5Modules), nLowerModules * sizeof(uint16_t));
@@ -1712,15 +1701,10 @@ void SDL::Event::createPixelQuintuplets()
     pixelModuleIndex = nLowerModules;
     unsigned int nInnerSegments = 0;
     cudaMemcpyAsync(&nInnerSegments, &(segmentsInGPU->nSegments[pixelModuleIndex]), sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-
-    //cudaMallocHost(&connectedPixelSize_host, nInnerSegments* sizeof(unsigned int));
-    //cudaMallocHost(&connectedPixelIndex_host, nInnerSegments* sizeof(unsigned int));
     connectedPixelSize_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
     connectedPixelIndex_host = (unsigned int*)cms::cuda::allocate_host(nInnerSegments* sizeof(unsigned int), stream);
-    //connectedPixelSize_dev = (unsigned int*)cms::cuda::allocate_device(dev,nInnerSegments* sizeof(unsigned int),stream);
-    //connectedPixelSize_dev = (unsigned int*)cms::cuda::allocate_device(dev,nInnerSegments* sizeof(unsigned int),stream);
-    cudaMalloc(&connectedPixelSize_dev, nInnerSegments* sizeof(unsigned int));
-    cudaMalloc(&connectedPixelIndex_dev, nInnerSegments* sizeof(unsigned int));
+    connectedPixelSize_dev = (unsigned int*)cms::cuda::allocate_device(dev,nInnerSegments* sizeof(unsigned int),stream);
+    connectedPixelIndex_dev = (unsigned int*)cms::cuda::allocate_device(dev,nInnerSegments* sizeof(unsigned int),stream);
     cudaStreamSynchronize(stream);
 
     int pixelIndexOffsetPos = pixelMapping->connectedPixelsIndex[44999] + pixelMapping->connectedPixelsSizes[44999];
@@ -1775,12 +1759,10 @@ cudaStreamSynchronize(stream);
 
     }
     cudaStreamSynchronize(stream);
-    //cudaFreeHost(connectedPixelSize_host);
-    //cudaFreeHost(connectedPixelIndex_host);
     cms::cuda::free_host(connectedPixelSize_host);
     cms::cuda::free_host(connectedPixelIndex_host);
-    cudaFree(connectedPixelSize_dev);
-    cudaFree(connectedPixelIndex_dev);
+    cms::cuda::free_device(dev, connectedPixelSize_dev);
+    cms::cuda::free_device(dev, connectedPixelIndex_dev);
     cms::cuda::free_host(superbins);
     cms::cuda::free_host(pixelTypes);
     cms::cuda::free_host(nQuintuplets);

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -524,17 +524,19 @@ void SDL::Event::resetEvent()
 
 void SDL::initModules(const char* moduleMetaDataFilePath)
 {
+    cudaStream_t default_stream = 0;
     if(modulesInGPU == nullptr)
     {
-        //modulesInGPU = (SDL::modules*)cms::cuda::allocate_host(sizeof(struct SDL::modules), 0);
+        //modulesInGPU = (SDL::modules*)cms::cuda::allocate_host(sizeof(struct SDL::modules), default_stream);
         cudaMallocHost(&modulesInGPU, sizeof(struct SDL::modules));
         //pixelMapping = new pixelMap;
         cudaMallocHost(&pixelMapping, sizeof(struct SDL::pixelMap));
-        //pixelMapping = (SDL::pixelMap*)cms::cuda::allocate_host(sizeof(struct SDL::pixelMap), 0);
-        loadModulesFromFile(*modulesInGPU,nModules,nLowerModules, *pixelMapping, 0, moduleMetaDataFilePath); //nModules gets filled here
-        cudaStreamSynchronize(0);
+        //pixelMapping = (SDL::pixelMap*)cms::cuda::allocate_host(sizeof(struct SDL::pixelMap), default_stream);
+        //nModules gets filled here
+        loadModulesFromFile(*modulesInGPU,nModules,nLowerModules, *pixelMapping, default_stream, moduleMetaDataFilePath);
+        cudaStreamSynchronize(default_stream);
     }
-    //resetObjectRanges(*modulesInGPU,nModules,modStream);
+    //resetObjectRanges(*modulesInGPU,nModules, default_stream);
 }
 
 

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -10,7 +10,6 @@ SDL::Event::Event(cudaStream_t estream)
 {
     int version;
     int driver;
-    int dev;
     cudaRuntimeGetVersion(&version);
     cudaDriverGetVersion(&driver);
     //printf("version: %d Driver %d\n",version, driver);

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -54,6 +54,7 @@ namespace SDL
 
 
         //CUDA stuff
+        int dev;
         struct objectRanges* rangesInGPU;
         struct hits* hitsInGPU;
         struct miniDoublets* mdsInGPU;

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -287,7 +287,7 @@ void SDL::freeModulesCache(struct modules& modulesInGPU,struct pixelMap& pixelMa
   //cms::cuda::free_host(pixelMapping.connectedPixelsIndexPos);
   //cms::cuda::free_host(pixelMapping.connectedPixelsIndexNeg);
 }
-void SDL::freeModules(struct modules& modulesInGPU, struct pixelMap& pixelMapping,cudaStream_t stream)
+void SDL::freeModules(struct modules& modulesInGPU, struct pixelMap& pixelMapping)
 {
 
   cudaFree(modulesInGPU.detIds);

--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -152,7 +152,7 @@ namespace SDL
     void createLowerModuleIndexMapExplicit(struct modules& modulesInGPU, unsigned int nLowerModules, unsigned int nModules, bool* isLower,cudaStream_t stream);
     void createModulesInUnifiedMemory(struct modules& modulesInGPU,unsigned int nModules,cudaStream_t stream);
     void createModulesInExplicitMemory(struct modules& modulesInGPU,unsigned int nModules,cudaStream_t stream);
-    void freeModules(struct modules& modulesInGPU,struct pixelMap& pixelMapping,cudaStream_t stream);
+    void freeModules(struct modules& modulesInGPU,struct pixelMap& pixelMapping);
     void freeModulesCache(struct modules& modulesInGPU,struct pixelMap& pixelMapping);
     void fillPixelMap(struct modules& modulesInGPU,struct pixelMap& pixelMapping,cudaStream_t stream);
     void fillConnectedModuleArrayExplicit(struct modules& modulesInGPU, unsigned int nModules,cudaStream_t stream);

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -34,21 +34,21 @@ void SDL::createSegmentArrayRanges(struct modules& modulesInGPU, struct objectRa
         write code here that will deal with importing module parameters to CPU, and get the relevant occupancies for a given module!*/
 
     int *module_segmentModuleIndices;
-    module_segmentModuleIndices = (int*)cms::cuda::allocate_host((nLowerModules + 1) * sizeof(unsigned int), stream);
     short* module_subdets;
-    cudaMallocHost(&module_subdets, nLowerModules* sizeof(short));
-    cudaMemcpyAsync(module_subdets,modulesInGPU.subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     short* module_layers;
-    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
-    cudaMemcpyAsync(module_layers,modulesInGPU.layers,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
     short* module_rings;
-    cudaMallocHost(&module_rings, nLowerModules * sizeof(short));
-    cudaMemcpyAsync(module_rings,modulesInGPU.rings,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
     float* module_eta;
-    cudaMallocHost(&module_eta, nLowerModules * sizeof(float));
-    cudaMemcpyAsync(module_eta,modulesInGPU.eta,nLowerModules * sizeof(float),cudaMemcpyDeviceToHost,stream);
     uint16_t* module_nConnectedModules;
+    module_segmentModuleIndices = (int*)cms::cuda::allocate_host((nLowerModules + 1) * sizeof(unsigned int), stream);
+    module_subdets = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
+    module_layers = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
+    module_rings = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
+    module_eta = (float*)cms::cuda::allocate_host(nLowerModules* sizeof(float), stream);
     module_nConnectedModules = (uint16_t*)cms::cuda::allocate_host(nLowerModules * sizeof(uint16_t), stream);
+    cudaMemcpyAsync(module_subdets,modulesInGPU.subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
+    cudaMemcpyAsync(module_layers,modulesInGPU.layers,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
+    cudaMemcpyAsync(module_rings,modulesInGPU.rings,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
+    cudaMemcpyAsync(module_eta,modulesInGPU.eta,nLowerModules * sizeof(float),cudaMemcpyDeviceToHost,stream);
     cudaMemcpyAsync(module_nConnectedModules,modulesInGPU.nConnectedModules,nLowerModules*sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
  
     cudaStreamSynchronize(stream);
@@ -95,10 +95,10 @@ void SDL::createSegmentArrayRanges(struct modules& modulesInGPU, struct objectRa
     cudaStreamSynchronize(stream);
     cms::cuda::free_host(module_segmentModuleIndices);
     cms::cuda::free_host(module_nConnectedModules);
-    cudaFreeHost(module_subdets);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_rings);
-    cudaFreeHost(module_eta);
+    cms::cuda::free_host(module_subdets);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_rings);
+    cms::cuda::free_host(module_eta);
 }
 
 void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned int nMemoryLocations, uint16_t nLowerModules, unsigned int maxPixelSegments,cudaStream_t stream)

--- a/SDL/TrackCandidate.cu
+++ b/SDL/TrackCandidate.cu
@@ -62,7 +62,7 @@ void SDL::createTrackCandidatesInUnifiedMemory(struct trackCandidates& trackCand
     cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT3,0, sizeof(unsigned int),stream);
     cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT5,0, sizeof(unsigned int),stream);
     cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespLS,0, sizeof(unsigned int),stream);
-    cudaMemsetAsync(trackCandidatesInGPU.partOfExtension, false, maxTrackCandidates * sizeof(bool));
+    cudaMemsetAsync(trackCandidatesInGPU.partOfExtension, false, maxTrackCandidates * sizeof(bool), stream);
     cudaMemsetAsync(trackCandidatesInGPU.logicalLayers, 0, 7 * maxTrackCandidates * sizeof(uint8_t), stream);
     cudaMemsetAsync(trackCandidatesInGPU.lowerModuleIndices, 0, 7 * maxTrackCandidates * sizeof(uint16_t), stream);
     cudaMemsetAsync(trackCandidatesInGPU.hitIndices, 0, 14 * maxTrackCandidates * sizeof(unsigned int), stream);
@@ -106,12 +106,12 @@ void SDL::createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCan
     cudaMalloc(&trackCandidatesInGPU.centerY, maxTrackCandidates * sizeof(FPX));
     cudaMalloc(&trackCandidatesInGPU.radius , maxTrackCandidates * sizeof(FPX));
 #endif
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidates,0, sizeof(unsigned int));
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatesT5,0, sizeof(unsigned int));
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT3,0, sizeof(unsigned int));
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT5,0, sizeof(unsigned int));
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespLS,0, sizeof(unsigned int));
-    cudaMemsetAsync(trackCandidatesInGPU.partOfExtension, false, maxTrackCandidates * sizeof(bool));
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidates,0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatesT5,0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT3,0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT5,0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespLS,0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.partOfExtension, false, maxTrackCandidates * sizeof(bool), stream);
     cudaMemsetAsync(trackCandidatesInGPU.logicalLayers, 0, 7 * maxTrackCandidates * sizeof(uint8_t), stream);
     cudaMemsetAsync(trackCandidatesInGPU.lowerModuleIndices, 0, 7 * maxTrackCandidates * sizeof(uint16_t), stream);
     cudaMemsetAsync(trackCandidatesInGPU.hitIndices, 0, 14 * maxTrackCandidates * sizeof(unsigned int), stream);

--- a/SDL/TrackExtensions.cu
+++ b/SDL/TrackExtensions.cu
@@ -73,16 +73,16 @@ void SDL::trackExtensions::freeMemoryCache()
 
 void SDL::trackExtensions::resetMemory(unsigned int maxTrackExtensions, unsigned int nTrackCandidates, cudaStream_t stream)
 {
-    cudaMemsetAsync(constituentTCTypes, 0, sizeof(short) * 3 * maxTrackExtensions);
-    cudaMemsetAsync(constituentTCIndices, 0, sizeof(unsigned int) * 3 * maxTrackExtensions);
-    cudaMemsetAsync(nLayerOverlaps, 0, sizeof(uint8_t) * 2 * maxTrackExtensions);
-    cudaMemsetAsync(nHitOverlaps, 0, sizeof(uint8_t) * 2 * maxTrackExtensions);
-    cudaMemsetAsync(rPhiChiSquared, 0, sizeof(FPX) * maxTrackExtensions);
-    cudaMemsetAsync(rzChiSquared, 0, sizeof(FPX) * maxTrackExtensions);
-    cudaMemsetAsync(isDup, 0, sizeof(bool) * maxTrackExtensions);
-    cudaMemsetAsync(regressionRadius, 0, sizeof(FPX) * maxTrackExtensions);
-    cudaMemsetAsync(nTrackExtensions, 0, sizeof(unsigned int) * nTrackCandidates);
-    cudaMemsetAsync(totOccupancyTrackExtensions, 0, sizeof(unsigned int) * nTrackCandidates);
+    cudaMemsetAsync(constituentTCTypes, 0, sizeof(short) * 3 * maxTrackExtensions, stream);
+    cudaMemsetAsync(constituentTCIndices, 0, sizeof(unsigned int) * 3 * maxTrackExtensions, stream);
+    cudaMemsetAsync(nLayerOverlaps, 0, sizeof(uint8_t) * 2 * maxTrackExtensions, stream);
+    cudaMemsetAsync(nHitOverlaps, 0, sizeof(uint8_t) * 2 * maxTrackExtensions, stream);
+    cudaMemsetAsync(rPhiChiSquared, 0, sizeof(FPX) * maxTrackExtensions, stream);
+    cudaMemsetAsync(rzChiSquared, 0, sizeof(FPX) * maxTrackExtensions, stream);
+    cudaMemsetAsync(isDup, 0, sizeof(bool) * maxTrackExtensions, stream);
+    cudaMemsetAsync(regressionRadius, 0, sizeof(FPX) * maxTrackExtensions, stream);
+    cudaMemsetAsync(nTrackExtensions, 0, sizeof(unsigned int) * nTrackCandidates, stream);
+    cudaMemsetAsync(totOccupancyTrackExtensions, 0, sizeof(unsigned int) * nTrackCandidates, stream);
 }
 
 

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -12,8 +12,8 @@ void SDL::triplets::resetMemory(unsigned int maxTriplets, unsigned int nLowerMod
     cudaMemsetAsync(totOccupancyTriplets,0, nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(betaIn,0, maxTriplets * 3 * sizeof(FPX),stream);
     cudaMemsetAsync(partOfPT5,0, maxTriplets * sizeof(bool),stream);
-    cudaMemsetAsync(partOfT5,0, maxTriplets * sizeof(bool));
-    cudaMemsetAsync(partOfPT3, 0, maxTriplets * sizeof(bool));
+    cudaMemsetAsync(partOfT5,0, maxTriplets * sizeof(bool), stream);
+    cudaMemsetAsync(partOfPT3, 0, maxTriplets * sizeof(bool), stream);
 }
 
 void SDL::createTripletArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct segments& segmentsInGPU, uint16_t& nLowerModules, unsigned int& nTotalTriplets, cudaStream_t stream, const uint16_t& maxTripletsPerModule)

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -19,23 +19,21 @@ void SDL::triplets::resetMemory(unsigned int maxTriplets, unsigned int nLowerMod
 void SDL::createTripletArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct segments& segmentsInGPU, uint16_t& nLowerModules, unsigned int& nTotalTriplets, cudaStream_t stream, const uint16_t& maxTripletsPerModule)
 {
     int* module_tripletModuleIndices;
-    module_tripletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
-
     short* module_subdets;
-    cudaMallocHost(&module_subdets, nLowerModules* sizeof(short));
-    cudaMemcpyAsync(module_subdets,modulesInGPU.subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
     short* module_layers;
-    cudaMallocHost(&module_layers, nLowerModules * sizeof(short));
-    cudaMemcpyAsync(module_layers,modulesInGPU.layers,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
     short* module_rings;
-    cudaMallocHost(&module_rings, nLowerModules * sizeof(short));
-    cudaMemcpyAsync(module_rings,modulesInGPU.rings,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
     float* module_eta;
-    cudaMallocHost(&module_eta, nLowerModules * sizeof(float));
-    cudaMemcpyAsync(module_eta,modulesInGPU.eta,nLowerModules * sizeof(float),cudaMemcpyDeviceToHost,stream);
-
     unsigned int* nSegments;
+    module_tripletModuleIndices = (int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
+    module_subdets = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
+    module_layers = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
+    module_rings = (short*)cms::cuda::allocate_host(nLowerModules* sizeof(short), stream);
+    module_eta = (float*)cms::cuda::allocate_host(nLowerModules* sizeof(float), stream);
     nSegments = (unsigned int*)cms::cuda::allocate_host(nLowerModules * sizeof(unsigned int), stream);
+    cudaMemcpyAsync(module_subdets,modulesInGPU.subdets,nLowerModules*sizeof(short),cudaMemcpyDeviceToHost,stream);
+    cudaMemcpyAsync(module_layers,modulesInGPU.layers,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
+    cudaMemcpyAsync(module_rings,modulesInGPU.rings,nLowerModules * sizeof(short),cudaMemcpyDeviceToHost,stream);
+    cudaMemcpyAsync(module_eta,modulesInGPU.eta,nLowerModules * sizeof(float),cudaMemcpyDeviceToHost,stream);
     cudaMemcpyAsync(nSegments, segmentsInGPU.nSegments, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
     cudaStreamSynchronize(stream);
 
@@ -75,10 +73,10 @@ void SDL::createTripletArrayRanges(struct modules& modulesInGPU, struct objectRa
     cudaStreamSynchronize(stream);
     cms::cuda::free_host(module_tripletModuleIndices);
     cms::cuda::free_host(nSegments);
-    cudaFreeHost(module_subdets);
-    cudaFreeHost(module_layers);
-    cudaFreeHost(module_rings);
-    cudaFreeHost(module_eta);
+    cms::cuda::free_host(module_subdets);
+    cms::cuda::free_host(module_layers);
+    cms::cuda::free_host(module_rings);
+    cms::cuda::free_host(module_eta);
 }
 
 void SDL::createTripletsInUnifiedMemory(struct triplets& tripletsInGPU, unsigned int maxTriplets, uint16_t nLowerModules,cudaStream_t stream)


### PR DESCRIPTION
This PR removes an extra stream (called modStream) by moving code to the default stream (stream=0). I also specified the stream for a few memsets to avoid conflicts with other streams. This seems to have cleared up previous issues with the host and device allocators. I then moved over variables to the allocators that were previously causing errors. I will upload validation plots soon.

New Timing
![fix_time](https://user-images.githubusercontent.com/25272611/178091688-f41666fe-5b52-46ff-ab5b-ee47841e3527.png)

Current Master
![master](https://user-images.githubusercontent.com/25272611/178091699-70f0883f-425c-483f-9ca4-ecb2424d69da.png)