### PR TITLE
Remove Unified Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Once every new shell, source the setup script to initilaize the enviornment.
 Compile the code with option flags
 
     sdl_make_tracklooper -m8
-    -x: run with explicit instead of unified memory
     -c: run with the cmssw caching allocator
     -h: show help screen with all options
  Run the code
@@ -40,13 +39,10 @@ Compile the code with option flags
 Run the validation on sample
 
     sdl_validate_segment_linking <dataset> 
-    Runs Explicit and unified versions over 200 events by default
+    Runs Explicit version over 200 events by default
     dataset: PU200, muonGun, pionGun, etc
 
 Run the validation on specific version of GPU implementation
 
-    sdl_validate_segment_linking <dataset> unified
-    sdl_validate_segment_linking <dataset> unified_cache
-    sdl_validate_segment_linking <dataset> explicit
-    sdl_validate_segment_linking <dataset> explicit_newgrid
+    sdl_validate_segment_linking <dataset> cache
     (can optionally add in number of events as 3rd option)

--- a/README.md
+++ b/README.md
@@ -44,5 +44,6 @@ Run the validation on sample
 
 Run the validation on specific version of GPU implementation
 
-    sdl_validate_segment_linking <dataset> cache
+    sdl_validate_segment_linking <dataset> explicit
+    sdl_validate_segment_linking <dataset> explicit_cache
     (can optionally add in number of events as 3rd option)

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -98,7 +98,6 @@ SDL::Event::~Event()
     if(quintupletsInGPU!= nullptr){cms::cuda::free_host(quintupletsInGPU);}
     if(trackExtensionsInGPU != nullptr){cms::cuda::free_host(trackExtensionsInGPU);}
 
-#ifdef Explicit_Hit
     if(hitsInCPU != nullptr)
     {
         delete[] hitsInCPU->idxs;
@@ -114,8 +113,7 @@ SDL::Event::~Event()
         delete[] rangesInCPU->quintupletModuleIndices;
         delete rangesInCPU;
     }
-#endif
-#ifdef Explicit_MD
+
     if(mdsInCPU != nullptr)
     {
         delete[] mdsInCPU->anchorHitIndices;
@@ -124,8 +122,7 @@ SDL::Event::~Event()
         delete[] mdsInCPU->totOccupancyMDs;
         delete mdsInCPU;
     }
-#endif
-#ifdef Explicit_Seg
+
     if(segmentsInCPU != nullptr)
     {
         delete[] segmentsInCPU->mdIndices;
@@ -139,8 +136,7 @@ SDL::Event::~Event()
         delete segmentsInCPU->nMemoryLocations;
         delete segmentsInCPU;
     }
-#endif
-#ifdef Explicit_Trips
+
     if(tripletsInCPU != nullptr)
     {
         delete[] tripletsInCPU->segmentIndices;
@@ -169,8 +165,6 @@ SDL::Event::~Event()
 #endif
         delete tripletsInCPU;
     }
-#endif
-#ifdef Explicit_T5
 #ifdef FINAL_T5
     if(quintupletsInCPU != nullptr)
     {
@@ -201,9 +195,7 @@ SDL::Event::~Event()
         delete quintupletsInCPU;
     }
 #endif
-#endif
 
-#ifdef Explicit_PT3
     if(pixelTripletsInCPU != nullptr)
     {
         delete[] pixelTripletsInCPU->tripletIndices;
@@ -220,8 +212,7 @@ SDL::Event::~Event()
 #endif
         delete pixelTripletsInCPU;
     }
-#endif
-#ifdef Explicit_PT5
+
     if(pixelQuintupletsInCPU != nullptr)
     {
         delete[] pixelQuintupletsInCPU->pixelIndices;
@@ -237,9 +228,7 @@ SDL::Event::~Event()
 #endif
         delete pixelQuintupletsInCPU;
     }
-#endif
 
-#ifdef Explicit_Track
     if(trackCandidatesInCPU != nullptr)
     {
         delete[] trackCandidatesInCPU->objectIndices;
@@ -250,8 +239,7 @@ SDL::Event::~Event()
         delete[] trackCandidatesInCPU->partOfExtension;
         delete trackCandidatesInCPU;
     }
-#endif
-#ifdef Explicit_Extensions
+
     if(trackExtensionsInCPU != nullptr)
     {
         delete[] trackExtensionsInCPU->nTrackExtensions;
@@ -271,8 +259,7 @@ SDL::Event::~Event()
 
         delete trackExtensionsInCPU;
     }
-#endif
-#ifdef Explicit_Module
+
     if(modulesInCPU != nullptr)
     {
         delete[] modulesInCPU->nLowerModules;
@@ -314,9 +301,9 @@ SDL::Event::~Event()
         delete[] modulesInCPUFull->moduleLayerType;
         delete[] modulesInCPUFull;
     }
-#endif
-SDL::freeEndCapMapMemory();
+    SDL::freeEndCapMapMemory();
 }
+
 void SDL::Event::resetEvent()
 {
 #ifdef CACHE_ALLOC
@@ -382,7 +369,7 @@ void SDL::Event::resetEvent()
     pixelQuintupletsInGPU = nullptr;}
     if(trackExtensionsInGPU){cms::cuda::free_host(trackExtensionsInGPU);
     trackExtensionsInGPU = nullptr;}
-#ifdef Explicit_Hit
+
     if(hitsInCPU != nullptr)
     {
         delete[] hitsInCPU->idxs;
@@ -401,8 +388,7 @@ void SDL::Event::resetEvent()
         delete rangesInCPU;
         rangesInCPU = nullptr;
     }
-#endif
-#ifdef Explicit_MD
+
     if(mdsInCPU != nullptr)
     {
         delete[] mdsInCPU->anchorHitIndices;
@@ -411,8 +397,7 @@ void SDL::Event::resetEvent()
         delete mdsInCPU;
         mdsInCPU = nullptr;
     }
-#endif
-#ifdef Explicit_Seg
+
     if(segmentsInCPU != nullptr)
     {
         delete[] segmentsInCPU->mdIndices;
@@ -426,8 +411,7 @@ void SDL::Event::resetEvent()
         delete segmentsInCPU;
         segmentsInCPU = nullptr;
     }
-#endif
-#ifdef Explicit_Trips
+
     if(tripletsInCPU != nullptr)
     {
         delete[] tripletsInCPU->segmentIndices;
@@ -442,8 +426,7 @@ void SDL::Event::resetEvent()
         delete tripletsInCPU;
         tripletsInCPU = nullptr;
     }
-#endif
-#ifdef Explicit_T5
+
 #ifdef FINAL_T5
     if(quintupletsInCPU != nullptr)
     {
@@ -458,9 +441,7 @@ void SDL::Event::resetEvent()
         quintupletsInCPU = nullptr;
     }
 #endif
-#endif
 
-#ifdef Explicit_PT3
     if(pixelTripletsInCPU != nullptr)
     {
         delete[] pixelTripletsInCPU->tripletIndices;
@@ -472,8 +453,7 @@ void SDL::Event::resetEvent()
         delete pixelTripletsInCPU;
         pixelTripletsInCPU = nullptr;
     }
-#endif
-#ifdef Explicit_PT5
+
     if(pixelQuintupletsInCPU != nullptr)
     {
         delete[] pixelQuintupletsInCPU->pixelIndices;
@@ -485,8 +465,7 @@ void SDL::Event::resetEvent()
         delete pixelQuintupletsInCPU;
         pixelQuintupletsInCPU = nullptr;
     }
-#endif
-#ifdef Explicit_Track
+
     if(trackCandidatesInCPU != nullptr)
     {
         delete[] trackCandidatesInCPU->objectIndices;
@@ -498,8 +477,7 @@ void SDL::Event::resetEvent()
         delete trackCandidatesInCPU;
         trackCandidatesInCPU = nullptr;
     }
-#endif
-#ifdef Explicit_Extensions
+
     if(trackExtensionsInCPU != nullptr)
     {
         delete[] trackExtensionsInCPU->nTrackExtensions;
@@ -514,8 +492,7 @@ void SDL::Event::resetEvent()
         delete trackExtensionsInCPU;
         trackExtensionsInCPU = nullptr;
     }
-#endif
-#ifdef Explicit_Module
+
     if(modulesInCPU != nullptr)
     {
         delete[] modulesInCPU->nLowerModules;
@@ -559,8 +536,6 @@ void SDL::Event::resetEvent()
         delete[] modulesInCPUFull;
         modulesInCPUFull = nullptr;
     }
-#endif
-
 
 }
 
@@ -702,21 +677,13 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
     if (hitsInGPU == nullptr)
     {
         hitsInGPU = (SDL::hits*)cms::cuda::allocate_host(sizeof(SDL::hits), stream);
-        #ifdef Explicit_Hit
-            // Unclear why but this has to be 2*nHits to avoid crashing.
-    	    createHitsInExplicitMemory(*hitsInGPU, nModules, 2*nHits, stream, 1);
-        #else
-            createHitsInUnifiedMemory(*hitsInGPU, nModules, 2*nHits, 0, stream, 1);
-        #endif
+        // Unclear why but this has to be 2*nHits to avoid crashing.
+        createHitsInExplicitMemory(*hitsInGPU, nModules, 2*nHits, stream, 1);
     }
     if (rangesInGPU == nullptr)
     {
         rangesInGPU = (SDL::objectRanges*)cms::cuda::allocate_host(sizeof(SDL::objectRanges), stream);
-        #ifdef Explicit_Hit
-    	    createRangesInExplicitMemory(*rangesInGPU, nModules, stream, nLowerModules);
-        #else
-            createRangesInUnifiedMemory(*rangesInGPU, nModules, stream, nLowerModules);
-        #endif
+    	createRangesInExplicitMemory(*rangesInGPU, nModules, stream, nLowerModules);
         resetObjectsInModule();
     }
     cudaStreamSynchronize(stream);
@@ -784,13 +751,10 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
         unsigned int nTotalMDs;
         createMDArrayRanges(*modulesInGPU, *rangesInGPU, nLowerModules, nTotalMDs, stream, N_MAX_MD_PER_MODULES, N_MAX_PIXEL_MD_PER_MODULES);
 
-#ifdef Explicit_MD
     	createMDsInExplicitMemory(*mdsInGPU, nTotalMDs, nLowerModules, N_MAX_PIXEL_MD_PER_MODULES,stream);
-#else
-    	createMDsInUnifiedMemory(*mdsInGPU, nTotalMDs, nLowerModules, N_MAX_PIXEL_MD_PER_MODULES,stream);
-#endif
+
         cudaMemcpyAsync(mdsInGPU->nMemoryLocations, &nTotalMDs, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
-         cudaStreamSynchronize(stream);
+        cudaStreamSynchronize(stream);
 
     }
     if(segmentsInGPU == nullptr)
@@ -801,11 +765,8 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
         createSegmentArrayRanges(*modulesInGPU, *rangesInGPU, *mdsInGPU, nLowerModules, nTotalSegments, stream, N_MAX_SEGMENTS_PER_MODULE, N_MAX_PIXEL_SEGMENTS_PER_MODULE);
 //        cout<<"nTotalSegments: "<<nTotalSegments<<std::endl; // for memory usage
 
-#ifdef Explicit_Seg
         createSegmentsInExplicitMemory(*segmentsInGPU, nTotalSegments, nLowerModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE,stream);
-#else
-        createSegmentsInUnifiedMemory(*segmentsInGPU, nTotalSegments,  nLowerModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE,stream);
-#endif
+
         cudaMemcpyAsync(segmentsInGPU->nMemoryLocations, &nTotalSegments, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);;
         cudaStreamSynchronize(stream);
 
@@ -1113,19 +1074,14 @@ void SDL::Event::createMiniDoublets()
     if(mdsInGPU == nullptr)
     {
         mdsInGPU = (SDL::miniDoublets*)cms::cuda::allocate_host(sizeof(SDL::miniDoublets), stream);
-#ifdef Explicit_MD
+
         //FIXME: Add memory locations for pixel MDs
         createMDsInExplicitMemory(*mdsInGPU, nTotalMDs, nLowerModules, N_MAX_PIXEL_MD_PER_MODULES, stream);
-
-#else
-        createMDsInUnifiedMemory(*mdsInGPU, nTotalMDs, nLowerModules, N_MAX_PIXEL_MD_PER_MODULES, stream);
-#endif
 
     }
     cudaStreamSynchronize(stream);
 
     int maxThreadsPerModule=0;
-#ifdef Explicit_Module
     int* module_hitRanges;
     module_hitRanges = (int*)cms::cuda::allocate_host(nModules* 2*sizeof(int), stream);
     cudaMemcpyAsync(module_hitRanges,hitsInGPU->hitRanges,nModules*2*sizeof(int),cudaMemcpyDeviceToHost,stream);
@@ -1156,21 +1112,7 @@ void SDL::Event::createMiniDoublets()
     cms::cuda::free_host(module_partnerModuleIndices);
     cms::cuda::free_host(module_isLower);
     cms::cuda::free_host(module_isInverted);
-#else
-    for (int i=0; i<nLowerModules; i++) 
-    {
-        int lowerModuleIndex = i;
-        int upperModuleIndex = modulesInGPU->partnerModuleIndices[i];
-        int lowerHitRanges = hitsInGPU->hitRanges[lowerModuleIndex*2];
-        int upperHitRanges = hitsInGPU->hitRanges[upperModuleIndex*2];
-        if(lowerHitRanges!=-1&&upperHitRanges!=-1) 
-        {
-            int nLowerHits = hitsInGPU->hitRanges[lowerModuleIndex * 2 + 1] - lowerHitRanges + 1;
-            int nUpperHits = hitsInGPU->hitRanges[upperModuleIndex * 2 + 1] - upperHitRanges + 1;
-            maxThreadsPerModule = maxThreadsPerModule > (nLowerHits*nUpperHits) ? maxThreadsPerModule : nLowerHits*nUpperHits;
-        }
-    }
-#endif
+
     dim3 nThreads(32,16,1);
     //dim3 nThreads(64,16,1);
     dim3 nBlocks(1,MAX_BLOCKS,1);
@@ -1186,11 +1128,7 @@ void SDL::Event::createMiniDoublets()
     cudaStreamSynchronize(stream);
 
 #if defined(AddObjects)
-#ifdef Explicit_MD
-    addMiniDoubletsToEventExplicit();
-#else
-    addMiniDoubletsToEvent();
-#endif
+addMiniDoubletsToEventExplicit();
 #endif
 
 }
@@ -1203,11 +1141,7 @@ void SDL::Event::createSegmentsWithModuleMap()
     if(segmentsInGPU == nullptr)
     {
         segmentsInGPU = (SDL::segments*)cms::cuda::allocate_host(sizeof(SDL::segments), stream);
-#ifdef Explicit_Seg
         createSegmentsInExplicitMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nLowerModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE,stream);
-#else
-        createSegmentsInUnifiedMemory(*segmentsInGPU, N_MAX_SEGMENTS_PER_MODULE, nLowerModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE,stream);
-#endif
     }
 
 //HERE
@@ -1223,11 +1157,7 @@ void SDL::Event::createSegmentsWithModuleMap()
     }
     cudaStreamSynchronize(stream);
 #if defined(AddObjects)
-#ifdef Explicit_Seg
     addSegmentsToEventExplicit();
-#else
-    addSegmentsToEvent();
-#endif
 #endif
 
 }
@@ -1245,11 +1175,8 @@ void SDL::Event::createTriplets()
         unsigned int maxTriplets;
         createTripletArrayRanges(*modulesInGPU, *rangesInGPU, *segmentsInGPU, nLowerModules, maxTriplets, stream);
 //        cout<<"nTotalTriplets: "<<maxTriplets<<std::endl; // for memory usage
-#ifdef Explicit_Trips
         createTripletsInExplicitMemory(*tripletsInGPU, maxTriplets, nLowerModules,stream);
-#else
-        createTripletsInUnifiedMemory(*tripletsInGPU, maxTriplets, nLowerModules,stream);
-#endif
+
         cudaMemcpyAsync(tripletsInGPU->nMemoryLocations, &maxTriplets, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
         cudaStreamSynchronize(stream);
 
@@ -1264,7 +1191,6 @@ void SDL::Event::createTriplets()
     cudaMemcpyAsync((void *)nSegments, segmentsInGPU->nSegments, nLowerModules*sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
     cudaStreamSynchronize(stream);
 
-#ifdef Explicit_Module
     uint16_t* module_nConnectedModules;
     module_nConnectedModules = (uint16_t*)cms::cuda::allocate_host(nLowerModules* sizeof(uint16_t), stream);
     cudaMemcpyAsync(module_nConnectedModules,modulesInGPU->nConnectedModules,nLowerModules*sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
@@ -1282,19 +1208,6 @@ void SDL::Event::createTriplets()
         max_InnerSeg = max(max_InnerSeg, nInnerSegments);
     }
     cms::cuda::free_host(module_nConnectedModules);
-#else
-    for (uint16_t innerLowerModuleIndex = 0; innerLowerModuleIndex < nLowerModules; innerLowerModuleIndex++) 
-    {
-        uint16_t nConnectedModules = modulesInGPU->nConnectedModules[innerLowerModuleIndex];
-        unsigned int nInnerSegments = nSegments[innerLowerModuleIndex];
-        if (nConnectedModules != 0 and nInnerSegments != 0) 
-        {
-            index[nonZeroModules] = innerLowerModuleIndex;
-            nonZeroModules++;
-        }
-        max_InnerSeg = max(max_InnerSeg, nInnerSegments);
-    }
-#endif
     cudaMemcpyAsync(index_gpu, index, nonZeroModules*sizeof(uint16_t), cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
 
@@ -1313,11 +1226,7 @@ void SDL::Event::createTriplets()
     cms::cuda::free_device(dev, index_gpu);
 
 #if defined(AddObjects)
-#ifdef Explicit_Trips
     addTripletsToEventExplicit();
-#else
-    addTripletsToEvent();
-#endif
 #endif
 }
 
@@ -1327,14 +1236,8 @@ void SDL::Event::createTrackCandidates()
     cudaMemcpyAsync(&nEligibleModules,rangesInGPU->nEligibleT5Modules,sizeof(uint16_t),cudaMemcpyDeviceToHost,stream);
     if(trackCandidatesInGPU == nullptr)
     {
-        //printf("did this run twice?\n");
         trackCandidatesInGPU = (SDL::trackCandidates*)cms::cuda::allocate_host(sizeof(SDL::trackCandidates), stream);
-#ifdef Explicit_Track
         createTrackCandidatesInExplicitMemory(*trackCandidatesInGPU, N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES,stream);
-#else
-        createTrackCandidatesInUnifiedMemory(*trackCandidatesInGPU, N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES,stream);
-
-#endif
     }
 
 #ifdef FINAL_pT3
@@ -1433,17 +1336,9 @@ void SDL::Event::createExtendedTracks()
     cudaMemcpyAsync(&nTrackCandidates, trackCandidatesInGPU->nTrackCandidates, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
 
 #ifdef T3T3_EXTENSIONS
-#ifdef Explicit_Extensions
     createTrackExtensionsInExplicitMemory(*trackExtensionsInGPU, nTrackCandidates * N_MAX_TRACK_EXTENSIONS_PER_TC + N_MAX_T3T3_TRACK_EXTENSIONS, nTrackCandidates + 1, stream); 
 #else
-    createTrackExtensionsInUnifiedMemory(*trackExtensionsInGPU, nTrackCandidates * N_MAX_TRACK_EXTENSIONS_PER_TC + N_MAX_T3T3_TRACK_EXTENSIONS, nTrackCandidates + 1, stream);
-#endif
-#else
-#ifdef Explicit_Extensions
     createTrackExtensionsInExplicitMemory(*trackExtensionsInGPU, nTrackCandidates * N_MAX_TRACK_EXTENSIONS_PER_TC, nTrackCandidates, stream); 
-#else
-    createTrackExtensionsInUnifiedMemory(*trackExtensionsInGPU, nTrackCandidates * N_MAX_TRACK_EXTENSIONS_PER_TC, nTrackCandidates, stream);
-#endif
 
     dim3 nThreads(16,1,1);
     dim3 nBlocks(80,1,nTrackCandidates); 
@@ -1494,11 +1389,8 @@ void SDL::Event::createPixelTriplets()
     {
         pixelTripletsInGPU = (SDL::pixelTriplets*)cms::cuda::allocate_host(sizeof(SDL::pixelTriplets), stream);
     }
-#ifdef Explicit_PT3
+
     createPixelTripletsInExplicitMemory(*pixelTripletsInGPU, N_MAX_PIXEL_TRIPLETS,stream);
-#else
-    createPixelTripletsInUnifiedMemory(*pixelTripletsInGPU, N_MAX_PIXEL_TRIPLETS,stream);
-#endif
 
     unsigned int pixelModuleIndex = nLowerModules;
     int* superbins;
@@ -1637,14 +1529,7 @@ cudaStreamSynchronize(stream);
     if(quintupletsInGPU == nullptr)
     {
         quintupletsInGPU = (SDL::quintuplets*)cms::cuda::allocate_host(sizeof(SDL::quintuplets), stream);
-#ifdef Explicit_T5
         createQuintupletsInExplicitMemory(*quintupletsInGPU, nTotalQuintuplets, nLowerModules, nEligibleT5Modules,stream);
-
-#else
-        createQuintupletsInUnifiedMemory(*quintupletsInGPU, nTotalQuintuplets, nLowerModules, nEligibleT5Modules,stream);
-
-
-#endif
         cudaMemcpyAsync(quintupletsInGPU->nMemoryLocations, &nTotalQuintuplets, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
         cudaStreamSynchronize(stream);
 
@@ -1673,11 +1558,7 @@ cudaStreamSynchronize(stream);
 #endif
 
 #if defined(AddObjects)
-#ifdef Explicit_T5
     addQuintupletsToEventExplicit();
-#else
-    addQuintupletsToEvent();
-#endif
 #endif
 
 }
@@ -1707,21 +1588,12 @@ void SDL::Event::createPixelQuintuplets()
     if(pixelQuintupletsInGPU == nullptr)
     {
         pixelQuintupletsInGPU = (SDL::pixelQuintuplets*)cms::cuda::allocate_host(sizeof(SDL::pixelQuintuplets), stream);
-#ifdef Explicit_PT5
-    createPixelQuintupletsInExplicitMemory(*pixelQuintupletsInGPU, N_MAX_PIXEL_QUINTUPLETS,stream);
-#else
-    createPixelQuintupletsInUnifiedMemory(*pixelQuintupletsInGPU, N_MAX_PIXEL_QUINTUPLETS,stream);
-#endif  
+        createPixelQuintupletsInExplicitMemory(*pixelQuintupletsInGPU, N_MAX_PIXEL_QUINTUPLETS,stream);
     }
    if(trackCandidatesInGPU == nullptr)
     {
         trackCandidatesInGPU = (SDL::trackCandidates*)cms::cuda::allocate_host(sizeof(SDL::trackCandidates), stream);
-#ifdef Explicit_Track
         createTrackCandidatesInExplicitMemory(*trackCandidatesInGPU, N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES,stream);
-#else
-        createTrackCandidatesInUnifiedMemory(*trackCandidatesInGPU, N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES,stream);
-
-#endif
     } 
 
     unsigned int pixelModuleIndex;
@@ -2149,14 +2021,10 @@ unsigned int SDL::Event::getNumberOfTripletsByLayerEndcap(unsigned int layer)
 
 unsigned int SDL::Event::getNumberOfPixelTriplets()
 {
-#ifdef Explicit_PT3
     unsigned int nPixelTriplets;
     cudaMemcpyAsync(&nPixelTriplets, pixelTripletsInGPU->nPixelTriplets, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-cudaStreamSynchronize(stream);
+    cudaStreamSynchronize(stream);
     return nPixelTriplets;
-#else
-    return *(pixelTripletsInGPU->nPixelTriplets);
-#endif
 }
 
 
@@ -2195,15 +2063,10 @@ unsigned int SDL::Event::getNumberOfT3T3ExtendedTracks()
 
 unsigned int SDL::Event::getNumberOfPixelQuintuplets()
 {
-#ifdef Explicit_PT5
     unsigned int nPixelQuintuplets;
     cudaMemcpyAsync(&nPixelQuintuplets, pixelQuintupletsInGPU->nPixelQuintuplets, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-cudaStreamSynchronize(stream);
+    cudaStreamSynchronize(stream);
     return nPixelQuintuplets;
-
-#else
-    return *(pixelQuintupletsInGPU->nPixelQuintuplets);
-#endif
 }
 unsigned int SDL::Event::getNumberOfQuintuplets()
 {
@@ -2292,7 +2155,7 @@ unsigned int SDL::Event::getNumberOfT5TrackCandidates()
     cudaMemcpyAsync(&nTrackCandidatesT5, trackCandidatesInGPU->nTrackCandidatesT5, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
     return nTrackCandidatesT5; 
 }
-#ifdef Explicit_Hit
+
 SDL::hits* SDL::Event::getHits() //std::shared_ptr should take care of garbage collection
 {
     if(hitsInCPU == nullptr)
@@ -2301,7 +2164,7 @@ SDL::hits* SDL::Event::getHits() //std::shared_ptr should take care of garbage c
         hitsInCPU->nHits = new unsigned int;
         unsigned int nHits;
         cudaMemcpyAsync(&nHits, hitsInGPU->nHits, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-cudaStreamSynchronize(stream);
+        cudaStreamSynchronize(stream);
         *(hitsInCPU->nHits) = nHits;
         hitsInCPU->idxs = new unsigned int[nHits];
         hitsInCPU->xs = new float[nHits];
@@ -2313,7 +2176,7 @@ cudaStreamSynchronize(stream);
         cudaMemcpyAsync(hitsInCPU->ys, hitsInGPU->ys, sizeof(float) * nHits, cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(hitsInCPU->zs, hitsInGPU->zs, sizeof(float) * nHits, cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(hitsInCPU->moduleIndices, hitsInGPU->moduleIndices, sizeof(uint16_t) * nHits, cudaMemcpyDeviceToHost,stream);
-cudaStreamSynchronize(stream);
+        cudaStreamSynchronize(stream);
     }
     return hitsInCPU;
 }
@@ -2339,19 +2202,7 @@ cudaStreamSynchronize(stream);
     }
     return rangesInCPU;
 }
-#else
-SDL::hits* SDL::Event::getHits() //std::shared_ptr should take care of garbage collection
-{
-    return hitsInGPU;
-}
-SDL::objectRanges* SDL::Event::getRanges()
-{
-    return rangesInGPU;
-}
-#endif
 
-
-#ifdef Explicit_MD
 SDL::miniDoublets* SDL::Event::getMiniDoublets()
 {
     if(mdsInCPU == nullptr)
@@ -2375,15 +2226,7 @@ SDL::miniDoublets* SDL::Event::getMiniDoublets()
     }
     return mdsInCPU;
 }
-#else
-SDL::miniDoublets* SDL::Event::getMiniDoublets()
-{
-    return mdsInGPU;
-}
-#endif
 
-
-#ifdef Explicit_Seg
 SDL::segments* SDL::Event::getSegments()
 {
     if(segmentsInCPU == nullptr)
@@ -2423,14 +2266,7 @@ SDL::segments* SDL::Event::getSegments()
     }
     return segmentsInCPU;
 }
-#else
-SDL::segments* SDL::Event::getSegments()
-{
-    return segmentsInGPU;
-}
-#endif
 
-#ifdef Explicit_Trips
 SDL::triplets* SDL::Event::getTriplets()
 {
     if(tripletsInCPU == nullptr)
@@ -2495,14 +2331,7 @@ SDL::triplets* SDL::Event::getTriplets()
     }
     return tripletsInCPU;
 }
-#else
-SDL::triplets* SDL::Event::getTriplets()
-{
-    return tripletsInGPU;
-}
-#endif
 
-#ifdef Explicit_T5
 SDL::quintuplets* SDL::Event::getQuintuplets()
 {
     if(quintupletsInCPU == nullptr)
@@ -2575,14 +2404,7 @@ cudaStreamSynchronize(stream);
 
     return quintupletsInCPU;
 }
-#else
-SDL::quintuplets* SDL::Event::getQuintuplets()
-{
-    return quintupletsInGPU;
-}
-#endif
 
-#ifdef Explicit_PT3
 SDL::pixelTriplets* SDL::Event::getPixelTriplets()
 {
     if(pixelTripletsInCPU == nullptr)
@@ -2627,14 +2449,7 @@ cudaStreamSynchronize(stream);
     }
     return pixelTripletsInCPU;
 }
-#else
-SDL::pixelTriplets* SDL::Event::getPixelTriplets()
-{
-    return pixelTripletsInGPU;
-}
-#endif
 
-#ifdef Explicit_PT5
 SDL::pixelQuintuplets* SDL::Event::getPixelQuintuplets()
 {
     if(pixelQuintupletsInCPU == nullptr)
@@ -2670,14 +2485,7 @@ cudaStreamSynchronize(stream);
     }
     return pixelQuintupletsInCPU;
 }
-#else
-SDL::pixelQuintuplets* SDL::Event::getPixelQuintuplets()
-{
-    return pixelQuintupletsInGPU;
-}
-#endif
 
-#ifdef Explicit_Track
 SDL::trackCandidates* SDL::Event::getTrackCandidates()
 {
     if(trackCandidatesInCPU == nullptr)
@@ -2685,7 +2493,7 @@ SDL::trackCandidates* SDL::Event::getTrackCandidates()
         trackCandidatesInCPU = new SDL::trackCandidates;
         trackCandidatesInCPU->nTrackCandidates = new unsigned int;
         cudaMemcpyAsync(trackCandidatesInCPU->nTrackCandidates, trackCandidatesInGPU->nTrackCandidates, sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
-cudaStreamSynchronize(stream);
+        cudaStreamSynchronize(stream);
         unsigned int nTrackCandidates = *(trackCandidatesInCPU->nTrackCandidates);
 
         trackCandidatesInCPU->objectIndices = new unsigned int[2 * nTrackCandidates];
@@ -2699,17 +2507,11 @@ cudaStreamSynchronize(stream);
         cudaMemcpyAsync(trackCandidatesInCPU->logicalLayers, trackCandidatesInGPU->logicalLayers, 7 * nTrackCandidates * sizeof(uint8_t), cudaMemcpyDeviceToHost, stream);
         cudaMemcpyAsync(trackCandidatesInCPU->objectIndices, trackCandidatesInGPU->objectIndices, 2 * nTrackCandidates * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);                                                                                    
         cudaMemcpyAsync(trackCandidatesInCPU->trackCandidateType, trackCandidatesInGPU->trackCandidateType, nTrackCandidates * sizeof(short), cudaMemcpyDeviceToHost,stream);                                                                                                                
-cudaStreamSynchronize(stream);
+        cudaStreamSynchronize(stream);
     }
     return trackCandidatesInCPU;
 }
-#else
-SDL::trackCandidates* SDL::Event::getTrackCandidates()
-{
-    return trackCandidatesInGPU;
-}
-#endif
-#ifdef Explicit_Module
+
 SDL::modules* SDL::Event::getFullModules()
 {
     if(modulesInCPUFull == nullptr)
@@ -2765,7 +2567,7 @@ SDL::modules* SDL::Event::getModules()
         modulesInCPU = new SDL::modules;
         uint16_t nLowerModules;
         cudaMemcpyAsync(&nLowerModules, modulesInGPU->nLowerModules, sizeof(uint16_t), cudaMemcpyDeviceToHost,stream);
-cudaStreamSynchronize(stream);
+        cudaStreamSynchronize(stream);
         modulesInCPU->nLowerModules = new uint16_t[1];
         modulesInCPU->nModules = new uint16_t[1];
         modulesInCPU->detIds = new unsigned int[nModules];
@@ -2793,22 +2595,11 @@ cudaStreamSynchronize(stream);
         cudaMemcpyAsync(modulesInCPU->eta, modulesInGPU->eta, nModules * sizeof(short), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(modulesInCPU->r, modulesInGPU->r, nModules * sizeof(short), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(modulesInCPU->moduleType, modulesInGPU->moduleType, nModules * sizeof(ModuleType), cudaMemcpyDeviceToHost, stream);
-cudaStreamSynchronize(stream);
+        cudaStreamSynchronize(stream);
     }
     return modulesInCPU;
 }
-#else
-SDL::modules* SDL::Event::getModules()
-{
-    return modulesInGPU;
-}
-SDL::modules* SDL::Event::getFullModules()
-{
-    return modulesInGPU;
-}
-#endif
 
-#ifdef Explicit_Extensions
 SDL::trackExtensions* SDL::Event::getTrackExtensions()
 {
    if(trackExtensionsInCPU == nullptr)
@@ -2858,10 +2649,4 @@ SDL::trackExtensions* SDL::Event::getTrackExtensions()
 
    return trackExtensionsInCPU;
 }
-#else
-SDL::trackExtensions* SDL::Event::getTrackExtensions()
-{
-    return trackExtensionsInGPU;
-}
-#endif
 

--- a/SDL/Hit.cu
+++ b/SDL/Hit.cu
@@ -30,74 +30,6 @@ SDL::hits::hits()
 SDL::hits::~hits()
 {
 }
-//FIXME:New array!
-void SDL::createHitsInUnifiedMemory(struct hits& hitsInGPU, int nModules, unsigned int nMaxHits,unsigned int nMax2SHits,cudaStream_t stream, unsigned int evtnum)
-{
-//#ifdef CACHE_ALLOC
-#if defined(CACHE_ALLOC)
-//    cudaStream_t stream=0;
-    hitsInGPU.xs = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-    hitsInGPU.ys = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-    hitsInGPU.zs = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-
-    hitsInGPU.rts = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-    hitsInGPU.phis = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-    hitsInGPU.etas = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-
-    hitsInGPU.moduleIndices = (uint16_t*)cms::cuda::allocate_managed(nMaxHits*sizeof(uint16_t),stream);
-    hitsInGPU.idxs = (unsigned int*)cms::cuda::allocate_managed(nMaxHits*sizeof(unsigned int),stream);
-    hitsInGPU.detid = (unsigned int*)cms::cuda::allocate_managed(nMaxHits*sizeof(unsigned int),stream);
-
-    hitsInGPU.highEdgeXs = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-    hitsInGPU.highEdgeYs = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-    hitsInGPU.lowEdgeXs = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-    hitsInGPU.lowEdgeYs = (float*)cms::cuda::allocate_managed(nMaxHits*sizeof(float),stream);
-
-    hitsInGPU.nHits = (unsigned int*)cms::cuda::allocate_managed(evtnum*sizeof(unsigned int),stream);
-    
-    hitsInGPU.hitRanges =                 (int*)cms::cuda::allocate_managed(evtnum*nModules * 2 * sizeof(int),stream);
-    hitsInGPU.hitRangesLower =                 (int*)cms::cuda::allocate_managed(    evtnum*nModules * sizeof(int),stream);
-    hitsInGPU.hitRangesUpper =                 (int*)cms::cuda::allocate_managed(    evtnum*nModules * sizeof(int),stream);
-    hitsInGPU.hitRangesnLower =                 (int8_t*)cms::cuda::allocate_managed(evtnum*nModules * sizeof(int8_t),stream);
-    hitsInGPU.hitRangesnUpper =                 (int8_t*)cms::cuda::allocate_managed(evtnum*nModules * sizeof(int8_t),stream);
-#else
-    //nMaxHits and nMax2SHits are the maximum possible numbers
-    cudaMallocManaged(&hitsInGPU.xs, nMaxHits * sizeof(float));
-    cudaMallocManaged(&hitsInGPU.ys, nMaxHits * sizeof(float));
-    cudaMallocManaged(&hitsInGPU.zs, nMaxHits * sizeof(float));
-    cudaMallocManaged(&hitsInGPU.moduleIndices, nMaxHits * sizeof(uint16_t));
-    //TODO:This dude (idxs) is not used in the GPU at all. It is only used for simhit matching to make efficiency plots
-    //We can even skip this one later
-    cudaMallocManaged(&hitsInGPU.idxs, nMaxHits * sizeof(unsigned int));
-    cudaMallocManaged(&hitsInGPU.detid, nMaxHits * sizeof(unsigned int));
-
-    cudaMallocManaged(&hitsInGPU.rts, nMaxHits * sizeof(float));
-    cudaMallocManaged(&hitsInGPU.phis, nMaxHits * sizeof(float));
-    cudaMallocManaged(&hitsInGPU.etas, nMaxHits * sizeof(float));
-
-    cudaMallocManaged(&hitsInGPU.highEdgeXs, nMaxHits * sizeof(float));
-    cudaMallocManaged(&hitsInGPU.highEdgeYs, nMaxHits * sizeof(float));
-    cudaMallocManaged(&hitsInGPU.lowEdgeXs, nMaxHits * sizeof(float));
-    cudaMallocManaged(&hitsInGPU.lowEdgeYs, nMaxHits * sizeof(float));
-
-    //counters
-    cudaMallocManaged(&hitsInGPU.nHits, evtnum*sizeof(unsigned int));
-
-    cudaMallocManaged(&hitsInGPU.hitRanges,      evtnum*nModules * 2 * sizeof(int));
-    cudaMallocManaged(&hitsInGPU.hitRangesLower, evtnum*nModules  * sizeof(int));
-    cudaMallocManaged(&hitsInGPU.hitRangesUpper, evtnum*nModules  * sizeof(int));
-    cudaMallocManaged(&hitsInGPU.hitRangesnLower,evtnum*nModules  * sizeof(int8_t));
-    cudaMallocManaged(&hitsInGPU.hitRangesnUpper,evtnum*nModules  * sizeof(int8_t));
-#endif
-    //*hitsInGPU.nHits = 0;
-    cudaMemsetAsync(hitsInGPU.nHits, 0,      evtnum*sizeof(unsigned int),stream);
-    cudaMemsetAsync(hitsInGPU.hitRanges, -1,      evtnum*nModules*2*sizeof(int),stream);
-    cudaMemsetAsync(hitsInGPU.hitRangesLower, -1, evtnum*nModules*sizeof(int),stream);
-    cudaMemsetAsync(hitsInGPU.hitRangesUpper, -1, evtnum*nModules*sizeof(int),stream);
-    cudaMemsetAsync(hitsInGPU.hitRangesnLower, -1,evtnum*nModules*sizeof(int8_t),stream);
-    cudaMemsetAsync(hitsInGPU.hitRangesnUpper, -1,evtnum*nModules*sizeof(int8_t),stream);
-    cudaStreamSynchronize(stream);
-}
 void SDL::createHitsInExplicitMemory(struct hits& hitsInGPU, int nModules, unsigned int nMaxHits,cudaStream_t stream,unsigned int evtnum)
 {
 //#ifdef CACHE_ALLOC
@@ -206,7 +138,6 @@ void SDL::printHit(struct hits& hitsInGPU, struct modules& modulesInGPU, unsigne
 
 void SDL::hits::freeMemoryCache()
 {
-#ifdef Explicit_Hit
     int dev;
     cudaGetDevice(&dev);
     cms::cuda::free_device(dev,nHits);
@@ -230,29 +161,6 @@ void SDL::hits::freeMemoryCache()
     cms::cuda::free_device(dev,hitRangesnLower);
     cms::cuda::free_device(dev,hitRangesUpper);
     cms::cuda::free_device(dev,hitRangesnUpper);
-#else
-    cms::cuda::free_managed(nHits);
-    cms::cuda::free_managed(xs);
-    cms::cuda::free_managed(ys);
-    cms::cuda::free_managed(zs);
-    cms::cuda::free_managed(moduleIndices);
-    cms::cuda::free_managed(rts);
-    cms::cuda::free_managed(idxs);
-    cms::cuda::free_managed(detid);
-    cms::cuda::free_managed(phis);
-    cms::cuda::free_managed(etas);
-
-    cms::cuda::free_managed(highEdgeXs);
-    cms::cuda::free_managed(highEdgeYs);
-    cms::cuda::free_managed(lowEdgeXs);
-    cms::cuda::free_managed(lowEdgeYs);
-    
-    cms::cuda::free_managed(hitRanges);
-    cms::cuda::free_managed(hitRangesLower);
-    cms::cuda::free_managed(hitRangesnLower);
-    cms::cuda::free_managed(hitRangesUpper);
-    cms::cuda::free_managed(hitRangesnUpper);
-#endif
 }
 void SDL::hits::freeMemory()
 //void SDL::hits::freeMemory(cudaStream_t stream)

--- a/SDL/Hit.cuh
+++ b/SDL/Hit.cuh
@@ -59,7 +59,6 @@ namespace SDL
 
     };
 
-    void createHitsInUnifiedMemory(struct hits& hitsInGPU, int nModules, unsigned int maxHits, unsigned int max2SHits,cudaStream_t stream,unsigned int evtnum);
     void createHitsInExplicitMemory(struct hits& hitsInGPU, int nModules, unsigned int maxHits,cudaStream_t stream,unsigned int evtnum);
     CUDA_G void addHitToMemoryKernel(struct hits& hitsInGPU,struct modules& modulesInGPU,const float* x,const float* y, const float* z,const uint16_t* moduleIndex,const float* phis, const int loopsize);
     //CUDA_G void checkHits(struct hits& hitsInGPU, const int loopsize);

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -27,7 +27,7 @@ DUPLICATES           = -DDUP_pLS -DDUP_T5 -DDUP_pT5 -DDUP_pT3 -DCrossclean_T5 -D
 MEMFLAG              =
 CACHEFLAG            =
 CUDALAUNCHFLAG       = #-DNESTED_PARA 
-MEMFLAG_FLAGS        = -DExplicit_MD -DExplicit_Seg -DExplicit_Tracklet -DExplicit_Trips -DExplicit_Hit -DExplicit_Track -DExplicit_Module -DExplicit_T5 -DExplicit_PT3 -DExplicit_PT5 -DExplicit_Extensions
+MEMFLAG_FLAGS        =
 CACHEFLAG_FLAGS      = -DCACHE_ALLOC
 CUDALAUNCHFLAG_FLAGS = #-DNEWGRID_MD -DNEWGRID_Seg -DNEWGRID_Trips -DNEWGRID_Tracklet -DNEWGRID_Pixel -DNEWGRID_Track -DNEWGRID_T5 -DNEWGRID_pT3 -DNEWGRID_pT5
 PT0P8       =
@@ -49,13 +49,6 @@ $(LIB):$(CCOBJECTS) $(CUOBJECTS)
 #$(LIB):$(CUOBJECTS)
 	$(LD)  $(SOFLAGS) $^ -o $@
 
-unified_cutvalue: CUTVALUEFLAG = $(CUTVALUEFLAG_FLAGS)
-unified_cutvalue: $(LIB) 
-unified: $(LIB)
-
-unified_cache: CACHEFLAG += $(CACHEFLAG_FLAGS)
-unified_cache: $(LIB)
-
 explicit: MEMFLAG += $(MEMFLAG_FLAGS)
 explicit: $(LIB)
 
@@ -67,9 +60,6 @@ explicit_cache_cutvalue: CUTVALUEFLAG = $(CUTVALUEFLAG_FLAGS)
 explicit_cache_cutvalue: MEMFLAG += $(MEMFLAG_FLAGS)
 explicit_cache_cutvalue: CACHEFLAG += $(CACHEFLAG_FLAGS)
 explicit_cache_cutvalue: $(LIB)
-
-
-all: unified
 
 clean:
 	rm -f *.opp \

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -86,67 +86,6 @@ void SDL::createMDArrayRanges(struct modules& modulesInGPU, struct objectRanges&
     cms::cuda::free_host(module_eta);
 }
 
-void SDL::createMDsInUnifiedMemory(struct miniDoublets& mdsInGPU, unsigned int nMemoryLocations, uint16_t nLowerModules, unsigned int maxPixelMDs,cudaStream_t stream)
-{
-#ifdef CACHE_ALLOC
-   // cudaStream_t stream=0;
-    mdsInGPU.anchorHitIndices = (unsigned int*)cms::cuda::allocate_managed(nMemoryLocations * 2 * sizeof(unsigned int), stream);
-    mdsInGPU.moduleIndices = (uint16_t*)cms::cuda::allocate_managed(nMemoryLocations * sizeof(uint16_t), stream);
-    mdsInGPU.nMDs = (unsigned int*)cms::cuda::allocate_managed((nLowerModules + 1)*sizeof(unsigned int),stream);
-    mdsInGPU.totOccupancyMDs = (unsigned int*)cms::cuda::allocate_managed((nLowerModules + 1)*sizeof(unsigned int),stream);
-    mdsInGPU.dphichanges = (float*)cms::cuda::allocate_managed(nMemoryLocations*9*sizeof(float),stream);
-    mdsInGPU.anchorX = (float*)cms::cuda::allocate_managed(nMemoryLocations * 6 * sizeof(float), stream);
-    mdsInGPU.anchorHighEdgeX = (float*)cms::cuda::allocate_managed(nMemoryLocations * 4 * sizeof(float), stream);
-    mdsInGPU.outerX = (float*)cms::cuda::allocate_managed(nMemoryLocations * 6 * sizeof(float), stream);
-    mdsInGPU.outerHighEdgeX = (float*)cms::cuda::allocate_managed(nMemoryLocations * 4 * sizeof(float), stream);
-
-    mdsInGPU.nMemoryLocations = (unsigned int*)cms::cuda::allocate_managed(sizeof(unsigned int), stream);
-#else
-    cudaMallocManaged(&mdsInGPU.anchorHitIndices, nMemoryLocations * 2 * sizeof(unsigned int));
-    cudaMallocManaged(&mdsInGPU.moduleIndices, nMemoryLocations * sizeof(uint16_t));
-    cudaMallocManaged(&mdsInGPU.dphichanges, nMemoryLocations * 9 * sizeof(float));
-    cudaMallocManaged(&mdsInGPU.nMDs, (nLowerModules + 1) * sizeof(unsigned int));
-    cudaMallocManaged(&mdsInGPU.totOccupancyMDs, (nLowerModules + 1) * sizeof(unsigned int));
-    cudaMallocManaged(&mdsInGPU.anchorX, nMemoryLocations * 6 * sizeof(float));
-    cudaMallocManaged(&mdsInGPU.anchorHighEdgeX, nMemoryLocations * 4 * sizeof(float));
-    cudaMallocManaged(&mdsInGPU.outerX, nMemoryLocations * 10 * sizeof(float));
-    cudaMallocManaged(&mdsInGPU.outerHighEdgeX, nMemoryLocations * 4 * sizeof(float));
-
-    cudaMallocManaged(&mdsInGPU.nMemoryLocations, sizeof(unsigned int));
-#endif
-    mdsInGPU.outerHitIndices = mdsInGPU.anchorHitIndices + nMemoryLocations;
-    mdsInGPU.dzs  = mdsInGPU.dphichanges + nMemoryLocations;
-    mdsInGPU.dphis  = mdsInGPU.dphichanges + 2*nMemoryLocations;
-    mdsInGPU.shiftedXs  = mdsInGPU.dphichanges + 3*nMemoryLocations;
-    mdsInGPU.shiftedYs  = mdsInGPU.dphichanges + 4*nMemoryLocations;
-    mdsInGPU.shiftedZs  = mdsInGPU.dphichanges + 5*nMemoryLocations;
-    mdsInGPU.noShiftedDzs  = mdsInGPU.dphichanges + 6*nMemoryLocations;
-    mdsInGPU.noShiftedDphis  = mdsInGPU.dphichanges + 7*nMemoryLocations;
-    mdsInGPU.noShiftedDphiChanges  = mdsInGPU.dphichanges + 8*nMemoryLocations;
-
-    mdsInGPU.anchorY = mdsInGPU.anchorX + nMemoryLocations;
-    mdsInGPU.anchorZ = mdsInGPU.anchorX + 2 * nMemoryLocations;
-    mdsInGPU.anchorRt = mdsInGPU.anchorX + 3 * nMemoryLocations;
-    mdsInGPU.anchorPhi = mdsInGPU.anchorX + 4 * nMemoryLocations;
-    mdsInGPU.anchorEta = mdsInGPU.anchorX + 5 * nMemoryLocations;
-    mdsInGPU.anchorHighEdgeY = mdsInGPU.anchorHighEdgeX + nMemoryLocations;
-    mdsInGPU.anchorLowEdgeX = mdsInGPU.anchorHighEdgeX + 2 * nMemoryLocations;
-    mdsInGPU.anchorLowEdgeY = mdsInGPU.anchorHighEdgeX + 3 * nMemoryLocations;
-
-    mdsInGPU.outerY = mdsInGPU.outerX + nMemoryLocations;
-    mdsInGPU.outerZ = mdsInGPU.outerX + 2 * nMemoryLocations;
-    mdsInGPU.outerRt = mdsInGPU.outerX + 3 * nMemoryLocations;
-    mdsInGPU.outerPhi = mdsInGPU.outerX + 4 * nMemoryLocations;
-    mdsInGPU.outerEta = mdsInGPU.outerX + 5 * nMemoryLocations;
-    mdsInGPU.outerHighEdgeY = mdsInGPU.outerHighEdgeX + nMemoryLocations;
-    mdsInGPU.outerLowEdgeX = mdsInGPU.outerHighEdgeX + 2 * nMemoryLocations;
-    mdsInGPU.outerLowEdgeY = mdsInGPU.outerHighEdgeX + 3 * nMemoryLocations;
-
-    cudaMemsetAsync(mdsInGPU.nMDs,0, (nLowerModules + 1) *sizeof(unsigned int),stream);
-    cudaMemsetAsync(mdsInGPU.totOccupancyMDs,0, (nLowerModules + 1) *sizeof(unsigned int),stream);
-    cudaStreamSynchronize(stream);
-}
-
 //FIXME:Add memory locations for the pixel MDs here!
 void SDL::createMDsInExplicitMemory(struct miniDoublets& mdsInGPU, unsigned int nMemoryLocations, uint16_t nLowerModules, unsigned int maxPixelMDs,cudaStream_t stream)
 {
@@ -895,7 +834,6 @@ SDL::miniDoublets::~miniDoublets()
 
 void SDL::miniDoublets::freeMemoryCache()
 {
-#ifdef Explicit_MD
     int dev;
     cudaGetDevice(&dev);
     cms::cuda::free_device(dev,anchorHitIndices);
@@ -908,18 +846,6 @@ void SDL::miniDoublets::freeMemoryCache()
     cms::cuda::free_device(dev, outerX);
     cms::cuda::free_device(dev, outerHighEdgeX);
     cms::cuda::free_device(dev, nMemoryLocations);
-#else
-    cms::cuda::free_managed(anchorHitIndices);
-    cms::cuda::free_managed(moduleIndices);
-    cms::cuda::free_managed(dphichanges);
-    cms::cuda::free_managed(nMDs);
-    cms::cuda::free_managed(totOccupancyMDs);
-    cms::cuda::free_managed(anchorX);
-    cms::cuda::free_managed(anchorHighEdgeX);
-    cms::cuda::free_managed(outerX);
-    cms::cuda::free_managed(outerHighEdgeX);
-    cms::cuda::free_managed(nMemoryLocations);
-#endif
 }
 
 

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -89,7 +89,6 @@ namespace SDL
 
 
 
-    void createMDsInUnifiedMemory(struct miniDoublets& mdsInGPU, unsigned int maxMDs,uint16_t nLowerModules, unsigned int maxPixelMDs, cudaStream_t stream);
     void createMDsInExplicitMemory(struct miniDoublets& mdsInGPU, unsigned int maxMDs,uint16_t nLowerModules, unsigned int maxPixelMDs,cudaStream_t stream);
 
 

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -126,7 +126,6 @@ void SDL::objectRanges::freeMemory()
   cudaFree(quintupletRanges);
   cudaFree(nEligibleT5Modules);
   cudaFree(indicesOfEligibleT5Modules);
-  cudaFree(indicesOfEligibleT5Modules);
   cudaFree(quintupletModuleIndices);
   cudaFree(miniDoubletModuleIndices);
   cudaFree(segmentModuleIndices);

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -11,49 +11,6 @@ std::map <unsigned int, float> *SDL::module_z;
 std::map <unsigned int, unsigned int> *SDL::module_type; // 23 : Ph2PSP, 24 : Ph2PSS, 25 : Ph2SS
 #endif
 
-void SDL::createRangesInUnifiedMemory(struct objectRanges& rangesInGPU,unsigned int nModules,cudaStream_t stream, unsigned int nLowerModules)
-{
-    /* modules stucture object will be created in Event.cu*/
-#ifdef CACHE_ALLOC
-    rangesInGPU.hitRanges =                 (int*)cms::cuda::allocate_managed(nModules * 2 * sizeof(int),stream);
-    rangesInGPU.hitRangesLower =                 (int*)cms::cuda::allocate_managed(nModules * sizeof(int),stream);
-    rangesInGPU.hitRangesUpper =                 (int*)cms::cuda::allocate_managed(nModules * sizeof(int),stream);
-    rangesInGPU.hitRangesnLower =                 (int8_t*)cms::cuda::allocate_managed(nModules * sizeof(int8_t),stream);
-    rangesInGPU.hitRangesnUpper =                 (int8_t*)cms::cuda::allocate_managed(nModules * sizeof(int8_t),stream);
-    rangesInGPU.mdRanges =                  (int*)cms::cuda::allocate_managed(nModules * 2 * sizeof(int),stream);
-    rangesInGPU.segmentRanges =             (int*)cms::cuda::allocate_managed(nModules * 2 * sizeof(int),stream);
-    rangesInGPU.trackletRanges =            (int*)cms::cuda::allocate_managed(nModules * 2 * sizeof(int),stream);
-    rangesInGPU.tripletRanges =             (int*)cms::cuda::allocate_managed(nModules * 2 * sizeof(int),stream);
-    rangesInGPU.trackCandidateRanges =      (int*)cms::cuda::allocate_managed(nModules * 2 * sizeof(int),stream);
-    rangesInGPU.quintupletRanges =          (int*)cms::cuda::allocate_managed(nModules * 2 * sizeof(int),stream);
-    rangesInGPU.nEligibleT5Modules =        (uint16_t*)cms::cuda::allocate_managed(sizeof(unsigned int),stream);
-
-    rangesInGPU.quintupletModuleIndices = (int*)cms::cuda::allocate_managed(nLowerModules * sizeof(int),stream);
-    rangesInGPU.miniDoubletModuleIndices = (int*)cms::cuda::allocate_managed((nLowerModules + 1) * sizeof(int), stream);
-    rangesInGPU.segmentModuleIndices = (int*)cms::cuda::allocate_managed((nLowerModules + 1) * sizeof(int), stream);
-    rangesInGPU.tripletModuleIndices = (int*)cms::cuda::allocate_managed(nLowerModules * sizeof(int), stream);
-
-#else
-    cudaMallocManaged(&rangesInGPU.hitRanges,nModules * 2 * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.hitRangesLower,nModules  * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.hitRangesUpper,nModules  * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.hitRangesnLower,nModules  * sizeof(int8_t));
-    cudaMallocManaged(&rangesInGPU.hitRangesnUpper,nModules  * sizeof(int8_t));
-    cudaMallocManaged(&rangesInGPU.mdRanges,nModules * 2 * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.segmentRanges,nModules * 2 * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.trackletRanges,nModules * 2 * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.tripletRanges,nModules * 2 * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.trackCandidateRanges, nModules * 2 * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.quintupletRanges, nModules * 2 * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.nEligibleT5Modules, sizeof(uint16_t));
-
-    cudaMallocManaged(&rangesInGPU.quintupletModuleIndices, nLowerModules * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.miniDoubletModuleIndices, (nLowerModules + 1) * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.segmentModuleIndices, (nLowerModules + 1) * sizeof(int));
-    cudaMallocManaged(&rangesInGPU.tripletModuleIndices, nLowerModules * sizeof(int));
-
-#endif
-}
 void SDL::createRangesInExplicitMemory(struct objectRanges& rangesInGPU,unsigned int nModules,cudaStream_t stream, unsigned int nLowerModules)
 {
     /* modules stucture object will be created in Event.cu*/
@@ -99,36 +56,7 @@ void SDL::createRangesInExplicitMemory(struct objectRanges& rangesInGPU,unsigned
 
 #endif
 }
-void SDL::createModulesInUnifiedMemory(struct modules& modulesInGPU,unsigned int nModules,cudaStream_t stream)
-{
-    cudaMallocManaged(&modulesInGPU.detIds,nModules * sizeof(unsigned int));
-    cudaMallocManaged(&modulesInGPU.moduleMap,nModules * 40 * sizeof(uint16_t));
-    cudaMallocManaged(&modulesInGPU.mapIdx, nModules*sizeof(uint16_t));
-    cudaMallocManaged(&modulesInGPU.mapdetId, nModules*sizeof(unsigned int));
-    cudaMallocManaged(&modulesInGPU.nConnectedModules,nModules * sizeof(uint16_t));
-    cudaMallocManaged(&modulesInGPU.drdzs,nModules * sizeof(float));
-    cudaMallocManaged(&modulesInGPU.slopes,nModules * sizeof(float));
-    cudaMallocManaged(&modulesInGPU.nModules,sizeof(uint16_t));
-    cudaMallocManaged(&modulesInGPU.nLowerModules,sizeof(uint16_t));
-    cudaMallocManaged(&modulesInGPU.partnerModuleIndices, nModules * sizeof(uint16_t));
 
-    cudaMallocManaged(&modulesInGPU.layers,nModules * sizeof(short));
-    cudaMallocManaged(&modulesInGPU.rings,nModules * sizeof(short));
-    cudaMallocManaged(&modulesInGPU.modules,nModules * sizeof(short));
-    cudaMallocManaged(&modulesInGPU.rods,nModules * sizeof(short));
-    cudaMallocManaged(&modulesInGPU.subdets,nModules * sizeof(short));
-    cudaMallocManaged(&modulesInGPU.sides,nModules * sizeof(short));
-    cudaMallocManaged(&modulesInGPU.eta,nModules * sizeof(float));
-    cudaMallocManaged(&modulesInGPU.r,nModules * sizeof(float));
-    cudaMallocManaged(&modulesInGPU.isInverted, nModules * sizeof(bool));
-    cudaMallocManaged(&modulesInGPU.isLower, nModules * sizeof(bool));
-    cudaMallocManaged(&modulesInGPU.isAnchor, nModules * sizeof(bool));
-    cudaMallocManaged(&modulesInGPU.moduleType,nModules * sizeof(ModuleType));
-
-    cudaMallocManaged(&modulesInGPU.moduleLayerType,nModules * sizeof(ModuleLayerType));
-
-    *modulesInGPU.nModules = nModules;
-}
 void SDL::createModulesInExplicitMemory(struct modules& modulesInGPU,unsigned int nModules,cudaStream_t stream)
 {
     /* modules stucture object will be created in Event.cu*/
@@ -163,7 +91,6 @@ void SDL::createModulesInExplicitMemory(struct modules& modulesInGPU,unsigned in
 
 void SDL::objectRanges::freeMemoryCache()//struct objectRanges& rangesInGPU)
 {
-#ifdef Explicit_Module
   int dev;
   cudaGetDevice(&dev);
   cms::cuda::free_device(dev,hitRanges);
@@ -183,26 +110,6 @@ void SDL::objectRanges::freeMemoryCache()//struct objectRanges& rangesInGPU)
   cms::cuda::free_device(dev, miniDoubletModuleIndices);
   cms::cuda::free_device(dev, segmentModuleIndices);
   cms::cuda::free_device(dev, tripletModuleIndices);
-#else
-  cms::cuda::free_managed(hitRanges);
-  cms::cuda::free_managed(mdRanges);
-  cms::cuda::free_managed(segmentRanges);
-  cms::cuda::free_managed(trackletRanges);
-  cms::cuda::free_managed(tripletRanges);
-  cms::cuda::free_managed(trackCandidateRanges);
-  cms::cuda::free_managed(quintupletRanges);
-  cms::cuda::free_managed(nEligibleT5Modules);
-  cms::cuda::free_managed(indicesOfEligibleT5Modules);
-  cms::cuda::free_managed(quintupletModuleIndices);
-  cms::cuda::free_managed(hitRangesLower);
-  cms::cuda::free_managed(hitRangesUpper);
-  cms::cuda::free_managed(hitRangesnLower);
-  cms::cuda::free_managed(hitRangesnUpper);
-  cms::cuda::free_managed(miniDoubletModuleIndices);
-  cms::cuda::free_managed(segmentModuleIndices);
-  cms::cuda::free_managed(tripletModuleIndices);
-
-#endif
 }
 void SDL::objectRanges::freeMemory()
 {
@@ -227,7 +134,6 @@ void SDL::objectRanges::freeMemory()
 }
 void SDL::freeModulesCache(struct modules& modulesInGPU,struct pixelMap& pixelMapping)
 {
-#ifdef Explicit_Module
   int dev;
   cudaGetDevice(&dev);
   cms::cuda::free_device(dev,modulesInGPU.detIds);
@@ -251,29 +157,6 @@ void SDL::freeModulesCache(struct modules& modulesInGPU,struct pixelMap& pixelMa
   cms::cuda::free_device(dev,modulesInGPU.moduleType);
   cms::cuda::free_device(dev,modulesInGPU.moduleLayerType);
   cms::cuda::free_device(dev,modulesInGPU.connectedPixels);
-#else
-  cms::cuda::free_managed(modulesInGPU.detIds);
-  cms::cuda::free_managed(modulesInGPU.moduleMap);
-  cms::cuda::free_managed(modulesInGPU.mapIdx);
-  cms::cuda::free_managed(modulesInGPU.mapdetId);
-  cms::cuda::free_managed(modulesInGPU.nConnectedModules);
-  cms::cuda::free_managed(modulesInGPU.drdzs);
-  cms::cuda::free_managed(modulesInGPU.slopes);
-  cms::cuda::free_managed(modulesInGPU.nModules);
-  cms::cuda::free_managed(modulesInGPU.nLowerModules);
-  cms::cuda::free_managed(modulesInGPU.layers);
-  cms::cuda::free_managed(modulesInGPU.rings);
-  cms::cuda::free_managed(modulesInGPU.modules);
-  cms::cuda::free_managed(modulesInGPU.rods);
-  cms::cuda::free_managed(modulesInGPU.subdets);
-  cms::cuda::free_managed(modulesInGPU.sides);
-  cms::cuda::free_managed(modulesInGPU.isInverted);
-  cms::cuda::free_managed(modulesInGPU.isLower);
-  cms::cuda::free_managed(modulesInGPU.isAnchor);
-  cms::cuda::free_managed(modulesInGPU.moduleType);
-  cms::cuda::free_managed(modulesInGPU.moduleLayerType);
-  cms::cuda::free_managed(modulesInGPU.connectedPixels);
-#endif
   cudaFreeHost(pixelMapping.connectedPixelsSizes);
   cudaFreeHost(pixelMapping.connectedPixelsSizesPos);
   cudaFreeHost(pixelMapping.connectedPixelsSizesNeg);
@@ -397,7 +280,6 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, 
     counter++;
     nModules = counter;
     std::cout<<"Number of modules = "<<nModules<<std::endl;
-#ifdef Explicit_Module
     createModulesInExplicitMemory(modulesInGPU,nModules,stream);
     unsigned int* host_detIds;
     short* host_layers;
@@ -602,136 +484,6 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, 
     fillConnectedModuleArrayExplicit(modulesInGPU,nModules,stream);
     fillMapArraysExplicit(modulesInGPU, nModules, stream);
     fillPixelMap(modulesInGPU,pixelMapping,stream);
-
-#else
-    createModulesInUnifiedMemory(modulesInGPU,nModules,stream);
-    nLowerModules = (nModules - 1) / 2;
-    unsigned int lowerModuleCounter = 0;
-    unsigned int upperModuleCounter = nLowerModules + 1;
-    for(auto it = (*detIdToIndex).begin(); it != (*detIdToIndex).end(); it++)
-    {
-        unsigned int detId = it->first;
-        float m_x = (*module_x)[detId];
-        float m_y = (*module_y)[detId];
-        float m_z = (*module_z)[detId];
-#ifdef CMSSW12GEOM
-        unsigned int m_t = (*module_type)[detId];
-#endif
-
-        float eta,r;
-
-        uint16_t index;
-        unsigned short layer,ring,rod,module,subdet,side;
-        bool isInverted, isLower;
-        if(detId == 1)
-        {
-            layer = 0;
-            ring = 0;
-            rod = 0;
-            module = 0;
-            subdet = 0;
-            side = 0;
-            isInverted = false;
-            isLower = false;
-
-        }
-        else
-        {
-            setDerivedQuantities(detId,layer,ring,rod,module,subdet,side,m_x,m_y,m_z,eta,r);
-            isInverted = modulesInGPU.parseIsInverted(subdet, side, module, layer);
-            isLower = modulesInGPU.parseIsLower(isInverted, detId);
-        }
-        if(isLower)
-        {
-            index = lowerModuleCounter;
-            lowerModuleCounter++;
-        }
-        else if(detId != 1)
-        {
-            index = upperModuleCounter;
-            upperModuleCounter++;
-        }
-        else
-        {
-            index = nLowerModules; //pixel
-        }
-        //reassigning indices!
-        (*detIdToIndex)[detId] = index;   
-        modulesInGPU.detIds[index] = detId;
-        modulesInGPU.layers[index] = layer;
-        modulesInGPU.rings[index] = ring;
-        modulesInGPU.rods[index] = rod;
-        modulesInGPU.modules[index] = module;
-        modulesInGPU.subdets[index] = subdet;
-        modulesInGPU.sides[index] = side;
-        modulesInGPU.isInverted[index] = isInverted;
-        modulesInGPU.isLower[index] = isLower;
-        modulesInGPU.eta[index] = eta;
-        modulesInGPU.r[index] = r;
-
-        if(detId == 1)
-        {
-            modulesInGPU.moduleType[index] = PixelModule;
-            modulesInGPU.moduleLayerType[index] = SDL::InnerPixelLayer;
-            modulesInGPU.slopes[index] = 0;
-            modulesInGPU.drdzs[index] = 0;
-            modulesInGPU.isAnchor[index] = false;
-        }
-        else
-        {
-
-#ifdef CMSSW12GEOM
-            modulesInGPU.moduleType[index]= ( m_t == 25 ? SDL::TwoS : SDL::PS );
-            modulesInGPU.moduleLayerType[index]= ( m_t == 23 ? SDL::Pixel : SDL::Strip );
-#else
-            modulesInGPU.moduleType[index] = modulesInGPU.parseModuleType(subdet, layer, ring);
-            modulesInGPU.moduleLayerType[index] = modulesInGPU.parseModuleLayerType(modulesInGPU.moduleType[index],modulesInGPU.isInverted[index],modulesInGPU.isLower[index]);
-#endif
-
-            if(modulesInGPU.moduleType[index] == SDL::PS and modulesInGPU.moduleLayerType[index] == SDL::Pixel)
-            {
-                modulesInGPU.isAnchor[index] = true;
-            }
-            else if(modulesInGPU.moduleType[index] == SDL::TwoS and modulesInGPU.isLower[index])
-            {
-                modulesInGPU.isAnchor[index] = true;   
-            }
-            else
-            {
-                modulesInGPU.isAnchor[index] = false;
-            }
-
-            modulesInGPU.slopes[index] = (subdet == Endcap) ? endcapGeometry.getSlopeLower(detId) : tiltedGeometry.getSlope(detId);
-            modulesInGPU.drdzs[index] = (subdet == Barrel) ? tiltedGeometry.getDrDz(detId) : 0;
-        }
-    }
-
-
-    //partner module stuff, and slopes and drdz move around
-    for(auto it = (*detIdToIndex).begin(); it != (*detIdToIndex).end(); it++)
-    {
-        auto& detId = it->first;
-        auto& index = it->second;
-        if(detId != 1)
-        {
-            modulesInGPU.partnerModuleIndices[index] = (*detIdToIndex)[modulesInGPU.parsePartnerModuleId(detId, modulesInGPU.isLower[index], modulesInGPU.isInverted[index])];
-            //add drdz and slope importing stuff here!
-            if(modulesInGPU.drdzs[index] == 0)
-            {
-                modulesInGPU.drdzs[index] = modulesInGPU.drdzs[modulesInGPU.partnerModuleIndices[index]];
-            }
-            if(modulesInGPU.slopes[index] == 0)
-            {
-                modulesInGPU.slopes[index] = modulesInGPU.slopes[modulesInGPU.partnerModuleIndices[index]];
-            }
-        }
-    }
-
-    *(modulesInGPU.nLowerModules) = nLowerModules;
-    std::cout<<"number of lower modules (without fake pixel module)= "<<*modulesInGPU.nLowerModules<<std::endl;
-    fillConnectedModuleArray(modulesInGPU,nModules);
-    fillPixelMap(modulesInGPU,pixelMapping,stream);
-    #endif
 }
 
 void SDL::fillConnectedModuleArray(struct modules& modulesInGPU, unsigned int nModules)
@@ -867,11 +619,7 @@ void SDL::fillPixelMap(struct modules& modulesInGPU, struct pixelMap& pixelMappi
 
     unsigned int* connectedPixels;
     connectedPixels = (unsigned int*)cms::cuda::allocate_host((totalSizes+totalSizes_pos+totalSizes_neg) * sizeof(unsigned int), stream);
-#ifdef Explicit_Module
     cudaMalloc(&modulesInGPU.connectedPixels,(totalSizes+totalSizes_pos+totalSizes_neg)* sizeof(unsigned int));
-#else
-    cudaMallocManaged(&modulesInGPU.connectedPixels,(totalSizes+totalSizes_pos+totalSizes_neg)* sizeof(unsigned int));
-#endif
 
     for(int icondet=0; icondet< totalSizes; icondet++){
       connectedPixels[icondet] = (*detIdToIndex)[connectedModuleDetIds[icondet]];
@@ -1222,7 +970,6 @@ SDL::ModuleLayerType SDL::modules::parseModuleLayerType(unsigned int index)
 
 void SDL::resetObjectRanges(struct objectRanges& rangesInGPU, unsigned int nModules,cudaStream_t stream)
 {
-//#ifdef Explicit_Module
         cudaMemsetAsync(rangesInGPU.hitRanges, -1,nModules*2*sizeof(int),stream);
         cudaMemsetAsync(rangesInGPU.hitRangesLower, -1,nModules*sizeof(int),stream);
         cudaMemsetAsync(rangesInGPU.hitRangesUpper, -1,nModules*sizeof(int),stream);

--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -152,7 +152,6 @@ namespace SDL
 
     void createLowerModuleIndexMap(struct modules& modulesInGPU, unsigned int nLowerModules, unsigned int nModules,cudaStream_t stream);
     void createLowerModuleIndexMapExplicit(struct modules& modulesInGPU, unsigned int nLowerModules, unsigned int nModules, bool* isLower,cudaStream_t stream);
-    void createModulesInUnifiedMemory(struct modules& modulesInGPU,unsigned int nModules,cudaStream_t stream);
     void createModulesInExplicitMemory(struct modules& modulesInGPU,unsigned int nModules,cudaStream_t stream);
     void freeModules(struct modules& modulesInGPU,struct pixelMap& pixelMapping);
     void freeModulesCache(struct modules& modulesInGPU,struct pixelMap& pixelMapping);
@@ -162,7 +161,6 @@ namespace SDL
     void fillConnectedModuleArray(struct modules& modulesInGPU, unsigned int nModules);
     void setDerivedQuantities(unsigned int detId, unsigned short& layer, unsigned short& ring, unsigned short& rod, unsigned short& module, unsigned short& subdet, unsigned short& side, float m_x, float m_y, float m_z, float& eta, float& r);
     void resetObjectRanges(struct objectRanges& rangesInGPU, unsigned int nModules,cudaStream_t stream);
-    void createRangesInUnifiedMemory(struct objectRanges& rangesInGPU,unsigned int nModules,cudaStream_t stream, unsigned int nLowerModules);
     void createRangesInExplicitMemory(struct objectRanges& rangesInGPU,unsigned int nModules,cudaStream_t stream, unsigned int nLowerModules);
 }
 

--- a/SDL/PixelTracklet.cuh
+++ b/SDL/PixelTracklet.cuh
@@ -59,7 +59,6 @@ namespace SDL
         void freeMemoryCache();
     };
 
-    void createPixelTrackletsInUnifiedMemory(struct pixelTracklets& pixelTrackletsInGPU, unsigned int maxPixelTracklets,cudaStream_t stream);
     void createPixelTrackletsInExplicitMemory(struct pixelTracklets& pixelTrackletsInGPU, unsigned int maxPixelTracklets,cudaStream_t stream);
 
 #ifdef CUT_VALUE_DEBUG

--- a/SDL/PixelTriplet.cu
+++ b/SDL/PixelTriplet.cu
@@ -33,7 +33,6 @@ SDL::pixelTriplets::pixelTriplets()
 
 void SDL::pixelTriplets::freeMemoryCache()
 {
-#ifdef Explicit_PT3
     int dev;
     cudaGetDevice(&dev);
     cms::cuda::free_device(dev,pixelSegmentIndices);
@@ -55,23 +54,6 @@ void SDL::pixelTriplets::freeMemoryCache()
     cms::cuda::free_device(dev, rPhiChiSquared);
     cms::cuda::free_device(dev, rPhiChiSquaredInwards);
     cms::cuda::free_device(dev, rzChiSquared);
-#endif
-#else
-    cms::cuda::free_managed(pixelSegmentIndices);
-    cms::cuda::free_managed(tripletIndices);
-    cms::cuda::free_managed(nPixelTriplets);
-    cms::cuda::free_managed(totOccupancyPixelTriplets);
-    cms::cuda::free_managed(pixelRadius);
-    cms::cuda::free_managed(tripletRadius);
-    cms::cuda::free_managed(pt);
-    cms::cuda::free_managed(isDup);
-    cms::cuda::free_managed(partOfPT5);
-    cms::cuda::free_managed(centerX);
-    cms::cuda::free_managed(centerY);
-    cms::cuda::free_managed(hitIndices);
-    cms::cuda::free_managed(logicalLayers);
-    cms::cuda::free_managed(lowerModuleIndices);
-
 #endif
 }
 void SDL::pixelTriplets::freeMemory(cudaStream_t stream)
@@ -113,59 +95,6 @@ void SDL::pixelTriplets::resetMemory(unsigned int maxPixelTriplets,cudaStream_t 
     cudaMemsetAsync(pt, 0,maxPixelTriplets * 6*sizeof(FPX),stream);
     cudaMemsetAsync(isDup, 0,maxPixelTriplets * sizeof(bool),stream);
     cudaMemsetAsync(partOfPT5, 0,maxPixelTriplets * sizeof(bool),stream);
-}
-void SDL::createPixelTripletsInUnifiedMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int maxPixelTriplets,cudaStream_t stream)
-{
-#ifdef CACHE_ALLOC
-//    cudaStream_t stream=0;
-    pixelTripletsInGPU.pixelSegmentIndices       =(unsigned int*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(unsigned int),stream);
-    pixelTripletsInGPU.tripletIndices            =(unsigned int*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(unsigned int),stream);
-    pixelTripletsInGPU.nPixelTriplets            =(unsigned int*)cms::cuda::allocate_managed(sizeof(unsigned int),stream);
-    pixelTripletsInGPU.totOccupancyPixelTriplets =(unsigned int*)cms::cuda::allocate_managed(sizeof(unsigned int),stream);
-    pixelTripletsInGPU.pixelRadius               =(FPX*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(FPX),stream);
-    pixelTripletsInGPU.tripletRadius             =(FPX*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(FPX),stream);
-    pixelTripletsInGPU.pt                        =(FPX*)cms::cuda::allocate_managed(maxPixelTriplets * 6*sizeof(FPX),stream);
-    pixelTripletsInGPU.isDup                     =(bool*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(bool),stream);
-    pixelTripletsInGPU.partOfPT5                 =(bool*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(bool),stream);
-
-    pixelTripletsInGPU.centerX = (FPX*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(FPX),stream);
-    pixelTripletsInGPU.centerY = (FPX*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(FPX),stream);
-    pixelTripletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(uint16_t) * 5, stream);
-    pixelTripletsInGPU.hitIndices = (unsigned int*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(unsigned int) * 10, stream);
-    pixelTripletsInGPU.logicalLayers = (uint8_t*)cms::cuda::allocate_managed(maxPixelTriplets * sizeof(uint8_t) * 5, stream);
-
-#else
-    cudaMallocManaged(&pixelTripletsInGPU.pixelSegmentIndices, maxPixelTriplets * sizeof(unsigned int));
-    cudaMallocManaged(&pixelTripletsInGPU.tripletIndices, maxPixelTriplets * sizeof(unsigned int));
-    cudaMallocManaged(&pixelTripletsInGPU.nPixelTriplets, sizeof(unsigned int));
-    cudaMallocManaged(&pixelTripletsInGPU.totOccupancyPixelTriplets, sizeof(unsigned int));
-    cudaMallocManaged(&pixelTripletsInGPU.pixelRadius, maxPixelTriplets * sizeof(FPX));
-    cudaMallocManaged(&pixelTripletsInGPU.tripletRadius, maxPixelTriplets * sizeof(FPX));
-    cudaMallocManaged(&pixelTripletsInGPU.pt, maxPixelTriplets * 6*sizeof(FPX));
-    cudaMallocManaged(&pixelTripletsInGPU.isDup, maxPixelTriplets * sizeof(bool));
-    cudaMallocManaged(&pixelTripletsInGPU.partOfPT5, maxPixelTriplets * sizeof(bool));
-
-    cudaMallocManaged(&pixelTripletsInGPU.centerX, maxPixelTriplets * sizeof(FPX));
-    cudaMallocManaged(&pixelTripletsInGPU.centerY, maxPixelTriplets * sizeof(FPX));
-    cudaMallocManaged(&pixelTripletsInGPU.logicalLayers, maxPixelTriplets * sizeof(uint8_t) * 5);
-    cudaMallocManaged(&pixelTripletsInGPU.hitIndices, maxPixelTriplets * sizeof(unsigned int) * 10);
-    cudaMallocManaged(&pixelTripletsInGPU.lowerModuleIndices, maxPixelTriplets * sizeof(uint16_t) * 5);
-#ifdef CUT_VALUE_DEBUG
-    cudaMallocManaged(&pixelTripletsInGPU.pixelRadiusError, maxPixelTriplets * sizeof(float));
-    cudaMallocManaged(&pixelTripletsInGPU.rPhiChiSquared, maxPixelTriplets * sizeof(float));
-    cudaMallocManaged(&pixelTripletsInGPU.rPhiChiSquaredInwards, maxPixelTriplets * sizeof(float));
-    cudaMallocManaged(&pixelTripletsInGPU.rzChiSquared, maxPixelTriplets * sizeof(float));
-#endif
-#endif
-    pixelTripletsInGPU.eta = pixelTripletsInGPU.pt + maxPixelTriplets;
-    pixelTripletsInGPU.phi = pixelTripletsInGPU.pt + maxPixelTriplets * 2;
-    pixelTripletsInGPU.eta_pix = pixelTripletsInGPU.pt + maxPixelTriplets *3;
-    pixelTripletsInGPU.phi_pix = pixelTripletsInGPU.pt + maxPixelTriplets * 4;
-    pixelTripletsInGPU.score = pixelTripletsInGPU.pt + maxPixelTriplets * 5;
-    cudaMemsetAsync(pixelTripletsInGPU.nPixelTriplets, 0, sizeof(unsigned int),stream);
-    cudaMemsetAsync(pixelTripletsInGPU.totOccupancyPixelTriplets, 0, sizeof(unsigned int),stream);
-    cudaMemsetAsync(pixelTripletsInGPU.partOfPT5, 0, maxPixelTriplets*sizeof(bool),stream);
-    cudaStreamSynchronize(stream);
 }
 
 void SDL::createPixelTripletsInExplicitMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int maxPixelTriplets, cudaStream_t stream)
@@ -1555,7 +1484,6 @@ SDL::pixelQuintuplets::~pixelQuintuplets()
 
 void SDL::pixelQuintuplets::freeMemoryCache()
 {
-#ifdef Explicit_PT5
     int dev;
     cudaGetDevice(&dev);
     cms::cuda::free_device(dev,pixelIndices);
@@ -1577,24 +1505,6 @@ void SDL::pixelQuintuplets::freeMemoryCache()
     cms::cuda::free_device(dev, rzChiSquared);
     cms::cuda::free_device(dev, rPhiChiSquared);
     cms::cuda::free_device(dev, rPhiChiSquaredInwards);
-#endif
-
-#else
-    cms::cuda::free_managed(pixelIndices);
-    cms::cuda::free_managed(T5Indices);
-    cms::cuda::free_managed(nPixelQuintuplets);
-    cms::cuda::free_managed(totOccupancyPixelQuintuplets);
-    cms::cuda::free_managed(isDup);
-    cms::cuda::free_managed(score);
-    cms::cuda::free_managed(eta);
-    cms::cuda::free_managed(phi);
-    cms::cuda::free_managed(hitIndices);
-    cms::cuda::free_managed(logicalLayers);
-    cms::cuda::free_managed(lowerModuleIndices);
-    cms::cuda::free_managed(centerX);
-    cms::cuda::free_managed(centerY);
-    cms::cuda::free_managed(pixelRadius);
-    cms::cuda::free_managed(quintupletRadius);
 #endif
 }
 void SDL::pixelQuintuplets::freeMemory(cudaStream_t stream)
@@ -1640,52 +1550,6 @@ void SDL::pixelQuintuplets::resetMemory(unsigned int maxPixelQuintuplets,cudaStr
     cudaMemsetAsync(score,0, maxPixelQuintuplets * sizeof(FPX),stream);
     cudaMemsetAsync(eta , 0, maxPixelQuintuplets * sizeof(FPX),stream);
     cudaMemsetAsync(phi , 0, maxPixelQuintuplets * sizeof(FPX),stream);
-}
-void SDL::createPixelQuintupletsInUnifiedMemory(struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int maxPixelQuintuplets,cudaStream_t stream)
-{
-#ifdef CACHE_ALLOC
-    pixelQuintupletsInGPU.pixelIndices        = (unsigned int*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(unsigned int),stream);
-    pixelQuintupletsInGPU.T5Indices           = (unsigned int*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(unsigned int),stream);
-    pixelQuintupletsInGPU.nPixelQuintuplets   = (unsigned int*)cms::cuda::allocate_managed(sizeof(unsigned int),stream);
-    pixelQuintupletsInGPU.totOccupancyPixelQuintuplets   = (unsigned int*)cms::cuda::allocate_managed(sizeof(unsigned int),stream);
-    pixelQuintupletsInGPU.isDup               = (bool*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(bool),stream);
-    pixelQuintupletsInGPU.score               = (FPX*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(FPX),stream);
-    pixelQuintupletsInGPU.eta                 = (FPX*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(FPX),stream);
-    pixelQuintupletsInGPU.phi                 = (FPX*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(FPX),stream);
-    pixelQuintupletsInGPU.hitIndices = (unsigned int*)cms::cuda::allocate_managed(maxPixelQuintuplets * 14 * sizeof(unsigned int), stream);
-    pixelQuintupletsInGPU.logicalLayers = (uint8_t*)cms::cuda::allocate_managed(maxPixelQuintuplets * 7 * sizeof(uint8_t), stream);
-    pixelQuintupletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_managed(maxPixelQuintuplets * 7 * sizeof(uint16_t), stream);
-    pixelQuintupletsInGPU.centerX          = (FPX*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(FPX), stream);
-    pixelQuintupletsInGPU.centerY          = (FPX*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(FPX), stream);
-    pixelQuintupletsInGPU.pixelRadius      = (FPX*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(FPX), stream);
-    pixelQuintupletsInGPU.quintupletRadius = (FPX*)cms::cuda::allocate_managed(maxPixelQuintuplets * sizeof(FPX), stream);
-
-#else
-    cudaMallocManaged(&pixelQuintupletsInGPU.pixelIndices, maxPixelQuintuplets * sizeof(unsigned int));
-    cudaMallocManaged(&pixelQuintupletsInGPU.T5Indices, maxPixelQuintuplets * sizeof(unsigned int));
-    cudaMallocManaged(&pixelQuintupletsInGPU.nPixelQuintuplets, sizeof(unsigned int));
-    cudaMallocManaged(&pixelQuintupletsInGPU.totOccupancyPixelQuintuplets, sizeof(unsigned int));
-    cudaMallocManaged(&pixelQuintupletsInGPU.isDup, maxPixelQuintuplets * sizeof(bool));
-    cudaMallocManaged(&pixelQuintupletsInGPU.score, maxPixelQuintuplets * sizeof(FPX));
-    cudaMallocManaged(&pixelQuintupletsInGPU.eta  , maxPixelQuintuplets * sizeof(FPX));
-    cudaMallocManaged(&pixelQuintupletsInGPU.phi  , maxPixelQuintuplets * sizeof(FPX));
-
-    cudaMallocManaged(&pixelQuintupletsInGPU.logicalLayers, maxPixelQuintuplets * 7 *sizeof(uint8_t));
-    cudaMallocManaged(&pixelQuintupletsInGPU.hitIndices, maxPixelQuintuplets * 14 * sizeof(unsigned int));
-    cudaMallocManaged(&pixelQuintupletsInGPU.lowerModuleIndices, maxPixelQuintuplets * 7 * sizeof(uint16_t));
-    cudaMallocManaged(&pixelQuintupletsInGPU.pixelRadius, maxPixelQuintuplets * sizeof(FPX));
-    cudaMallocManaged(&pixelQuintupletsInGPU.quintupletRadius, maxPixelQuintuplets * sizeof(FPX));
-    cudaMallocManaged(&pixelQuintupletsInGPU.centerX, maxPixelQuintuplets * sizeof(FPX));
-    cudaMallocManaged(&pixelQuintupletsInGPU.centerY, maxPixelQuintuplets * sizeof(FPX));
-#ifdef CUT_VALUE_DEBUG
-    cudaMallocManaged(&pixelQuintupletsInGPU.rzChiSquared, maxPixelQuintuplets * sizeof(unsigned int));
-    cudaMallocManaged(&pixelQuintupletsInGPU.rPhiChiSquared, maxPixelQuintuplets * sizeof(unsigned int));
-    cudaMallocManaged(&pixelQuintupletsInGPU.rPhiChiSquaredInwards, maxPixelQuintuplets * sizeof(unsigned int));
-#endif
-#endif
-    cudaMemsetAsync(pixelQuintupletsInGPU.nPixelQuintuplets, 0, sizeof(unsigned int),stream);
-    cudaMemsetAsync(pixelQuintupletsInGPU.totOccupancyPixelQuintuplets, 0, sizeof(unsigned int),stream);
-  cudaStreamSynchronize(stream);
 }
 
 void SDL::createPixelQuintupletsInExplicitMemory(struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int maxPixelQuintuplets,cudaStream_t stream)

--- a/SDL/PixelTriplet.cuh
+++ b/SDL/PixelTriplet.cuh
@@ -62,8 +62,6 @@ namespace SDL
         void resetMemory(unsigned int maxPixelTriplets,cudaStream_t stream);
     };
 
-    void createPixelTripletsInUnifiedMemory(struct pixelTriplets& pixelTripletsInGPU, unsigned int maxPixelTriplets, cudaStream_t stream);
-
     void createPixelTripletsInExplicitMemory(struct pixelTriplets& pixelTripletsinGPU, unsigned int maxPixelTriplets, cudaStream_t stream);
 
 #ifdef CUT_VALUE_DEBUG
@@ -176,7 +174,6 @@ namespace SDL
 
     };
 
-    void createPixelQuintupletsInUnifiedMemory(struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int maxPixelQuintuplets,cudaStream_t stream);
     void createPixelQuintupletsInExplicitMemory(struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int maxPixelQuintuplets, cudaStream_t stream);
 
 //    CUDA_DEV void rmPixelQuintupletToMemory(struct pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pixelQuintupletIndex);

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -48,7 +48,6 @@ SDL::quintuplets::~quintuplets()
 
 void SDL::quintuplets::freeMemoryCache()
 {
-#ifdef Explicit_T5
     int dev;
     cudaGetDevice(&dev);
     cms::cuda::free_device(dev,tripletIndices);
@@ -83,25 +82,6 @@ void SDL::quintuplets::freeMemoryCache()
     cms::cuda::free_device(dev, outerRadiusMax2S);
     cms::cuda::free_device(dev, chiSquared);
     cms::cuda::free_device(dev, nonAnchorChiSquared);
-#endif
-#else
-    cms::cuda::free_managed(tripletIndices);
-    cms::cuda::free_managed(lowerModuleIndices);
-    cms::cuda::free_managed(nQuintuplets);
-    cms::cuda::free_managed(totOccupancyQuintuplets);
-    cms::cuda::free_managed(innerRadius);
-    cms::cuda::free_managed(outerRadius);
-    cms::cuda::free_managed(partOfPT5);
-    cms::cuda::free_managed(isDup);
-    cms::cuda::free_managed(pt);
-    cms::cuda::free_managed(layer);
-    cms::cuda::free_managed(regressionG);
-    cms::cuda::free_managed(regressionF);
-    cms::cuda::free_managed(regressionRadius);
-
-    cms::cuda::free_managed(logicalLayers);
-    cms::cuda::free_managed(hitIndices);
-    cms::cuda::free_managed(nMemoryLocations);
 #endif
 }
 
@@ -205,85 +185,6 @@ __global__ void SDL::createEligibleModulesListForQuintupletsGPU(struct modules& 
 //        printf("nTotalT5 %u\n",nTotalQuintupletsx);
         *device_nTotalQuintuplets = nTotalQuintupletsx;
     }
-}
-
-void SDL::createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& nTotalQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules, cudaStream_t stream)
-{
-//    unsigned int nMemoryLocations = maxQuintuplets * nEligibleModules;
-//    std::cout<<"Number of eligible T5 modules = "<<nEligibleModules<<std::endl;
-#ifdef CACHE_ALLOC
-//    cudaStream_t stream = 0;
-    quintupletsInGPU.tripletIndices = (unsigned int*)cms::cuda::allocate_managed(nTotalQuintuplets * 2 * sizeof(unsigned int), stream);
-    quintupletsInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_managed(nTotalQuintuplets * 5 * sizeof(uint16_t), stream);
-    quintupletsInGPU.nQuintuplets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int), stream);
-    quintupletsInGPU.totOccupancyQuintuplets = (unsigned int*)cms::cuda::allocate_managed(nLowerModules * sizeof(unsigned int), stream);
-    quintupletsInGPU.innerRadius = (FPX*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(FPX), stream);
-    quintupletsInGPU.outerRadius = (FPX*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(FPX), stream);
-    quintupletsInGPU.pt = (FPX*)cms::cuda::allocate_managed(nTotalQuintuplets *4* sizeof(FPX), stream);
-    quintupletsInGPU.layer = (uint8_t*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(uint8_t), stream);
-    quintupletsInGPU.isDup = (bool*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(bool), stream);
-    quintupletsInGPU.partOfPT5 = (bool*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(bool), stream);
-    quintupletsInGPU.regressionRadius = (float*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(float), stream);
-    quintupletsInGPU.regressionG = (float*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(float), stream);
-    quintupletsInGPU.regressionF = (float*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(float), stream);
-    quintupletsInGPU.logicalLayers = (uint8_t*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(uint8_t) * 5, stream);
-    quintupletsInGPU.hitIndices = (unsigned int*)cms::cuda::allocate_managed(nTotalQuintuplets * sizeof(unsigned int) * 10, stream);
-    quintupletsInGPU.nMemoryLocations = (unsigned int*)cms::cuda::allocate_managed(sizeof(unsigned int), stream);
-#else
-    cudaMallocManaged(&quintupletsInGPU.tripletIndices, 2 * nTotalQuintuplets * sizeof(unsigned int));
-    cudaMallocManaged(&quintupletsInGPU.lowerModuleIndices, 5 * nTotalQuintuplets * sizeof(uint16_t));
-
-    cudaMallocManaged(&quintupletsInGPU.nQuintuplets, nLowerModules * sizeof(unsigned int));
-    cudaMallocManaged(&quintupletsInGPU.totOccupancyQuintuplets, nLowerModules * sizeof(unsigned int));
-    cudaMallocManaged(&quintupletsInGPU.innerRadius, nTotalQuintuplets * sizeof(FPX));
-    cudaMallocManaged(&quintupletsInGPU.outerRadius, nTotalQuintuplets * sizeof(FPX));
-    cudaMallocManaged(&quintupletsInGPU.pt, nTotalQuintuplets *4* sizeof(FPX));
-    cudaMallocManaged(&quintupletsInGPU.layer, nTotalQuintuplets * sizeof(uint8_t));
-    cudaMallocManaged(&quintupletsInGPU.isDup, nTotalQuintuplets * sizeof(bool));
-    cudaMallocManaged(&quintupletsInGPU.partOfPT5, nTotalQuintuplets * sizeof(bool));
-    cudaMallocManaged(&quintupletsInGPU.regressionRadius, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.regressionG, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.regressionF, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.logicalLayers, nTotalQuintuplets * sizeof(uint8_t) * 5);
-    cudaMallocManaged(&quintupletsInGPU.hitIndices, nTotalQuintuplets * sizeof(unsigned int) * 10);
-    cudaMallocManaged(&quintupletsInGPU.nMemoryLocations, sizeof(unsigned int));
-
-#ifdef CUT_VALUE_DEBUG
-    cudaMallocManaged(&quintupletsInGPU.innerRadiusMin, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.innerRadiusMax, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.bridgeRadius, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.bridgeRadiusMin, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.bridgeRadiusMax, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.outerRadiusMin, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.outerRadiusMax, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.innerRadiusMin2S, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.innerRadiusMax2S, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.bridgeRadiusMin2S, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.bridgeRadiusMax2S, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.outerRadiusMin2S, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.outerRadiusMax2S, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.chiSquared, nTotalQuintuplets * sizeof(float));
-    cudaMallocManaged(&quintupletsInGPU.nonAnchorChiSquared, nTotalQuintuplets * sizeof(float));
-#endif
-
-#endif
-    quintupletsInGPU.eta = quintupletsInGPU.pt + nTotalQuintuplets;
-    quintupletsInGPU.phi = quintupletsInGPU.pt + 2*nTotalQuintuplets;
-    //quintupletsInGPU.score_rphi = quintupletsInGPU.pt + 3*nTotalQuintuplets;
-    //quintupletsInGPU.score_rz = quintupletsInGPU.pt + 4*nTotalQuintuplets;
-    quintupletsInGPU.score_rphisum = quintupletsInGPU.pt + 3*nTotalQuintuplets;
-    //quintupletsInGPU.score_rzlsq = quintupletsInGPU.pt + 6*nTotalQuintuplets;
-//#pragma omp parallel for
-//    for(size_t i = 0; i<nLowerModules;i++)
-//    {
-//        quintupletsInGPU.nQuintuplets[i] = 0;
-//    }
-
-    cudaMemsetAsync(quintupletsInGPU.nQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
-    cudaMemsetAsync(quintupletsInGPU.totOccupancyQuintuplets,0,nLowerModules * sizeof(unsigned int),stream);
-    cudaMemsetAsync(quintupletsInGPU.isDup,0,nTotalQuintuplets * sizeof(bool),stream);
-    cudaMemsetAsync(quintupletsInGPU.partOfPT5,0,nTotalQuintuplets * sizeof(bool),stream);
-    cudaStreamSynchronize(stream);
 }
 
 void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& nTotalQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream)

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -73,8 +73,6 @@ namespace SDL
         void freeMemoryCache();
     };
 
-    void createQuintupletsInUnifiedMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& maxQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream);
-
     void createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintupletsInGPU, const unsigned int& maxQuintuplets, const uint16_t& nLowerModules, const uint16_t& nEligibleModules,cudaStream_t stream);
 
 //    void createEligibleModulesListForQuintuplets(struct modules& modulesInGPU, struct triplets& tripletsInGPU, uint16_t& nEligibleModules, uint16_t* indicesOfEligibleModules, unsigned int& nTotalQuintuplets, unsigned int& maxTriplets,cudaStream_t stream, struct objectRanges& rangesInGPU);

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -70,7 +70,6 @@ namespace SDL
     void resetMemory(unsigned int nMemoryLocationsx, unsigned int nModules, unsigned int maxPixelSegments,cudaStream_t stream);
     };
 
-    void createSegmentsInUnifiedMemory(struct segments& segmentsInGPU, unsigned int maxSegments, uint16_t nLowerModules, unsigned int maxPixelSegments ,cudaStream_t stream);
     void createSegmentsInExplicitMemory(struct segments& segmentsInGPU, unsigned int maxSegments, uint16_t nLowerModules, unsigned int maxPixelSegments,cudaStream_t stream);
 
     void createSegmentArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct miniDoublets& mdsinGPU, uint16_t& nLowerModules, unsigned int& nSegments, cudaStream_t stream, const uint16_t& maxSegmentsPerModule, const uint16_t& maxPixelSegments);

--- a/SDL/TrackCandidate.cuh
+++ b/SDL/TrackCandidate.cuh
@@ -53,8 +53,6 @@ namespace SDL
         void resetMemory(unsigned int maxTrackCandidates,cudaStream_t stream);
     };
 
-    void createTrackCandidatesInUnifiedMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates,cudaStream_t stream);
-
     void createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates,cudaStream_t stream);
     
     CUDA_DEV void addTrackCandidateToMemory(struct trackCandidates& trackCandidatesInGPU, short trackCandidateType, unsigned int innerTrackletIndex, unsigned int outerTrackletIndex, unsigned int trackCandidateIndex);

--- a/SDL/TrackExtensions.cuh
+++ b/SDL/TrackExtensions.cuh
@@ -47,8 +47,6 @@ namespace SDL
         void resetMemory(unsigned int maxTrackExtensions, unsigned int nTrackCandidates, cudaStream_t stream);
     };
 
-    void createTrackExtensionsInUnifiedMemory(struct trackExtensions& trackExtensionsInGPU, unsigned int maxTrackExtensions, unsigned int nTrackCandidates, cudaStream_t stream);
-
     void createTrackExtensionsInExplicitMemory(struct trackExtensions& trackExtensionsInGPU, unsigned int maxTrackExtensions, unsigned int nTrackCandidates, cudaStream_t stream);
 #ifdef CUT_VALUE_DEBUG
     CUDA_DEV void addTrackExtensionToMemory(struct trackExtensions& trackExtensionsInGPU, short* constituentTCType, unsigned int* constituentTCIndex, unsigned int* nLayerOverlaps, unsigned int* nHitOverlaps, float rPhiChiSquared, float rzChiSquared, float regressionRadius, float innerRadius, float outerRadius, unsigned int trackExtensionIndex);

--- a/SDL/Tracklet.cuh
+++ b/SDL/Tracklet.cuh
@@ -60,7 +60,6 @@ namespace SDL
         void freeMemoryCache();
     };
 
-     void createTrackletsInUnifiedMemory(struct tracklets& trackletsInGPU, unsigned int maxTracklets, uint16_t nLowerModules,cudaStream_t stream);
     void createTrackletsInExplicitMemory(struct tracklets& trackletsInGPU, unsigned int maxTracklets, uint16_t nLowerModules,cudaStream_t stream);
 
 

--- a/SDL/Triplet.cuh
+++ b/SDL/Triplet.cuh
@@ -78,7 +78,6 @@ namespace SDL
 
     void createTripletArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct segments& segmentsInGPU, uint16_t& nLowerModules, unsigned int& nTotalTriplets, cudaStream_t stream);
 
-    void createTripletsInUnifiedMemory(struct triplets& tripletsInGPU, unsigned int maxTriplets, uint16_t nLowerModules,cudaStream_t stream);
     void createTripletsInExplicitMemory(struct triplets& tripletsInGPU, unsigned int maxTriplets, uint16_t nLowerModules,cudaStream_t stream);
 #ifdef CUT_VALUE_DEBUG
 CUDA_DEV void addTripletToMemory(struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, struct segments& segmentsInGPU, struct triplets& tripletsInGPU, unsigned int& innerSegmentIndex, unsigned int& outerSegmentIndex, uint16_t& innerInnerLowerModuleIndex, uint16_t& middleLowerModuleIndex, uint16_t& outerOuterLowerModuleIndex, float& zOut, float& rtOut, float& deltaPhiPos, float& deltaPhi, float& betaIn, float& betaOut, float& pt_beta, float& zLo, float& zHi, float& rtLo, float& rtHi, float& zLoPointed, float&

--- a/bin/sdl_make_tracklooper
+++ b/bin/sdl_make_tracklooper
@@ -19,7 +19,6 @@ usage()
   echo
   echo "Options:"
   echo "  -h    Help                    (Display this message)"
-  echo "  -x    explicit memory         (Make library with explicit memory enabled)"
   echo "  -c    cache                   (Make library with cache enabled)"
   echo "  -s    show log                (Full compilation script to stdout)"
   echo "  -m    make clean binaries     (Make clean binaries before remake. e.g. when header files changed in SDL/*.cuh)"
@@ -36,7 +35,6 @@ usage()
 while getopts ":cxgsmdp823eh" OPTION; do
   case $OPTION in
     c) MAKECACHE=true;;
-    x) MAKEEXPLICIT=true;;
     s) SHOWLOG=true;;
     m) MAKECLEANBINARIES=true;;
     d) MAKECUTVALUES=true;;
@@ -51,7 +49,6 @@ done
 
 # If the command line options are not provided set it to default value of false
 if [ -z ${MAKECACHE} ]; then MAKECACHE=false; fi
-if [ -z ${MAKEEXPLICIT}  ]; then MAKEEXPLICIT=false; fi
 if [ -z ${SHOWLOG} ]; then SHOWLOG=false; fi
 if [ -z ${MAKECLEANBINARIES} ]; then MAKECLEANBINARIES=false; fi
 if [ -z ${MAKECUTVALUES} ]; then MAKECUTVALUES=false; fi
@@ -77,7 +74,6 @@ echo "====================================================="  | tee -a ${LOG}
 echo "Compilation options set to..."                          | tee -a ${LOG}
 echo ""                                                       | tee -a ${LOG}
 echo "  MAKECACHE         : ${MAKECACHE}"                     | tee -a ${LOG}
-echo "  MAKEEXPLICIT      : ${MAKEEXPLICIT}"                  | tee -a ${LOG}
 echo "  SHOWLOG           : ${SHOWLOG}"                       | tee -a ${LOG}
 echo "  MAKECLEANBINARIES : ${MAKECLEANBINARIES}"             | tee -a ${LOG}
 echo "  MAKECUTVALUES     : ${MAKECUTVALUES}"                 | tee -a ${LOG}
@@ -89,11 +85,10 @@ echo ""                                                       | tee -a ${LOG}
 echo "  (cf. Run > sh $(basename $0) -h to see all options)"  | tee -a ${LOG}
 echo ""                                                       | tee -a ${LOG}
 
-# Target to make default is unified
-MAKETARGET=unified
+
 TRACKLOOPERTARGET=
 # If make explicit is true then make library with explicit memory on GPU
-if $MAKEEXPLICIT; then MAKETARGET=explicit; fi
+MAKETARGET=explicit;
 
 # If make cache is true then make library with cache enabled
 if $MAKECACHE; then MAKETARGET=${MAKETARGET}_cache; fi

--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -1871,11 +1871,6 @@ float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP)
     return hit_loading_elapsed;
 }
 
-//__________________________________________________________________________________________
-float addInputsToLineSegmentTrackingUsingUnifiedMemory(SDL::Event &event)
-{
-    return addInputsToLineSegmentTracking(event, true);
-}
 
 //__________________________________________________________________________________________
 float addInputsToLineSegmentTrackingUsingExplicitMemory(SDL::Event &event)

--- a/code/core/trkCore.h
+++ b/code/core/trkCore.h
@@ -78,7 +78,6 @@ float drfracSimHitConsistentWithHelix(SDLMath::Helix& helix, int isimhitidx);
 float distxySimHitConsistentWithHelix(int isimtrk, int isimhitidx);
 float distxySimHitConsistentWithHelix(SDLMath::Helix& helix, int isimhitidx);
 
-float addInputsToLineSegmentTrackingUsingUnifiedMemory(SDL::Event &event);
 float addInputsToLineSegmentTrackingUsingExplicitMemory(SDL::Event &event);
 float addInputsToLineSegmentTracking(SDL::Event &event, bool useOMP);
 void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>>& out_trkX,std::vector<std::vector<float>>& out_trkY,std::vector<std::vector<float>>& out_trkZ,

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -25,7 +25,7 @@ run_timing_test_usage()
     echo
     echo "Arguments:"
     echo "   SAMPLETYPE                          muonGun, PU200, or pionGun"
-    echo "   SPECIFICGPUVERSION (optional)       Run only one of the unified, unified_cache, ... , explicit, explicit_newgrid, ... , etc."
+    echo "   SPECIFICGPUVERSION (optional)       Run only one of the cache, etc."
     echo "                                       If nothing provided, then it checks all possible tests."
     echo "   NEVENTS            (optional)       200, 10000, -1, etc."
     echo ""
@@ -104,14 +104,6 @@ mkdir -p ${OUTDIR}
 rm -f timing_temp.txt
 
 # Run different GPU configurations
-if [[ "${SPECIFICGPUVERSION}" == "unified" ]]; then
-    run_gpu unified ${SAMPLE} ${NEVENTS} -8 -e
-    :
-fi
-if [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
-    run_gpu unified_cache ${SAMPLE} ${NEVENTS} -c -8 -e
-    :
-fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; then
     run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 -e
     :

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -105,11 +105,11 @@ rm -f timing_temp.txt
 
 # Run different GPU configurations
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; then
-    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 -e
+    run_gpu explicit ${SAMPLE} ${NEVENTS} -8 -e
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
-     run_gpu explicit_cache ${SAMPLE} ${NEVENTS} -x -c -8 -e
+     run_gpu explicit_cache ${SAMPLE} ${NEVENTS} -c -8 -e
     :
 fi
 

--- a/efficiency/bin/sdl_validate_efficiency
+++ b/efficiency/bin/sdl_validate_efficiency
@@ -116,10 +116,10 @@ mkdir -p ${OUTDIR}
 
 # Run different GPU configurations
 if [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; then
-    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 ${runExtension}
+    run_gpu explicit ${SAMPLE} ${NEVENTS} -8 ${runExtension}
     :
 fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
-    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -c ${runExtension}
+    run_gpu explicit ${SAMPLE} ${NEVENTS} -c -8 ${runExtension}
     :
 fi

--- a/efficiency/bin/sdl_validate_efficiency
+++ b/efficiency/bin/sdl_validate_efficiency
@@ -37,7 +37,7 @@ validate_efficiency_usage()
     echo
     echo "Arguments:"
     echo "   SAMPLETYPE                          muonGun, PU200, or pionGun"
-    echo "   SPECIFICGPUVERSION (optional)       Run only one of the unified, unified_cache, ... , explicit, explicit_newgrid, ... , etc."
+    echo "   SPECIFICGPUVERSION (optional)       Run only one of the cache, etc."
     echo "                                       If nothing provided, then it checks all possible tests."
     echo "   NEVENTS            (optional)       200, 10000, -1, etc."
     echo ""
@@ -115,20 +115,11 @@ rm -rf ${OUTDIR}
 mkdir -p ${OUTDIR}
 
 # Run different GPU configurations
-if [[ "${SPECIFICGPUVERSION}" == "unified" ]]; then
-    run_gpu unified ${SAMPLE} ${NEVENTS} -8 ${runExtension}
-    :
-fi
 if [[ "${SPECIFICGPUVERSION}" == "explicit" ]]; then
     run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 ${runExtension}
     :
 fi
-if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "unified_cache" ]]; then
-    run_gpu unified ${SAMPLE} ${NEVENTS} -8 -c ${runExtension}
-    :
-fi
 if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache" ]]; then
-    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -8 -c ${runExtension}
+    run_gpu explicit ${SAMPLE} ${NEVENTS} -x -c ${runExtension}
     :
 fi
-sdl_compare_efficiencies -i ${SAMPLE} -t ${GITHASH} -f

--- a/efficiency/python/plot_compare.py
+++ b/efficiency/python/plot_compare.py
@@ -47,7 +47,7 @@ cs = [2, 3, 4, 6, 7, 8, 9, 30, 46, 38, 40]
 gpu_tgraphs = {}
 configurations = []
 for eff_file_gpu in eff_files_gpu:
-    configuration = os.path.basename(os.path.dirname(eff_file_gpu)).split("GPU_")[1].split("_{}".format(githash))[0] # e.g. unified_cache ...
+    configuration = os.path.basename(os.path.dirname(eff_file_gpu)).split("GPU_")[1].split("_{}".format(githash))[0]
     tempf = r.TFile(eff_file_gpu)
     if tempf.Get(keys[0]):
         configurations.append(configuration)

--- a/efficiency/python/plot_compare_arbitrary.py
+++ b/efficiency/python/plot_compare_arbitrary.py
@@ -95,7 +95,7 @@ cs = [2, 3, 4, 6, 7, 8, 9, 30, 46, 38, 40]
 gpu_tgraphs = {}
 configurations = []
 for eff_file_gpu in eff_files_gpu:
-    configuration = os.path.basename(os.path.dirname(eff_file_gpu)).split("GPU_")[1].split("_{}".format(githash))[0] # e.g. unified_cache ...
+    configuration = os.path.basename(os.path.dirname(eff_file_gpu)).split("GPU_")[1].split("_{}".format(githash))[0]
     configurations.append(configuration)
     gpu_file = r.TFile(eff_file_gpu)
     gpu_tgraphs[configuration] = {}


### PR DESCRIPTION
This PR removes the deprecated "unified" and "unified_cache" versions from the codebase.

New Timing (unchanged)
![time](https://user-images.githubusercontent.com/25272611/181859999-1a6bd2b4-97f3-45d2-b8c9-65738fb5c684.png)
