### PR TITLE
Fix for trkAlgo iterations

### DIFF
--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -1426,11 +1426,11 @@ std::vector<std::vector<short>>&    out_isQuad_vec)
 
         bool good_seed_type = false;
         if (trk.see_algo()[iSeed] == 4) good_seed_type = true;
-        if (trk.see_algo()[iSeed] == 5) good_seed_type = true;
-        if (trk.see_algo()[iSeed] == 7) good_seed_type = true;
+        //if (trk.see_algo()[iSeed] == 5) good_seed_type = true;
+        //if (trk.see_algo()[iSeed] == 7) good_seed_type = true;
         if (trk.see_algo()[iSeed] == 22) good_seed_type = true;
-        if (trk.see_algo()[iSeed] == 23) good_seed_type = true;
-        if (trk.see_algo()[iSeed] == 24) good_seed_type = true;
+        //if (trk.see_algo()[iSeed] == 23) good_seed_type = true;
+        //if (trk.see_algo()[iSeed] == 24) good_seed_type = true;
         if (not good_seed_type) continue;
 
         TVector3 p3LH(trk.see_stateTrajGlbPx()[iSeed], trk.see_stateTrajGlbPy()[iSeed], trk.see_stateTrajGlbPz()[iSeed]);


### PR DESCRIPTION
This PR is a fix on removing the extra tracking algorithm iterations in one more place in the code. Prior to this PR, the issue of higher fake rate seems to be evident even in the CMSSW 11 geometry (somehow this was missed in previous PRs?). I am not sure if a recent change caused that. However, this PR fixes the issue in any geometry, as can be seen in the validation plots (I hope that the labels are self-explanatory):
https://www.classe.cornell.edu/~evourlio/www/SDL_GPU/trkIterAlgoRevisited/
