### PR TITLE
Makefile modifications for CMSSW integration and instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EXES=bin/sdl
 ROOUTIL=code/rooutil/
 
 SOURCES=$(wildcard code/core/*.cc) $(wildcard code/AnalysisInterface/*.cc) #$(wildcard SDL/*.cc)
-OBJECTS=$(SOURCES:.cc=.o) $(wildcard ${TRACKLOOPERDIR}/SDL/sdl.so)
+OBJECTS=$(SOURCES:.cc=.o) $(wildcard ${TRACKLOOPERDIR}/SDL/libsdl.so)
 HEADERS=$(SOURCES:.cc=.h)
 
 CC          = nvcc

--- a/README.md
+++ b/README.md
@@ -47,3 +47,48 @@ Run the validation on specific version of GPU implementation
     sdl_validate_segment_linking <dataset> explicit
     sdl_validate_segment_linking <dataset> explicit_cache
     (can optionally add in number of events as 3rd option)
+
+
+## CMSSW Integration
+This is the a complete set of instruction on how the TrackLooper code
+can be linked as an external tool in CMSSW:
+
+### Build TrackLooper
+```bash
+git clone git@github.com:SegmentLinking/TrackLooper.git
+cd TrackLooper/
+source setup.sh
+sdl_make_tracklooper -m8xc2
+cd ..
+```
+
+### Set up `TrackLooper` as an external
+```bash
+export SCRAM_ARCH=slc7_amd64_gcc10
+cmsrel CMSSW_12_6_0_pre2
+cd CMSSW_12_6_0_pre2/src
+cmsenv
+git cms-init
+cat <<EOF >lst.xml
+<tool name="lst" version="1.0">
+  <client>
+    <environment name="LSTBASE" default="$PWD/../../TrackLooper"/>
+    <environment name="LIBDIR" default="\$LSTBASE/SDL"/>
+    <environment name="INCLUDE" default="\$LSTBASE/SDL"/>
+  </client>
+  <runtime name="LST_BASE" value="\$LSTBASE"/>
+  <lib name="sdl"/>
+</tool>
+EOF
+scram setup lst.xml
+cmsenv
+git cms-checkdeps -a
+scram b -j 12
+```
+
+Including the line
+```
+<use name="lst"/>
+```
+in the relevant package `BuildFile.xml` allows for
+including our headers in the code of that package.

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -10,7 +10,7 @@ CCHEADERS=$(CCSOURCES:.cc=.h)
 CUSOURCES=$(wildcard *.cu)
 CUOBJECTS=$(CUSOURCES:.cu=_cuda.o)
 CUHEADERS=$(CUSOURCES:.cu=.cuh)
-LIB=sdl.so
+LIB=libsdl.so
 
 #
 # flags to keep track of

--- a/bin/sdl_make_tracklooper
+++ b/bin/sdl_make_tracklooper
@@ -97,7 +97,7 @@ if $MAKECACHE; then MAKETARGET=${MAKETARGET}_cache; fi
 
 # If make clean binaries are called then first make clean before making
 if $MAKECLEANBINARIES; then
-    echo "First make cleaning all of TrackLooper objects and sdl.so" | tee -a ${LOG}
+    echo "First make cleaning all of TrackLooper objects and libsdl.so" | tee -a ${LOG}
     cd SDL;make clean >>${LOG} 2>&1;cd -;
     make clean >> ${LOG} 2>&1
 fi
@@ -146,8 +146,8 @@ else
     (cd SDL && make clean && make ${CMSSW12GEOMOPT} ${PT0P8OPT} ${T3T3EXTENSIONOPT} -j 32 ${MAKETARGET} && cd -) >> ${LOG} 2>&1
 fi
 
-if [ ! -f SDL/sdl.so ]; then
-    echo "ERROR: SDL/sdl.so failed to compile!" | tee -a ${LOG}
+if [ ! -f SDL/libsdl.so ]; then
+    echo "ERROR: SDL/libsdl.so failed to compile!" | tee -a ${LOG}
     echo "See ${LOG} file for more detail..." | tee -a ${LOG}
     exit
 fi


### PR DESCRIPTION
As per title, in order to make our code work within CMSSW, I had to change a bit the naming of our shared library. After the modification, I verified that the standalone compiles fine.

I have also included the instructions to set up our code as an external to CMSSW. CMSSW compiles fine and I have made local tests that variables from our header files can be used normally in CMSSW producers.