### PR TITLE
Explicit cut value ntuple

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -2449,9 +2449,7 @@ SDL::triplets* SDL::Event::getTriplets()
         tripletsInCPU->pt_beta = new FPX[*(tripletsInCPU->nMemoryLocations)];
         tripletsInCPU->hitIndices = new unsigned int[6 * *(tripletsInCPU->nMemoryLocations)];
         tripletsInCPU->logicalLayers = new uint8_t[3 * *(tripletsInCPU->nMemoryLocations)];
-        std::cout<<"rinkiya ke papa"<<std::endl;
 #ifdef CUT_VALUE_DEBUG
-        std::cout<<"memory locations created!"<<std::endl;
 
         tripletsInCPU->zOut = new float[4 * *(tripletsInCPU->nMemoryLocations)];
         tripletsInCPU->zLo = new float[*(tripletsInCPU->nMemoryLocations)];

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -153,6 +153,20 @@ SDL::Event::~Event()
         delete[] tripletsInCPU->logicalLayers;
         delete[] tripletsInCPU->lowerModuleIndices;
         delete tripletsInCPU->nMemoryLocations;
+#ifdef CUT_VALUE_DEBUG
+        delete[] tripletsInCPU->zOut;
+        delete[] tripletsInCPU->zLo;
+        delete[] tripletsInCPU->zHi;
+        delete[] tripletsInCPU->zLoPointed;
+        delete[] tripletsInCPU->zHiPointed;
+        delete[] tripletsInCPU->sdlCut;
+        delete[] tripletsInCPU->betaInCut;
+        delete[] tripletsInCPU->betaOutCut;
+        delete[] tripletsInCPU->deltaBetaCut;
+        delete[] tripletsInCPU->rtLo;
+        delete[] tripletsInCPU->rtHi;
+        delete[] tripletsInCPU->kZ;
+#endif
         delete tripletsInCPU;
     }
 #endif
@@ -167,6 +181,23 @@ SDL::Event::~Event()
         delete[] quintupletsInCPU->innerRadius;
         delete[] quintupletsInCPU->outerRadius;
         delete[] quintupletsInCPU->regressionRadius;
+#ifdef CUT_VALUE_DEBUG
+        delete[] quintupletsInCPU->innerRadiusMin;
+        delete[] quintupletsInCPU->innerRadiusMin2S;
+        delete[] quintupletsInCPU->innerRadiusMax;
+        delete[] quintupletsInCPU->innerRadiusMax2S;
+        delete[] quintupletsInCPU->bridgeRadius;
+        delete[] quintupletsInCPU->bridgeRadiusMin;
+        delete[] quintupletsInCPU->bridgeRadiusMin2S;
+        delete[] quintupletsInCPU->bridgeRadiusMax;
+        delete[] quintupletsInCPU->bridgeRadiusMax2S;
+        delete[] quintupletsInCPU->outerRadiusMin;
+        delete[] quintupletsInCPU->outerRadiusMin2S;
+        delete[] quintupletsInCPU->outerRadiusMax;
+        delete[] quintupletsInCPU->outerRadiusMax2S;
+        delete[] quintupletsInCPU->chiSquared;
+        delete[] quintupletsInCPU->nonAnchorChiSquared;
+#endif
         delete quintupletsInCPU;
     }
 #endif
@@ -181,6 +212,12 @@ SDL::Event::~Event()
         delete[] pixelTripletsInCPU->tripletRadius;
         delete pixelTripletsInCPU->nPixelTriplets;
         delete pixelTripletsInCPU->totOccupancyPixelTriplets;
+#ifdef CUT_VALUE_DEBUG
+        delete[] pixelTripletsInCPU->pixelRadiusError;
+        delete[] pixelTripletsInCPU->rzChiSquared;
+        delete[] pixelTripletsInCPU->rPhiChiSquared;
+        delete[] pixelTripletsInCPU->rPhiChiSquaredInwards;
+#endif
         delete pixelTripletsInCPU;
     }
 #endif
@@ -193,6 +230,11 @@ SDL::Event::~Event()
         delete[] pixelQuintupletsInCPU->score;
         delete pixelQuintupletsInCPU->nPixelQuintuplets;
         delete pixelQuintupletsInCPU->totOccupancyPixelQuintuplets;
+#ifdef CUT_VALUE_DEBUG
+        delete[] pixelQuintupletsInCPU->rzChiSquared;
+        delete[] pixelQuintupletsInCPU->rPhiChiSquared;
+        delete[] pixelQuintupletsInCPU->rPhiChiSquaredInwards;
+#endif
         delete pixelQuintupletsInCPU;
     }
 #endif
@@ -220,6 +262,12 @@ SDL::Event::~Event()
         delete[] trackExtensionsInCPU->nHitOverlaps;
         delete[] trackExtensionsInCPU->isDup;
         delete[] trackExtensionsInCPU->regressionRadius;
+#ifdef CUT_VALUE_DEBUG
+        delete[] trackExtensionsInCPU->rPhiChiSquared;
+        delete[] trackExtensionsInCPU->rzChiSquared;
+        delete[] trackExtensionsInCPU->innerRadius;
+        delete[] trackExtensionsInCPU->outerRadius;
+#endif
 
         delete trackExtensionsInCPU;
     }
@@ -633,7 +681,7 @@ __global__ void hitLoopKernel(
             hitsInGPU->lowEdgeYs[ihit] = ihit_y - 2.5f * sin_phi;
         }
         // Need to set initial value if index hasn't been seen before.
-        int old = atomicCAS(&hitsInGPU->hitRanges[lastModuleIndex * 2], -1, ihit);
+        int old = atomicCAS(&(hitsInGPU->hitRanges[lastModuleIndex * 2]), -1, ihit);
         // For subsequent visits, stores the min value.
         if (old != -1)
             atomicMin(&hitsInGPU->hitRanges[lastModuleIndex * 2], ihit);
@@ -680,7 +728,6 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
     cudaMemcpyAsync(hitsInGPU->idxs, &idxInNtuple[0], nHits*sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
     cudaMemcpyAsync(hitsInGPU->nHits, &nHits, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
     cudaStreamSynchronize(stream);
-
     // Calculate secondary variables on the GPU.
     hitLoopKernel<<<MAX_BLOCKS,256,0,stream>>>(
                                             Endcap,
@@ -711,13 +758,8 @@ __global__ void addPixelSegmentToEventKernel(unsigned int* hitIndices0,unsigned 
       unsigned int outerMDIndex = rangesInGPU.miniDoubletModuleIndices[pixelModuleIndex] + 2*(tid) +1;
       unsigned int pixelSegmentIndex = rangesInGPU.segmentModuleIndices[pixelModuleIndex] + tid;
 
-#ifdef CUT_VALUE_DEBUG
-      addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices0[tid], hitIndices1[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,0,0,0,0,innerMDIndex);
-      addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices2[tid], hitIndices3[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,0,0,0,0,outerMDIndex);
-#else
       addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices0[tid], hitIndices1[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,innerMDIndex);
       addMDToMemory(mdsInGPU, hitsInGPU, modulesInGPU, hitIndices2[tid], hitIndices3[tid], pixelModuleIndex, 0,0,0,0,0,0,0,0,0,outerMDIndex);
-#endif
 
     //in outer hits - pt, eta, phi
     float slope = sinhf(hitsInGPU.ys[mdsInGPU.outerHitIndices[innerMDIndex]]);
@@ -2407,6 +2449,40 @@ SDL::triplets* SDL::Event::getTriplets()
         tripletsInCPU->pt_beta = new FPX[*(tripletsInCPU->nMemoryLocations)];
         tripletsInCPU->hitIndices = new unsigned int[6 * *(tripletsInCPU->nMemoryLocations)];
         tripletsInCPU->logicalLayers = new uint8_t[3 * *(tripletsInCPU->nMemoryLocations)];
+        std::cout<<"rinkiya ke papa"<<std::endl;
+#ifdef CUT_VALUE_DEBUG
+        std::cout<<"memory locations created!"<<std::endl;
+
+        tripletsInCPU->zOut = new float[4 * *(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->zLo = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->zHi = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->zLoPointed = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->zHiPointed = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->sdlCut = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->betaInCut = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->betaOutCut = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->deltaBetaCut = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->rtLo = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->rtHi = new float[*(tripletsInCPU->nMemoryLocations)];
+        tripletsInCPU->kZ = new float[*(tripletsInCPU->nMemoryLocations)];
+
+        tripletsInCPU->rtOut = tripletsInCPU->zOut + *(tripletsInCPU->nMemoryLocations);
+        tripletsInCPU->deltaPhiPos = tripletsInCPU->zOut + 2 * *(tripletsInCPU->nMemoryLocations);
+        tripletsInCPU->deltaPhi = tripletsInCPU->zOut + 3 * *(tripletsInCPU->nMemoryLocations);
+
+        cudaMemcpyAsync(tripletsInCPU->zOut, tripletsInGPU->zOut, 4 * * (tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->zLo, tripletsInGPU->zLo, * (tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->zHi, tripletsInGPU->zHi, * (tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->zLoPointed, tripletsInGPU->zLoPointed, 4 * * (tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->zHiPointed, tripletsInGPU->zHiPointed, * (tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->sdlCut, tripletsInGPU->sdlCut, *(tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->betaInCut, tripletsInGPU->betaInCut,  * (tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->betaOutCut, tripletsInGPU->betaOutCut,  * (tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->deltaBetaCut, tripletsInGPU->deltaBetaCut, *(tripletsInCPU->nMemoryLocations)*sizeof(unsigned int), cudaMemcpyDeviceToHost);
+        cudaMemcpyAsync(tripletsInCPU->rtLo, tripletsInGPU->rtLo,  * (tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->rtHi, tripletsInGPU->rtHi,  * (tripletsInCPU->nMemoryLocations)* sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(tripletsInCPU->kZ, tripletsInGPU->kZ,  * (tripletsInCPU->nMemoryLocations) * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
+#endif
 
         cudaMemcpyAsync(tripletsInCPU->hitIndices, tripletsInGPU->hitIndices, 6 * *(tripletsInCPU->nMemoryLocations) * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
         cudaMemcpyAsync(tripletsInCPU->logicalLayers, tripletsInGPU->logicalLayers, 3 * *(tripletsInCPU->nMemoryLocations) * sizeof(uint8_t), cudaMemcpyDeviceToHost, stream);
@@ -2417,7 +2493,6 @@ SDL::triplets* SDL::Event::getTriplets()
         tripletsInCPU->totOccupancyTriplets = new unsigned int[nLowerModules];
         cudaMemcpyAsync(tripletsInCPU->nTriplets, tripletsInGPU->nTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(tripletsInCPU->totOccupancyTriplets, tripletsInGPU->totOccupancyTriplets, nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-
         cudaStreamSynchronize(stream);
     }
     return tripletsInCPU;
@@ -2455,6 +2530,37 @@ SDL::quintuplets* SDL::Event::getQuintuplets()
         quintupletsInCPU->eta = new FPX[nMemoryLocations];
         quintupletsInCPU->phi = new FPX[nMemoryLocations];
         quintupletsInCPU->regressionRadius = new float[nMemoryLocations];
+#ifdef CUT_VALUE_DEBUG
+        quintupletsInCPU->innerRadiusMin = new float[nMemoryLocations];
+        quintupletsInCPU->innerRadiusMin2S = new float[nMemoryLocations];
+        quintupletsInCPU->innerRadiusMax = new float[nMemoryLocations];
+        quintupletsInCPU->innerRadiusMax2S = new float[nMemoryLocations];
+        quintupletsInCPU->bridgeRadius = new float[nMemoryLocations];
+        quintupletsInCPU->bridgeRadiusMin = new float[nMemoryLocations];
+        quintupletsInCPU->bridgeRadiusMin2S = new float[nMemoryLocations];
+        quintupletsInCPU->bridgeRadiusMax = new float[nMemoryLocations];
+        quintupletsInCPU->bridgeRadiusMax2S = new float[nMemoryLocations];
+        quintupletsInCPU->outerRadiusMin = new float[nMemoryLocations];
+        quintupletsInCPU->outerRadiusMin2S = new float[nMemoryLocations];
+        quintupletsInCPU->outerRadiusMax = new float[nMemoryLocations];
+        quintupletsInCPU->outerRadiusMax2S = new float[nMemoryLocations];
+        quintupletsInCPU->chiSquared = new float[nMemoryLocations];
+        quintupletsInCPU->nonAnchorChiSquared = new float[nMemoryLocations];
+
+        cudaMemcpyAsync(quintupletsInCPU->innerRadiusMin, quintupletsInGPU->innerRadiusMin, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->innerRadiusMax, quintupletsInGPU->innerRadiusMax, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->bridgeRadius, quintupletsInGPU->bridgeRadius, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->bridgeRadiusMin, quintupletsInGPU->bridgeRadiusMin, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->bridgeRadiusMin2S, quintupletsInGPU->bridgeRadiusMin2S, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->bridgeRadiusMax, quintupletsInGPU->bridgeRadiusMax, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->bridgeRadiusMax2S, quintupletsInGPU->bridgeRadiusMax2S, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->outerRadiusMin, quintupletsInGPU->outerRadiusMin, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->outerRadiusMin2S, quintupletsInGPU->outerRadiusMin2S, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->outerRadiusMax, quintupletsInGPU->outerRadiusMax, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->outerRadiusMax2S, quintupletsInGPU->outerRadiusMax2S, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->chiSquared, quintupletsInGPU->chiSquared, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(quintupletsInCPU->nonAnchorChiSquared, quintupletsInGPU->nonAnchorChiSquared, nMemoryLocations * sizeof(float), cudaMemcpyDeviceToHost, stream);
+#endif
         cudaMemcpyAsync(quintupletsInCPU->nQuintuplets, quintupletsInGPU->nQuintuplets,  nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(quintupletsInCPU->totOccupancyQuintuplets, quintupletsInGPU->totOccupancyQuintuplets,  nLowerModules * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(quintupletsInCPU->tripletIndices, quintupletsInGPU->tripletIndices, 2 * nMemoryLocations * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
@@ -2499,6 +2605,17 @@ cudaStreamSynchronize(stream);
         pixelTripletsInCPU->eta = new  FPX[nPixelTriplets];
         pixelTripletsInCPU->phi = new  FPX[nPixelTriplets];
         pixelTripletsInCPU->score =new FPX[nPixelTriplets];
+#ifdef CUT_VALUE_DEBUG
+        pixelTripletsInCPU->pixelRadiusError = new float[nPixelTriplets];
+        pixelTripletsInCPU->rzChiSquared = new float[nPixelTriplets];
+        pixelTripletsInCPU->rPhiChiSquared = new float[nPixelTriplets];
+        pixelTripletsInCPU->rPhiChiSquaredInwards = new float[nPixelTriplets];
+
+        cudaMemcpyAsync(pixelTripletsInCPU->pixelRadiusError, pixelTripletsInGPU->pixelRadiusError, nPixelTriplets * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(pixelTripletsInCPU->rzChiSquared, pixelTripletsInGPU->rzChiSquared, nPixelTriplets * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(pixelTripletsInCPU->rPhiChiSquared, pixelTripletsInGPU->rPhiChiSquared, nPixelTriplets * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(pixelTripletsInCPU->rPhiChiSquaredInwards, pixelTripletsInGPU->rPhiChiSquaredInwards, nPixelTriplets * sizeof(float), cudaMemcpyDeviceToHost, stream);
+#endif
 
         cudaMemcpyAsync(pixelTripletsInCPU->tripletIndices, pixelTripletsInGPU->tripletIndices, nPixelTriplets * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(pixelTripletsInCPU->pixelSegmentIndices, pixelTripletsInGPU->pixelSegmentIndices, nPixelTriplets * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
@@ -2537,12 +2654,21 @@ cudaStreamSynchronize(stream);
         pixelQuintupletsInCPU->T5Indices = new unsigned int[nPixelQuintuplets];
         pixelQuintupletsInCPU->isDup = new bool[nPixelQuintuplets];
         pixelQuintupletsInCPU->score = new FPX[nPixelQuintuplets];
+#ifdef CUT_VALUE_DEBUG
+        pixelQuintupletsInCPU->rzChiSquared = new float[nPixelQuintuplets];
+        pixelQuintupletsInCPU->rPhiChiSquared = new float[nPixelQuintuplets];
+        pixelQuintupletsInCPU->rPhiChiSquaredInwards = new float[nPixelQuintuplets];
 
+        cudaMemcpyAsync(pixelQuintupletsInCPU->rzChiSquared, pixelQuintupletsInGPU->rzChiSquared, nPixelQuintuplets * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(pixelQuintupletsInCPU->rPhiChiSquared, pixelQuintupletsInGPU->rPhiChiSquared, nPixelQuintuplets * sizeof(float), cudaMemcpyDeviceToHost, stream);
+        cudaMemcpyAsync(pixelQuintupletsInCPU->rPhiChiSquaredInwards, pixelQuintupletsInGPU->rPhiChiSquaredInwards, nPixelQuintuplets * sizeof(float), cudaMemcpyDeviceToHost, stream);
+
+#endif
         cudaMemcpyAsync(pixelQuintupletsInCPU->pixelIndices, pixelQuintupletsInGPU->pixelIndices, nPixelQuintuplets * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(pixelQuintupletsInCPU->T5Indices, pixelQuintupletsInGPU->T5Indices, nPixelQuintuplets * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(pixelQuintupletsInCPU->isDup, pixelQuintupletsInGPU->isDup, nPixelQuintuplets * sizeof(bool), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(pixelQuintupletsInCPU->score, pixelQuintupletsInGPU->score, nPixelQuintuplets * sizeof(FPX), cudaMemcpyDeviceToHost,stream);
-cudaStreamSynchronize(stream);
+        cudaStreamSynchronize(stream);
     }
     return pixelQuintupletsInCPU;
 }
@@ -2654,6 +2780,7 @@ cudaStreamSynchronize(stream);
         modulesInCPU->sides = new short[nModules];
         modulesInCPU->eta = new float[nModules];
         modulesInCPU->r = new float[nModules];
+        modulesInCPU->moduleType = new ModuleType[nModules];
 
         cudaMemcpyAsync(modulesInCPU->nLowerModules, modulesInGPU->nLowerModules, sizeof(uint16_t), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(modulesInCPU->nModules, modulesInGPU->nModules, sizeof(uint16_t), cudaMemcpyDeviceToHost,stream);
@@ -2667,7 +2794,7 @@ cudaStreamSynchronize(stream);
         cudaMemcpyAsync(modulesInCPU->sides, modulesInGPU->sides, nModules * sizeof(short), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(modulesInCPU->eta, modulesInGPU->eta, nModules * sizeof(short), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(modulesInCPU->r, modulesInGPU->r, nModules * sizeof(short), cudaMemcpyDeviceToHost,stream);
-
+        cudaMemcpyAsync(modulesInCPU->moduleType, modulesInGPU->moduleType, nModules * sizeof(ModuleType), cudaMemcpyDeviceToHost, stream);
 cudaStreamSynchronize(stream);
     }
     return modulesInCPU;
@@ -2706,6 +2833,18 @@ SDL::trackExtensions* SDL::Event::getTrackExtensions()
        trackExtensionsInCPU->nHitOverlaps = new uint8_t[2 * maxTrackExtensions];
        trackExtensionsInCPU->isDup = new bool[maxTrackExtensions];
        trackExtensionsInCPU->regressionRadius = new FPX[maxTrackExtensions];
+#ifdef CUT_VALUE_DEBUG
+       trackExtensionsInCPU->rPhiChiSquared = new FPX[maxTrackExtensions];
+       trackExtensionsInCPU->rzChiSquared = new FPX[maxTrackExtensions];
+       trackExtensionsInCPU->innerRadius = new float[maxTrackExtensions];
+       trackExtensionsInCPU->outerRadius = new float[maxTrackExtensions];
+       
+       cudaMemcpyAsync(trackExtensionsInCPU->rPhiChiSquared, trackExtensionsInGPU->rPhiChiSquared, maxTrackExtensions * sizeof(FPX), cudaMemcpyDeviceToHost, stream);
+       cudaMemcpyAsync(trackExtensionsInCPU->rzChiSquared, trackExtensionsInGPU->rzChiSquared, maxTrackExtensions * sizeof(FPX), cudaMemcpyDeviceToHost, stream);
+       cudaMemcpyAsync(trackExtensionsInCPU->innerRadius, trackExtensionsInGPU->innerRadius, maxTrackExtensions * sizeof(float), cudaMemcpyDeviceToHost, stream);
+       cudaMemcpyAsync(trackExtensionsInCPU->outerRadius, trackExtensionsInGPU->outerRadius, maxTrackExtensions * sizeof(float), cudaMemcpyDeviceToHost, stream);
+
+#endif
 
        cudaMemcpyAsync(trackExtensionsInCPU->nTrackExtensions, trackExtensionsInGPU->nTrackExtensions, nTrackCandidates * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);
        cudaMemcpyAsync(trackExtensionsInCPU->totOccupancyTrackExtensions, trackExtensionsInGPU->totOccupancyTrackExtensions, nTrackCandidates * sizeof(unsigned int), cudaMemcpyDeviceToHost, stream);

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -63,6 +63,12 @@ explicit_cache: MEMFLAG += $(MEMFLAG_FLAGS)
 explicit_cache: CACHEFLAG += $(CACHEFLAG_FLAGS)
 explicit_cache: $(LIB)
 
+explicit_cache_cutvalue: CUTVALUEFLAG = $(CUTVALUEFLAG_FLAGS)
+explicit_cache_cutvalue: MEMFLAG += $(MEMFLAG_FLAGS)
+explicit_cache_cutvalue: CACHEFLAG += $(CACHEFLAG_FLAGS)
+explicit_cache_cutvalue: $(LIB)
+
+
 all: unified
 
 clean:

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -96,12 +96,8 @@ namespace SDL
     void createMDArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, uint16_t& nLowerModules, unsigned int& nTotalMDs, cudaStream_t stream, const unsigned int& maxMDsPerModule, const unsigned int& maxPixelMDs);
 
 
-#ifdef CUT_VALUE_DEBUG
-    CUDA_HOSTDEV void addMDToMemory(struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int lowerHitIdx, unsigned int upperHitIdx, uint16_t& lowerModuleIdx, float dz, float drt, float dPhi, float dPhiChange, float shiftedX, float shiftedY, float shiftedZ, float noShiftedDz, float noShiftedDphi, float noShiftedDPhiChange, float dzCut, float drtCut, float miniCut, unsigned int idx);
-#else
     //for successful MDs
     CUDA_HOSTDEV void addMDToMemory(struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int lowerHitIdx, unsigned int upperHitIdx, uint16_t& lowerModuleIdx, float dz, float dPhi, float dPhiChange, float shiftedX, float shiftedY, float shiftedZ, float noShiftedDz, float noShiftedDphi, float noShiftedDPhiChange, unsigned int idx);
-#endif
 
     //CUDA_DEV float dPhiThreshold(struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int hitIndex, unsigned int moduleIndex, float dPhi = 0, float dz = 0);
     CUDA_DEV extern inline float dPhiThreshold(float rt, struct modules& modulesInGPU, uint16_t&  moduleIndex, float dPhi = 0, float dz = 0);

--- a/SDL/PixelTriplet.cu
+++ b/SDL/PixelTriplet.cu
@@ -50,6 +50,12 @@ void SDL::pixelTriplets::freeMemoryCache()
     cms::cuda::free_device(dev, hitIndices);
     cms::cuda::free_device(dev, logicalLayers);
     cms::cuda::free_device(dev, lowerModuleIndices);
+#ifdef CUT_VALUE_DEBUG
+    cms::cuda::free_device(dev, pixelRadiusError);
+    cms::cuda::free_device(dev, rPhiChiSquared);
+    cms::cuda::free_device(dev, rPhiChiSquaredInwards);
+    cms::cuda::free_device(dev, rzChiSquared);
+#endif
 #else
     cms::cuda::free_managed(pixelSegmentIndices);
     cms::cuda::free_managed(tripletIndices);
@@ -182,6 +188,13 @@ void SDL::createPixelTripletsInExplicitMemory(struct pixelTriplets& pixelTriplet
     pixelTripletsInGPU.lowerModuleIndices        = (uint16_t*)cms::cuda::allocate_device(dev, maxPixelTriplets * sizeof(uint16_t) * 5, stream);
     pixelTripletsInGPU.hitIndices                = (unsigned int*)cms::cuda::allocate_device(dev, maxPixelTriplets * sizeof(unsigned int) * 10, stream);
     pixelTripletsInGPU.logicalLayers             = (uint8_t*)cms::cuda::allocate_device(dev, maxPixelTriplets * sizeof(uint8_t) * 5, stream);
+
+#ifdef CUT_VALUE_DEBUG
+    pixelTripletsInGPU.pixelRadiusError = (float*)cms::cuda::allocate_device(dev, maxPixelTriplets * sizeof(float), stream);
+    pixelTripletsInGPU.rPhiChiSquared = (float*)cms::cuda::allocate_device(dev, maxPixelTriplets * sizeof(float), stream);
+    pixelTripletsInGPU.rPhiChiSquaredInwards = (float*)cms::cuda::allocate_device(dev, maxPixelTriplets * sizeof(float), stream);
+    pixelTripletsInGPU.rzChiSquared = (float*)cms::cuda::allocate_device(dev, maxPixelTriplets * sizeof(float), stream);
+#endif
 #else
     cudaMalloc(&pixelTripletsInGPU.pixelSegmentIndices, maxPixelTriplets * sizeof(unsigned int));
     cudaMalloc(&pixelTripletsInGPU.tripletIndices, maxPixelTriplets * sizeof(unsigned int));
@@ -197,6 +210,13 @@ void SDL::createPixelTripletsInExplicitMemory(struct pixelTriplets& pixelTriplet
     cudaMalloc(&pixelTripletsInGPU.logicalLayers, maxPixelTriplets * sizeof(uint8_t) * 5);
     cudaMalloc(&pixelTripletsInGPU.hitIndices, maxPixelTriplets * sizeof(unsigned int) * 10);
     cudaMalloc(&pixelTripletsInGPU.lowerModuleIndices, maxPixelTriplets * sizeof(uint16_t) * 5);
+
+#ifdef CUT_VALUE_DEBUG
+    cudaMalloc(&pixelTripletsInGPU.pixelRadiusError, maxPixelTriplets * sizeof(float));
+    cudaMalloc(&pixelTripletsInGPU.rPhiChiSquared, maxPixelTriplets * sizeof(float));
+    cudaMalloc(&pixelTripletsInGPU.rPhiChiSquaredInwards, maxPixelTriplets * sizeof(float));
+    cudaMalloc(&pixelTripletsInGPU.rzChiSquared, maxPixelTriplets * sizeof(float));
+#endif
 #endif
     cudaMemsetAsync(pixelTripletsInGPU.nPixelTriplets, 0, sizeof(unsigned int),stream);
     cudaMemsetAsync(pixelTripletsInGPU.totOccupancyPixelTriplets, 0, sizeof(unsigned int),stream);
@@ -1553,6 +1573,12 @@ void SDL::pixelQuintuplets::freeMemoryCache()
     cms::cuda::free_device(dev, centerY);
     cms::cuda::free_device(dev, pixelRadius);
     cms::cuda::free_device(dev, quintupletRadius);
+#ifdef CUT_VALUE_DEBUG
+    cms::cuda::free_device(dev, rzChiSquared);
+    cms::cuda::free_device(dev, rPhiChiSquared);
+    cms::cuda::free_device(dev, rPhiChiSquaredInwards);
+#endif
+
 #else
     cms::cuda::free_managed(pixelIndices);
     cms::cuda::free_managed(T5Indices);
@@ -1657,7 +1683,6 @@ void SDL::createPixelQuintupletsInUnifiedMemory(struct SDL::pixelQuintuplets& pi
     cudaMallocManaged(&pixelQuintupletsInGPU.rPhiChiSquaredInwards, maxPixelQuintuplets * sizeof(unsigned int));
 #endif
 #endif
-
     cudaMemsetAsync(pixelQuintupletsInGPU.nPixelQuintuplets, 0, sizeof(unsigned int),stream);
     cudaMemsetAsync(pixelQuintupletsInGPU.totOccupancyPixelQuintuplets, 0, sizeof(unsigned int),stream);
   cudaStreamSynchronize(stream);
@@ -1684,6 +1709,12 @@ void SDL::createPixelQuintupletsInExplicitMemory(struct SDL::pixelQuintuplets& p
     pixelQuintupletsInGPU.centerY          = (FPX*)cms::cuda::allocate_device(dev, maxPixelQuintuplets * sizeof(FPX), stream);
     pixelQuintupletsInGPU.pixelRadius      = (FPX*)cms::cuda::allocate_device(dev, maxPixelQuintuplets * sizeof(FPX), stream);
     pixelQuintupletsInGPU.quintupletRadius = (FPX*)cms::cuda::allocate_device(dev, maxPixelQuintuplets * sizeof(FPX), stream);
+#ifdef CUT_VALUE_DEBUG
+     pixelQuintupletsInGPU.rzChiSquared          = (float*)cms::cuda::allocate_device(dev, maxPixelQuintuplets * sizeof(float), stream);
+    pixelQuintupletsInGPU.rPhiChiSquared      = (float*)cms::cuda::allocate_device(dev, maxPixelQuintuplets * sizeof(float), stream);
+    pixelQuintupletsInGPU.rPhiChiSquaredInwards = (float*)cms::cuda::allocate_device(dev, maxPixelQuintuplets * sizeof(float), stream);
+   
+#endif
 #else
     cudaMalloc(&pixelQuintupletsInGPU.pixelIndices, maxPixelQuintuplets * sizeof(unsigned int));
     cudaMalloc(&pixelQuintupletsInGPU.T5Indices, maxPixelQuintuplets * sizeof(unsigned int));
@@ -1701,6 +1732,11 @@ void SDL::createPixelQuintupletsInExplicitMemory(struct SDL::pixelQuintuplets& p
     cudaMalloc(&pixelQuintupletsInGPU.quintupletRadius, maxPixelQuintuplets * sizeof(FPX));
     cudaMalloc(&pixelQuintupletsInGPU.centerX, maxPixelQuintuplets * sizeof(FPX));
     cudaMalloc(&pixelQuintupletsInGPU.centerY, maxPixelQuintuplets * sizeof(FPX));
+#ifdef CUT_VALUE_DEBUG
+    cudaMalloc(&pixelQuintupletsInGPU.rzChiSquared, maxPixelQuintuplets * sizeof(unsigned int));
+    cudaMalloc(&pixelQuintupletsInGPU.rPhiChiSquared, maxPixelQuintuplets * sizeof(unsigned int));
+    cudaMalloc(&pixelQuintupletsInGPU.rPhiChiSquaredInwards, maxPixelQuintuplets * sizeof(unsigned int));
+#endif
 #endif
     cudaMemsetAsync(pixelQuintupletsInGPU.nPixelQuintuplets, 0, sizeof(unsigned int),stream);
     cudaMemsetAsync(pixelQuintupletsInGPU.totOccupancyPixelQuintuplets, 0, sizeof(unsigned int),stream);
@@ -1979,8 +2015,6 @@ __device__ bool SDL::passPT5RPhiChiSquaredCuts(struct modules& modulesInGPU, uin
     }
     return true;
 }
-
-
 
 __device__ bool SDL::passPT5RPhiChiSquaredInwardsCuts(struct modules& modulesInGPU, uint16_t& lowerModuleIndex1, uint16_t& lowerModuleIndex2, uint16_t& lowerModuleIndex3, uint16_t& lowerModuleIndex4, uint16_t& lowerModuleIndex5, float rPhiChiSquared)
 {

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -230,6 +230,7 @@ void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsI
     cudaMallocManaged(&quintupletsInGPU.logicalLayers, nTotalQuintuplets * sizeof(uint8_t) * 5);
     cudaMallocManaged(&quintupletsInGPU.hitIndices, nTotalQuintuplets * sizeof(unsigned int) * 10);
     cudaMallocManaged(&quintupletsInGPU.nMemoryLocations, sizeof(unsigned int));
+
 #ifdef CUT_VALUE_DEBUG
     cudaMallocManaged(&quintupletsInGPU.innerRadiusMin, nTotalQuintuplets * sizeof(float));
     cudaMallocManaged(&quintupletsInGPU.innerRadiusMax, nTotalQuintuplets * sizeof(float));
@@ -246,8 +247,8 @@ void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsI
     cudaMallocManaged(&quintupletsInGPU.outerRadiusMax2S, nTotalQuintuplets * sizeof(float));
     cudaMallocManaged(&quintupletsInGPU.chiSquared, nTotalQuintuplets * sizeof(float));
     cudaMallocManaged(&quintupletsInGPU.nonAnchorChiSquared, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.nMemoryLocations, sizeof(unsigned int));
 #endif
+
 #endif
     quintupletsInGPU.eta = quintupletsInGPU.pt + nTotalQuintuplets;
     quintupletsInGPU.phi = quintupletsInGPU.pt + 2*nTotalQuintuplets;
@@ -292,6 +293,24 @@ void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintuplets
     quintupletsInGPU.hitIndices = (unsigned int*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(unsigned int) * 10, stream);
     quintupletsInGPU.nMemoryLocations = (unsigned int*)cms::cuda::allocate_device(dev, sizeof(unsigned int), stream);
 
+#ifdef CUT_VALUE_DEBUG
+    quintupletsInGPU.innerRadiusMin = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.innerRadiusMax = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.bridgeRadius = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.bridgeRadiusMin = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.bridgeRadiusMax = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.outerRadiusMin = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.outerRadiusMax = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.innerRadiusMin2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.innerRadiusMax2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.bridgeRadiusMin2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.bridgeRadiusMax2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+     quintupletsInGPU.outerRadiusMin2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.outerRadiusMax2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+
+    quintupletsInGPU.chiSquared = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.nonAnchorChiSquared = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+#endif
 #else
     cudaMalloc(&quintupletsInGPU.tripletIndices, 2 * nTotalQuintuplets * sizeof(unsigned int));
     cudaMalloc(&quintupletsInGPU.lowerModuleIndices, 5 * nTotalQuintuplets * sizeof(uint16_t));
@@ -309,6 +328,25 @@ void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintuplets
     cudaMalloc(&quintupletsInGPU.logicalLayers, nTotalQuintuplets * 5 * sizeof(uint8_t));
     cudaMalloc(&quintupletsInGPU.hitIndices, nTotalQuintuplets * 10 * sizeof(unsigned int));
     cudaMalloc(&quintupletsInGPU.nMemoryLocations, sizeof(unsigned int));
+
+#ifdef CUT_VALUE_DEBUG
+    cudaMalloc(&quintupletsInGPU.innerRadiusMin, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.innerRadiusMax, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.bridgeRadius, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.bridgeRadiusMin, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.bridgeRadiusMax, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.outerRadiusMin, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.outerRadiusMax, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.innerRadiusMin2S, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.innerRadiusMax2S, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.bridgeRadiusMin2S, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.bridgeRadiusMax2S, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.outerRadiusMin2S, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.outerRadiusMax2S, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.chiSquared, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.nonAnchorChiSquared, nTotalQuintuplets * sizeof(float));
+    cudaMalloc(&quintupletsInGPU.nMemoryLocations, sizeof(unsigned int));
+#endif
 #endif
     cudaMemsetAsync(quintupletsInGPU.nQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(quintupletsInGPU.totOccupancyQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
@@ -366,13 +404,13 @@ __device__ void SDL::addQuintupletToMemory(struct SDL::triplets& tripletsInGPU, 
     quintupletsInGPU.hitIndices[10 * quintupletIndex + 8] = tripletsInGPU.hitIndices[6 * outerTripletIndex + 4];
     quintupletsInGPU.hitIndices[10 * quintupletIndex + 9] = tripletsInGPU.hitIndices[6 * outerTripletIndex + 5];
 #ifdef CUT_VALUE_DEBUG
-    quintupletsInGPU.innerRadiusMin[quintupletIndex] = 1.0/innerInvRadiusMin;
-    quintupletsInGPU.innerRadiusMax[quintupletIndex] = 1.0/innerInvRadiusMax;
-    quintupletsInGPU.outerRadiusMin[quintupletIndex] = 1.0/outerInvRadiusMin;
-    quintupletsInGPU.outerRadiusMax[quintupletIndex] = 1.0/outerInvRadiusMax;
+    quintupletsInGPU.innerRadiusMin[quintupletIndex] = innerRadiusMin;
+    quintupletsInGPU.innerRadiusMax[quintupletIndex] = innerRadiusMax;
+    quintupletsInGPU.outerRadiusMin[quintupletIndex] = outerRadiusMin;
+    quintupletsInGPU.outerRadiusMax[quintupletIndex] = outerRadiusMax;
     quintupletsInGPU.bridgeRadius[quintupletIndex] = bridgeRadius;
-    quintupletsInGPU.bridgeRadiusMin[quintupletIndex] = 1.0/bridgeInvRadiusMin;
-    quintupletsInGPU.bridgeRadiusMax[quintupletIndex] = 1.0/bridgeInvRadiusMax;
+    quintupletsInGPU.bridgeRadiusMin[quintupletIndex] = bridgeRadiusMin;
+    quintupletsInGPU.bridgeRadiusMax[quintupletIndex] = bridgeRadiusMax;
     quintupletsInGPU.innerRadiusMin2S[quintupletIndex] = innerRadiusMin2S;
     quintupletsInGPU.innerRadiusMax2S[quintupletIndex] = innerRadiusMax2S;
     quintupletsInGPU.bridgeRadiusMin2S[quintupletIndex] = bridgeRadiusMin2S;

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -305,7 +305,7 @@ void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintuplets
     quintupletsInGPU.innerRadiusMax2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
     quintupletsInGPU.bridgeRadiusMin2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
     quintupletsInGPU.bridgeRadiusMax2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
-     quintupletsInGPU.outerRadiusMin2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
+    quintupletsInGPU.outerRadiusMin2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
     quintupletsInGPU.outerRadiusMax2S = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);
 
     quintupletsInGPU.chiSquared = (float*)cms::cuda::allocate_device(dev, nTotalQuintuplets * sizeof(float), stream);

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -67,6 +67,23 @@ void SDL::quintuplets::freeMemoryCache()
     cms::cuda::free_device(dev, logicalLayers);
     cms::cuda::free_device(dev, hitIndices);
     cms::cuda::free_device(dev, nMemoryLocations);
+#ifdef CUT_VALUE_DEBUG
+    cms::cuda::free_device(dev, innerRadiusMin);
+    cms::cuda::free_device(dev, innerRadiusMax);
+    cms::cuda::free_device(dev, bridgeRadius);
+    cms::cuda::free_device(dev, bridgeRadiusMin);
+    cms::cuda::free_device(dev, bridgeRadiusMax);
+    cms::cuda::free_device(dev, outerRadiusMin);
+    cms::cuda::free_device(dev, outerRadiusMax);
+    cms::cuda::free_device(dev, innerRadiusMin2S);
+    cms::cuda::free_device(dev, innerRadiusMax2S);
+    cms::cuda::free_device(dev, bridgeRadiusMin2S);
+    cms::cuda::free_device(dev, bridgeRadiusMax2S);
+    cms::cuda::free_device(dev, outerRadiusMin2S);
+    cms::cuda::free_device(dev, outerRadiusMax2S);
+    cms::cuda::free_device(dev, chiSquared);
+    cms::cuda::free_device(dev, nonAnchorChiSquared);
+#endif
 #else
     cms::cuda::free_managed(tripletIndices);
     cms::cuda::free_managed(lowerModuleIndices);

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -142,25 +142,6 @@ void SDL::createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned
     cudaMallocManaged(&segmentsInGPU.partOfPT5, maxPixelSegments * sizeof(bool));
     cudaMallocManaged(&segmentsInGPU.pLSHitsIdxs, maxPixelSegments * sizeof(uint4));
     cudaMallocManaged(&segmentsInGPU.nMemoryLocations, sizeof(unsigned int));
-#ifdef CUT_VALUE_DEBUG
-    cudaMallocManaged(&segmentsInGPU.zIns, nMemoryLocations * 7 * sizeof(float));
-    cudaMallocManaged(&segmentsInGPU.zLo, nMemoryLocations * sizeof(float));
-    cudaMallocManaged(&segmentsInGPU.zHi, nMemoryLocations * sizeof(float));
-    cudaMallocManaged(&segmentsInGPU.rtLo, nMemoryLocations * sizeof(float));
-    cudaMallocManaged(&segmentsInGPU.rtHi, nMemoryLocations * sizeof(float));
-    cudaMallocManaged(&segmentsInGPU.sdCut, nMemoryLocations * sizeof(float));
-    cudaMallocManaged(&segmentsInGPU.dAlphaInnerMDSegmentThreshold, nMemoryLocations * sizeof(float));
-    cudaMallocManaged(&segmentsInGPU.dAlphaOuterMDSegmentThreshold, nMemoryLocations * sizeof(float));
-    cudaMallocManaged(&segmentsInGPU.dAlphaInnerMDOuterMDThreshold, nMemoryLocations * sizeof(float));
-
-    segmentsInGPU.zOuts = segmentsInGPU.zIns + nMemoryLocations;
-    segmentsInGPU.rtIns = segmentsInGPU.zIns + nMemoryLocations * 2;
-    segmentsInGPU.rtOuts = segmentsInGPU.zIns + nMemoryLocations * 3;
-    segmentsInGPU.dAlphaInnerMDSegments = segmentsInGPU.zIns + nMemoryLocations * 4;
-    segmentsInGPU.dAlphaOuterMDSegments = segmentsInGPU.zIns + nMemoryLocations * 5;
-    segmentsInGPU.dAlphaInnerMDOuterMDs = segmentsInGPU.zIns + nMemoryLocations * 6;
-
-#endif
 #endif
     //segmentsInGPU.innerLowerModuleIndices = segmentsInGPU.mdIndices + nMemoryLocations * 2;
     segmentsInGPU.outerLowerModuleIndices = segmentsInGPU.innerLowerModuleIndices + nMemoryLocations;
@@ -288,24 +269,6 @@ SDL::segments::segments()
     partOfPT5 = nullptr;
     pLSHitsIdxs = nullptr;
 
-#ifdef CUT_VALUE_DEBUG
-    zIns = nullptr;
-    zOuts = nullptr;
-    rtIns = nullptr;
-    rtOuts = nullptr;
-    dAlphaInnerMDSegments = nullptr;
-    dAlphaOuterMDSegments = nullptr;
-    dAlphaInnerMDOuterMDs = nullptr;
-
-    zLo = nullptr;
-    zHi = nullptr;
-    rtLo = nullptr;
-    rtHi = nullptr;
-    sdCut = nullptr;
-    dAlphaInnerMDSegmentThreshold = nullptr;
-    dAlphaOuterMDSegmentThreshold = nullptr;
-    dAlphaInnerMDOuterMDThreshold = nullptr;
-#endif
 }
 
 SDL::segments::~segments()
@@ -373,26 +336,10 @@ void SDL::segments::freeMemory(cudaStream_t stream)
     cudaFree(partOfPT5);
     cudaFree(pLSHitsIdxs);
     cudaFree(nMemoryLocations);
-#ifdef CUT_VALUE_DEBUG
-    cudaFree(zIns);
-    cudaFree(zLo);
-    cudaFree(zHi);
-    cudaFree(rtLo);
-    cudaFree(rtHi);
-    cudaFree(sdCut);
-    cudaFree(dAlphaInnerMDSegmentThreshold);
-    cudaFree(dAlphaOuterMDSegmentThreshold);
-    cudaFree(dAlphaInnerMDOuterMDThreshold);
-#endif
 }
 
 
-#ifdef CUT_VALUE_DEBUG
-__device__ void SDL::addSegmentToMemory(struct segments& segmentsInGPU, unsigned int lowerMDIndex, unsigned int upperMDIndex, uint16_t innerLowerModuleIndex, uint16_t outerLowerModuleIndex, unsigned int innerMDAnchorHitIndex, unsigned int outerMDAnchorHitIndex, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float&
-        dAlphaInnerMDOuterMD, float& zLo, float& zHi, float& rtLo, float& rtHi, float& sdCut, float& dAlphaInnerMDSegmentThreshold, float& dAlphaOuterMDSegmentThreshold, float& dAlphaInnerMDOuterMDThreshold, unsigned int idx)
-#else
 __device__ void SDL::addSegmentToMemory(struct segments& segmentsInGPU, unsigned int lowerMDIndex, unsigned int upperMDIndex, uint16_t innerLowerModuleIndex, uint16_t outerLowerModuleIndex, unsigned int innerMDAnchorHitIndex, unsigned int outerMDAnchorHitIndex, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, unsigned int idx)
-#endif
 {
     //idx will be computed in the kernel, which is the index into which the 
     //segment will be written
@@ -412,24 +359,6 @@ __device__ void SDL::addSegmentToMemory(struct segments& segmentsInGPU, unsigned
     segmentsInGPU.dPhiChangeMins[idx] = __F2H(dPhiChangeMin);
     segmentsInGPU.dPhiChangeMaxs[idx] = __F2H(dPhiChangeMax);
 
-#ifdef CUT_VALUE_DEBUG
-    segmentsInGPU.zIns[idx] = zIn;
-    segmentsInGPU.zOuts[idx] = zOut;
-    segmentsInGPU.rtIns[idx] = rtIn;
-    segmentsInGPU.rtOuts[idx] = rtOut;
-    segmentsInGPU.dAlphaInnerMDSegments[idx] = dAlphaInnerMDSegment;
-    segmentsInGPU.dAlphaOuterMDSegments[idx] = dAlphaOuterMDSegment;
-    segmentsInGPU.dAlphaInnerMDOuterMDs[idx] = dAlphaInnerMDOuterMD;
-
-    segmentsInGPU.zLo[idx] = zLo;
-    segmentsInGPU.zHi[idx] = zHi;
-    segmentsInGPU.rtLo[idx] = rtLo;
-    segmentsInGPU.rtHi[idx] = rtHi;
-    segmentsInGPU.sdCut[idx] = sdCut;
-    segmentsInGPU.dAlphaInnerMDSegmentThreshold[idx] = dAlphaInnerMDSegmentThreshold;
-    segmentsInGPU.dAlphaOuterMDSegmentThreshold[idx] = dAlphaOuterMDSegmentThreshold;
-    segmentsInGPU.dAlphaInnerMDOuterMDThreshold[idx] = dAlphaInnerMDOuterMDThreshold;
-#endif
 }
 
 __device__ void SDL::addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, uint16_t pixelModuleIndex, unsigned int hitIdxs[4], unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, float eta, float phi, unsigned int idx, unsigned int pixelSegmentArrayIndex, int superbin,
@@ -1017,12 +946,7 @@ __global__ void SDL::createSegmentsInGPUv2(struct SDL::modules& modulesInGPU, st
                     unsigned int segmentModuleIdx = atomicAdd(&segmentsInGPU.nSegments[innerLowerModuleIndex],1);
                     unsigned int segmentIdx = rangesInGPU.segmentModuleIndices[innerLowerModuleIndex] + segmentModuleIdx;
 
-#ifdef CUT_VALUE_DEBUG
-                    addSegmentToMemory(segmentsInGPU,innerMDIndex, outerMDIndex,innerLowerModuleIndex, outerLowerModuleIndex, innerMiniDoubletAnchorHitIndex, outerMiniDoubletAnchorHitIndex, dPhi, dPhiMin, dPhiMax, dPhiChange, dPhiChangeMin, dPhiChangeMax, zIn, zOut, rtIn, rtOut, dAlphaInnerMDSegment, dAlphaOuterMDSegment, dAlphaInnerMDOuterMD, zLo, zHi, rtLo, rtHi, sdCut, dAlphaInnerMDSegmentThreshold, dAlphaOuterMDSegmentThreshold,
-                dAlphaInnerMDOuterMDThreshold, segmentIdx);
-#else
                     addSegmentToMemory(segmentsInGPU,innerMDIndex, outerMDIndex,innerLowerModuleIndex, outerLowerModuleIndex, innerMiniDoubletAnchorHitIndex, outerMiniDoubletAnchorHitIndex, dPhi, dPhiMin, dPhiMax, dPhiChange, dPhiChangeMin, dPhiChangeMax, segmentIdx);
-#endif
 
                 }
             }

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -62,23 +62,6 @@ namespace SDL
         bool* partOfPT5;
         uint4* pLSHitsIdxs;
 
-#ifdef CUT_VALUE_DEBUG
-        float* zIns;
-        float* zOuts;
-        float* rtIns;
-        float* rtOuts;
-        float* dAlphaInnerMDSegments;
-        float* dAlphaOuterMDSegments;
-        float* dAlphaInnerMDOuterMDs;
-        float* zLo;
-        float* zHi;
-        float* rtLo;
-        float* rtHi;
-        float* sdCut;
-        float* dAlphaInnerMDSegmentThreshold;
-        float* dAlphaOuterMDSegmentThreshold;
-        float* dAlphaInnerMDOuterMDThreshold;
-#endif
 
         segments();
         ~segments();
@@ -94,12 +77,7 @@ namespace SDL
 
 
     CUDA_DEV void dAlphaThreshold(float* dAlphaThresholdValues, struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, float& xIn, float& yIn, float& zIn, float& rtIn, float& xOut, float& yOut, float& zOut, float& rtOut, uint16_t& innerLowerModuleIndex, uint16_t& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex);
-#ifdef CUT_VALUE_DEBUG
-    CUDA_DEV void addSegmentToMemory(struct segments& segmentsInGPU, unsigned int lowerMDIndex, unsigned int upperMDIndex, uint16_t innerLowerModuleIndex, uint16_t outerLowerModuleIndex, unsigned int innerMDAnchorHitIndex, unsigned int outerMDAnchorHitIndex, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float&
-        dAlphaInnerMDOuterMD, float& zLo, float& zHi, float& rtLo, float& rtHi, float& sdCut, float& dAlphaInnerMDSegmentThreshold, float& dAlphaOuterMDSegmentThreshold, float& dAlphaInnerMDOuterMDThreshold, unsigned int idx);
-#else
     CUDA_DEV void addSegmentToMemory(struct segments& segmentsInGPU, unsigned int lowerMDIndex, unsigned int upperMDIndex, uint16_t innerLowerModuleIndex, uint16_t outerLowerModuleIndex, unsigned int innerMDAnchorHitIndex, unsigned int outerMDAnchorHitIndex, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, unsigned int idx);
-#endif
 
 //    CUDA_DEV void rmPixelSegmentFromMemory(struct segments& segmentsInGPU, unsigned int pixelSegmentArrayIndex);
 

--- a/SDL/TrackExtensions.cu
+++ b/SDL/TrackExtensions.cu
@@ -57,6 +57,10 @@ void SDL::trackExtensions::freeMemoryCache()
     cms::cuda::free_device(dev, nTrackExtensions);
     cms::cuda::free_device(dev, totOccupancyTrackExtensions);
     cms::cuda::free_device(dev, regressionRadius);
+#ifdef CUT_VALUE_DEBUG
+    cms::cuda::free_device(dev, innerRadius);
+    cms::cuda::free_device(dev, outerRadius);
+#endif
 #else
     cms::cuda::free_managed(constituentTCTypes);
     cms::cuda::free_managed(constituentTCIndices);

--- a/SDL/TrackExtensions.cu
+++ b/SDL/TrackExtensions.cu
@@ -144,6 +144,10 @@ void SDL::createTrackExtensionsInExplicitMemory(struct trackExtensions& trackExt
     trackExtensionsInGPU.nTrackExtensions = (unsigned int*)cms::cuda::allocate_device(dev,nTrackCandidates * sizeof(unsigned int), stream);
     trackExtensionsInGPU.totOccupancyTrackExtensions = (unsigned int*)cms::cuda::allocate_device(dev,nTrackCandidates * sizeof(unsigned int), stream);
     trackExtensionsInGPU.regressionRadius = (FPX*)cms::cuda::allocate_device(dev, maxTrackExtensions * sizeof(FPX), stream);
+#ifdef CUT_VALUE_DEBUG
+    trackExtensionsInGPU.innerRadius = (float*)cms::cuda::allocate_device(dev, maxTrackExtensions * sizeof(float), stream);
+    trackExtensionsInGPU.outerRadius = (float*)cms::cuda::allocate_device(dev, maxTrackExtensions * sizeof(float), stream);
+#endif
 #else
     cudaMalloc(&trackExtensionsInGPU.constituentTCTypes, sizeof(short) * 3 * maxTrackExtensions);
     cudaMalloc(&trackExtensionsInGPU.constituentTCIndices, sizeof(unsigned int) * 3 * maxTrackExtensions);

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -110,25 +110,6 @@ void SDL::createTripletsInUnifiedMemory(struct triplets& tripletsInGPU, unsigned
     cudaMallocManaged(&tripletsInGPU.logicalLayers, maxTriplets * 3 * sizeof(uint8_t));
     cudaMallocManaged(&tripletsInGPU.hitIndices, maxTriplets * 6 * sizeof(unsigned int));
     cudaMallocManaged(&tripletsInGPU.nMemoryLocations, sizeof(unsigned int));
-
-#ifdef CUT_VALUE_DEBUG
-    cudaMallocManaged(&tripletsInGPU.zOut, maxTriplets * 4*sizeof(unsigned int));
-    cudaMallocManaged(&tripletsInGPU.zLo, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.zHi, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.zLoPointed, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.zHiPointed, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.sdlCut, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.betaInCut, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.betaOutCut, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.deltaBetaCut, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.rtLo, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.rtHi, maxTriplets * sizeof(float));
-    cudaMallocManaged(&tripletsInGPU.kZ, maxTriplets * sizeof(float));
-
-    tripletsInGPU.rtOut = tripletsInGPU.zOut + maxTriplets;
-    tripletsInGPU.deltaPhiPos = tripletsInGPU.zOut + maxTriplets *2;
-    tripletsInGPU.deltaPhi = tripletsInGPU.zOut + maxTriplets *3;
-#endif
 #endif
     tripletsInGPU.betaOut = tripletsInGPU.betaIn + maxTriplets ;
     tripletsInGPU.pt_beta = tripletsInGPU.betaIn + maxTriplets * 2;
@@ -161,6 +142,25 @@ void SDL::createTripletsInExplicitMemory(struct triplets& tripletsInGPU, unsigne
     tripletsInGPU.hitIndices = (unsigned int*)cms::cuda::allocate_device(dev, maxTriplets * 6 * sizeof(unsigned int), stream);
     tripletsInGPU.nMemoryLocations = (unsigned int*)cms::cuda::allocate_device(dev, sizeof(unsigned int), stream);
 
+#ifdef CUT_VALUE_DEBUG
+    tripletsInGPU.zOut = (float*)cms::cuda::allocate_device(dev, maxTriplets * 4 * sizeof(float), stream);
+    tripletsInGPU.zLo = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.zHi = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.zLoPointed = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.zHiPointed = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.sdlCut = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.betaInCut = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.betaOutCut = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.deltaBetaCut = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.rtLo = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.rtHi = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.kZ = (float*)cms::cuda::allocate_device(dev, maxTriplets * sizeof(float), stream);
+    tripletsInGPU.rtOut = tripletsInGPU.zOut + maxTriplets;
+    tripletsInGPU.deltaPhiPos = tripletsInGPU.zOut + maxTriplets *2;
+    tripletsInGPU.deltaPhi = tripletsInGPU.zOut + maxTriplets *3;
+#endif
+
+
 #else
     cudaMalloc(&tripletsInGPU.segmentIndices, /*5*/2 * maxTriplets * sizeof(unsigned int));
     cudaMalloc(&tripletsInGPU.lowerModuleIndices, 3 * maxTriplets * sizeof(uint16_t));
@@ -175,6 +175,26 @@ void SDL::createTripletsInExplicitMemory(struct triplets& tripletsInGPU, unsigne
     cudaMalloc(&tripletsInGPU.logicalLayers, maxTriplets * 3 * sizeof(uint8_t));
     cudaMalloc(&tripletsInGPU.hitIndices, maxTriplets * 6 * sizeof(unsigned int));
     cudaMalloc(&tripletsInGPU.nMemoryLocations, sizeof(unsigned int));
+
+#ifdef CUT_VALUE_DEBUG
+    cudaMalloc(&tripletsInGPU.zOut, maxTriplets * 4*sizeof(unsigned int));
+    cudaMalloc(&tripletsInGPU.zLo, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.zHi, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.zLoPointed, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.zHiPointed, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.sdlCut, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.betaInCut, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.betaOutCut, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.deltaBetaCut, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.rtLo, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.rtHi, maxTriplets * sizeof(float));
+    cudaMalloc(&tripletsInGPU.kZ, maxTriplets * sizeof(float));
+
+    tripletsInGPU.rtOut = tripletsInGPU.zOut + maxTriplets;
+    tripletsInGPU.deltaPhiPos = tripletsInGPU.zOut + maxTriplets *2;
+    tripletsInGPU.deltaPhi = tripletsInGPU.zOut + maxTriplets *3;
+#endif
+
 #endif
     cudaMemsetAsync(tripletsInGPU.nTriplets,0,nLowerModules * sizeof(unsigned int),stream);
     cudaMemsetAsync(tripletsInGPU.totOccupancyTriplets,0,nLowerModules * sizeof(unsigned int),stream);
@@ -289,6 +309,19 @@ void SDL::triplets::freeMemoryCache()
     cms::cuda::free_device(dev, logicalLayers);
     cms::cuda::free_device(dev, hitIndices);
     cms::cuda::free_device(dev, nMemoryLocations);
+#ifdef CUT_VALUE_DEBUG
+    cms::cuda::free_device(dev, zOut);
+    cms::cuda::free_device(dev, zLo);
+    cms::cuda::free_device(dev, zHi);
+    cms::cuda::free_device(dev, zLoPointed);
+    cms::cuda::free_device(dev, zHiPointed);
+    cms::cuda::free_device(dev, betaInCut);
+    cms::cuda::free_device(dev, betaOutCut);
+    cms::cuda::free_device(dev, deltaBetaCut);
+    cms::cuda::free_device(dev, rtLo);
+    cms::cuda::free_device(dev, rtHi);
+    cms::cuda::free_device(dev, kZ);
+#endif
 #else
     cms::cuda::free_managed(segmentIndices);
     cms::cuda::free_managed(lowerModuleIndices);

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -315,6 +315,7 @@ void SDL::triplets::freeMemoryCache()
     cms::cuda::free_device(dev, zHi);
     cms::cuda::free_device(dev, zLoPointed);
     cms::cuda::free_device(dev, zHiPointed);
+    cms::cuda::free_device(dev, sdlCut);
     cms::cuda::free_device(dev, betaInCut);
     cms::cuda::free_device(dev, betaOutCut);
     cms::cuda::free_device(dev, deltaBetaCut);

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -334,21 +334,21 @@ void createQuintupletCutValueBranches()
     ana.tx->createBranch<vector<int>>("t5_layer_binary");
     ana.tx->createBranch<vector<vector<float>>>("t5_matched_pt");
     ana.tx->createBranch<vector<float>>("t5_innerRadius");
-    ana.tx->createBranch<vector<float>>("t5_innerRadiusMin");
-    ana.tx->createBranch<vector<float>>("t5_innerRadiusMax");
+    ana.tx->createBranch<vector<float>>("t5_innerInvRadiusMin");
+    ana.tx->createBranch<vector<float>>("t5_innerInvRadiusMax");
     ana.tx->createBranch<vector<float>>("t5_outerRadius");
     ana.tx->createBranch<vector<float>>("t5_regressionRadius");
-    ana.tx->createBranch<vector<float>>("t5_outerRadiusMin");
-    ana.tx->createBranch<vector<float>>("t5_outerRadiusMax");
+    ana.tx->createBranch<vector<float>>("t5_outerInvRadiusMin");
+    ana.tx->createBranch<vector<float>>("t5_outerInvRadiusMax");
     ana.tx->createBranch<vector<float>>("t5_bridgeRadius");
-    ana.tx->createBranch<vector<float>>("t5_bridgeRadiusMin");
-    ana.tx->createBranch<vector<float>>("t5_bridgeRadiusMax");
-    ana.tx->createBranch<vector<float>>("t5_innerRadiusMin2S");
-    ana.tx->createBranch<vector<float>>("t5_innerRadiusMax2S");
-    ana.tx->createBranch<vector<float>>("t5_bridgeRadiusMin2S");
-    ana.tx->createBranch<vector<float>>("t5_bridgeRadiusMax2S");
-    ana.tx->createBranch<vector<float>>("t5_outerRadiusMin2S");
-    ana.tx->createBranch<vector<float>>("t5_outerRadiusMax2S");
+    ana.tx->createBranch<vector<float>>("t5_bridgeInvRadiusMin");
+    ana.tx->createBranch<vector<float>>("t5_bridgeInvRadiusMax");
+    ana.tx->createBranch<vector<float>>("t5_innerInvRadiusMin2S");
+    ana.tx->createBranch<vector<float>>("t5_innerInvRadiusMax2S");
+    ana.tx->createBranch<vector<float>>("t5_bridgeInvRadiusMin2S");
+    ana.tx->createBranch<vector<float>>("t5_bridgeInvRadiusMax2S");
+    ana.tx->createBranch<vector<float>>("t5_outerInvRadiusMin2S");
+    ana.tx->createBranch<vector<float>>("t5_outerInvRadiusMax2S");
     ana.tx->createBranch<vector<int>>("t5_moduleType_binary");
     ana.tx->createBranch<vector<float>>("t5_chiSquared");
     ana.tx->createBranch<vector<float>>("t5_nonAnchorChiSquared");
@@ -2550,7 +2550,7 @@ void fillQuintupletOutputBranches(SDL::Event* event)
             unsigned int innerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex];
             unsigned int outerTripletIndex = quintupletsInGPU.tripletIndices[2 * quintupletIndex + 1];
 
-            if(quintupletsInGPU.isDup[quintupletIndex]==1){continue;}
+     //       if(quintupletsInGPU.isDup[quintupletIndex]==1){continue;}
             t5_foundDuplicate.emplace_back(quintupletsInGPU.isDup[quintupletIndex]);
             t5_score_rphisum.emplace_back(__H2F(quintupletsInGPU.score_rphisum[quintupletIndex]));
             t5_eta_2.emplace_back(__H2F(quintupletsInGPU.eta[quintupletIndex]));
@@ -2760,23 +2760,23 @@ void fillQuintupletOutputBranches(SDL::Event* event)
 
     ana.tx->setBranch<vector<float>>("t5_outerRadius",t5_outerRadius);
     ana.tx->setBranch<vector<float>>("t5_regressionRadius", t5_regressionRadius);
-    ana.tx->setBranch<vector<float>>("t5_outerRadiusMin",t5_outerRadiusMin);
-    ana.tx->setBranch<vector<float>>("t5_outerRadiusMax",t5_outerRadiusMax);
-    ana.tx->setBranch<vector<float>>("t5_outerRadiusMin2S",t5_outerRadiusMin2S);
-    ana.tx->setBranch<vector<float>>("t5_outerRadiusMax2S",t5_outerRadiusMax2S);
+    ana.tx->setBranch<vector<float>>("t5_outerInvRadiusMin",t5_outerRadiusMin);
+    ana.tx->setBranch<vector<float>>("t5_outerInvRadiusMax",t5_outerRadiusMax);
+    ana.tx->setBranch<vector<float>>("t5_outerInvRadiusMin2S",t5_outerRadiusMin2S);
+    ana.tx->setBranch<vector<float>>("t5_outerInvRadiusMax2S",t5_outerRadiusMax2S);
     ana.tx->setBranch<vector<float>>("t5_chiSquared", t5_chiSquared);
     ana.tx->setBranch<vector<float>>("t5_nonAnchorChiSquared", t5_nonAnchorChiSquared);
 
     ana.tx->setBranch<vector<float>>("t5_innerRadius",t5_innerRadius);
-    ana.tx->setBranch<vector<float>>("t5_innerRadiusMin",t5_innerRadiusMin);
-    ana.tx->setBranch<vector<float>>("t5_innerRadiusMax",t5_innerRadiusMax);
-    ana.tx->setBranch<vector<float>>("t5_innerRadiusMin2S",t5_innerRadiusMin2S);
-    ana.tx->setBranch<vector<float>>("t5_innerRadiusMax2S",t5_innerRadiusMax2S);
+    ana.tx->setBranch<vector<float>>("t5_innerInvRadiusMin",t5_innerRadiusMin);
+    ana.tx->setBranch<vector<float>>("t5_innerInvRadiusMax",t5_innerRadiusMax);
+    ana.tx->setBranch<vector<float>>("t5_innerInvRadiusMin2S",t5_innerRadiusMin2S);
+    ana.tx->setBranch<vector<float>>("t5_innerInvRadiusMax2S",t5_innerRadiusMax2S);
     ana.tx->setBranch<vector<float>>("t5_bridgeRadius",t5_bridgeRadius);
-    ana.tx->setBranch<vector<float>>("t5_bridgeRadiusMin",t5_bridgeRadiusMin);
-    ana.tx->setBranch<vector<float>>("t5_bridgeRadiusMax",t5_bridgeRadiusMax);
-    ana.tx->setBranch<vector<float>>("t5_bridgeRadiusMin2S",t5_bridgeRadiusMin2S);
-    ana.tx->setBranch<vector<float>>("t5_bridgeRadiusMax2S",t5_bridgeRadiusMax2S);
+    ana.tx->setBranch<vector<float>>("t5_bridgeInvRadiusMin",t5_bridgeRadiusMin);
+    ana.tx->setBranch<vector<float>>("t5_bridgeInvRadiusMax",t5_bridgeRadiusMax);
+    ana.tx->setBranch<vector<float>>("t5_bridgeInvRadiusMin2S",t5_bridgeRadiusMin2S);
+    ana.tx->setBranch<vector<float>>("t5_bridgeInvRadiusMax2S",t5_bridgeRadiusMax2S);
     ana.tx->setBranch<vector<int>>("t5_layer_binary",layer_binaries); 
     ana.tx->setBranch<vector<int>>("t5_moduleType_binary", moduleType_binaries);
 #endif
@@ -2826,7 +2826,7 @@ void fillPixelTripletOutputBranches(SDL::Event* event)
         unsigned int pixelSegmentIndex = pixelTripletsInGPU.pixelSegmentIndices[jdx];
         unsigned int tripletIndex = pixelTripletsInGPU.tripletIndices[jdx];
 
-        if(pixelTripletsInGPU.isDup[jdx]==1){continue;}
+     //   if(pixelTripletsInGPU.isDup[jdx]==1){continue;}
         pT3_eta_2.emplace_back(__H2F(pixelTripletsInGPU.eta[jdx]));
         pT3_phi_2.emplace_back(__H2F(pixelTripletsInGPU.phi[jdx]));
         pT3_score.emplace_back(__H2F(pixelTripletsInGPU.score[jdx]));
@@ -3058,7 +3058,7 @@ void fillPixelQuintupletOutputBranches(SDL::Event* event)
     for(unsigned int jdx = 0; jdx < nPixelQuintuplets; jdx++)
     {
         //obtain the hits
-        if(pixelQuintupletsInGPU.isDup[jdx]) {continue;};
+//        if(pixelQuintupletsInGPU.isDup[jdx]) {continue;};
         pT5_score.emplace_back(__H2F(pixelQuintupletsInGPU.score[jdx]));
         unsigned int T5Index = pixelQuintupletsInGPU.T5Indices[jdx];
     

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -1,4 +1,5 @@
 #include "write_sdl_ntuple.h"
+#include "write_sdl_ntuple.h"
 
 #define N_MAX_MD_PER_MODULES 89
 #define N_MAX_SEGMENTS_PER_MODULE 537
@@ -3201,24 +3202,6 @@ void fillPixelQuintupletOutputBranches(SDL::Event* event)
         moduleType_binary |= (moduleType12 << 8);
 
         pT5_layer_binary.push_back(layer_binary);
-
-        int moduleType0 = modulesInGPU.moduleType[module_idxs[0]];
-        int moduleType2 = modulesInGPU.moduleType[module_idxs[2]];
-        int moduleType4 = modulesInGPU.moduleType[module_idxs[4]];
-        int moduleType6 = modulesInGPU.moduleType[module_idxs[6]];
-        int moduleType8 = modulesInGPU.moduleType[module_idxs[8]];
-        int moduleType10 = modulesInGPU.moduleType[module_idxs[10]];
-        int moduleType12 = modulesInGPU.moduleType[module_idxs[12]];
-
-
-        int moduleType_binary = 0;
-        moduleType_binary |= (moduleType4 << 0);
-        moduleType_binary |= (moduleType6 << 2);
-        moduleType_binary |= (moduleType8 << 4);
-        moduleType_binary |= (moduleType10 << 6);
-        moduleType_binary |= (moduleType12 << 8);
-
-        pT5_moduleType_binary.push_back(moduleType_binary);
         pT5_rzChiSquared.push_back(pixelQuintupletsInGPU.rzChiSquared[jdx]);
         pT5_rPhiChiSquared.push_back(pixelQuintupletsInGPU.rPhiChiSquared[jdx]);
         pT5_rPhiChiSquaredInwards.push_back(pixelQuintupletsInGPU.rPhiChiSquaredInwards[jdx]);
@@ -3661,7 +3644,6 @@ void fillTripletOutputBranches(SDL::Event* event)
             int moduleType2 = modulesInGPU.moduleType[module_idxs[2]];
             int moduleType4 = modulesInGPU.moduleType[module_idxs[4]];
             int moduleType6 = modulesInGPU.moduleType[module_idxs[6]];
-            
             moduleType_binary |= (moduleType0 << 0);
             moduleType_binary |= (moduleType2 << 2);
             moduleType_binary |= (moduleType4 << 4);
@@ -3726,7 +3708,7 @@ void fillTripletOutputBranches(SDL::Event* event)
             float deltaPhiPos = tripletsInGPU.deltaPhiPos[tripletIndex];
             float deltaPhi = tripletsInGPU.deltaPhi[tripletIndex];
             //betaIn and betaOut already defined!
-            float deltaBeta = betaIn - betaOut;
+            float deltaBeta = tripletsInGPU.betaIn[tripletIndex] - tripletsInGPU.betaOut[tripletIndex];
             float zLo = tripletsInGPU.zLo[tripletIndex];
             float zHi = tripletsInGPU.zHi[tripletIndex];
             float rtLo = tripletsInGPU.rtLo[tripletIndex];
@@ -3743,8 +3725,8 @@ void fillTripletOutputBranches(SDL::Event* event)
             t3_RtOut.push_back(rtOut);
             t3_deltaPhiPos.push_back(deltaPhiPos);
             t3_deltaPhi.push_back(deltaPhi);
-            t3_betaIn.push_back(betaIn);
-            t3_betaOut.push_back(betaOut);
+            t3_betaIn.push_back(tripletsInGPU.betaIn[tripletIndex]);
+            t3_betaOut.push_back(tripletsInGPU.betaOut[tripletIndex]);
             t3_deltaBeta.push_back(deltaBeta);
             t3_ZLo.push_back(zLo);
             t3_ZHi.push_back(zHi);

--- a/code/core/write_sdl_ntuple.h
+++ b/code/core/write_sdl_ntuple.h
@@ -28,6 +28,7 @@ void createMiniDoubletCutValueBranches();
 void createOccupancyBranches();
 void createPixelQuadrupletCutValueBranches();
 void createPixelTripletCutValueBranches();
+void createTrackExtensionCutValueBranches();
 void createPrimitiveBranches();
 void createPrimitiveBranches_v1();
 void createPrimitiveBranches_v2();


### PR DESCRIPTION
Given that unified is pretty much dead, and the cut value debug ntuple part of the code was not working. This PR creates appropriate memory in the explicit framework. 

compiling with options `-mxc8d` adds the extra branches in the output ntuples