### PR TITLE
LST in CMSSW

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ cat <<EOF >lst.xml
   <client>
     <environment name="LSTBASE" default="$PWD/../../TrackLooper"/>
     <environment name="LIBDIR" default="\$LSTBASE/SDL"/>
-    <environment name="INCLUDE" default="\$LSTBASE/SDL"/>
+    <environment name="INCLUDE" default="\$LSTBASE"/>
   </client>
   <runtime name="LST_BASE" value="\$LSTBASE"/>
   <lib name="sdl"/>

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -58,7 +58,6 @@ SDL::Event::Event(cudaStream_t estream)
         }
     }
     //resetObjectsInModule();
-
 }
 
 SDL::Event::~Event()
@@ -716,7 +715,7 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
     //std::cout << cudaGetLastError() << std::endl;
 }
 
-__global__ void addPixelSegmentToEventKernel(unsigned int* hitIndices0,unsigned int* hitIndices1,unsigned int* hitIndices2,unsigned int* hitIndices3, float* dPhiChange, float* ptIn, float* ptErr, float* px, float* py, float* pz, float* eta, float* etaErr,float* phi, int* charge, uint16_t pixelModuleIndex, struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU,const int size, int* superbin, int8_t* pixelType, short* isQuad)
+__global__ void addPixelSegmentToEventKernel(unsigned int* hitIndices0,unsigned int* hitIndices1,unsigned int* hitIndices2,unsigned int* hitIndices3, float* dPhiChange, float* ptIn, float* ptErr, float* px, float* py, float* pz, float* eta, float* etaErr,float* phi, int* charge, unsigned int* seedIdx, uint16_t pixelModuleIndex, struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::hits& hitsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU,const int size, int* superbin, int8_t* pixelType, short* isQuad)
 {
     for( int tid = blockIdx.x * blockDim.x + threadIdx.x; tid < size; tid += blockDim.x*gridDim.x)
     {
@@ -739,10 +738,10 @@ __global__ void addPixelSegmentToEventKernel(unsigned int* hitIndices0,unsigned 
     hits1[1] = hitsInGPU.idxs[mdsInGPU.anchorHitIndices[outerMDIndex]];
     hits1[2] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[innerMDIndex]];
     hits1[3] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[outerMDIndex]];
-    addPixelSegmentToMemory(segmentsInGPU, mdsInGPU, modulesInGPU, innerMDIndex, outerMDIndex, pixelModuleIndex, hits1, hitIndices0[tid], hitIndices2[tid], dPhiChange[tid], ptIn[tid], ptErr[tid], px[tid], py[tid], pz[tid], etaErr[tid], eta[tid], phi[tid], charge[tid], pixelSegmentIndex, tid, superbin[tid], pixelType[tid],isQuad[tid],score_lsq);
+    addPixelSegmentToMemory(segmentsInGPU, mdsInGPU, modulesInGPU, innerMDIndex, outerMDIndex, pixelModuleIndex, hits1, hitIndices0[tid], hitIndices2[tid], dPhiChange[tid], ptIn[tid], ptErr[tid], px[tid], py[tid], pz[tid], etaErr[tid], eta[tid], phi[tid], charge[tid], seedIdx[tid], pixelSegmentIndex, tid, superbin[tid], pixelType[tid],isQuad[tid],score_lsq);
     }
 }
-void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> eta, std::vector<float> etaErr, std::vector<float> phi, std::vector<int> charge, std::vector<int> superbin, std::vector<int8_t> pixelType, std::vector<short> isQuad)
+void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> eta, std::vector<float> etaErr, std::vector<float> phi, std::vector<int> charge, std::vector<unsigned int> seedIdx, std::vector<int> superbin, std::vector<int8_t> pixelType, std::vector<short> isQuad)
 {
     if(mdsInGPU == nullptr)
     {
@@ -786,6 +785,7 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     float* eta_host = &eta[0];
     float* phi_host = &phi[0];
     int* charge_host = &charge[0];
+    unsigned int* seedIdx_host = &seedIdx[0];
     int* superbin_host = &superbin[0];
     int8_t* pixelType_host = &pixelType[0];
     short* isQuad_host = &isQuad[0];
@@ -804,6 +804,7 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     float* eta_dev;
     float* phi_dev;
     int* charge_dev;
+    unsigned int* seedIdx_dev;
     int* superbin_dev;
     int8_t* pixelType_dev;
     short* isQuad_dev;
@@ -821,6 +822,7 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     eta_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
     phi_dev = (float*)cms::cuda::allocate_device(dev, size*sizeof(float), stream);
     charge_dev = (int*)cms::cuda::allocate_device(dev, size*sizeof(int), stream);
+    seedIdx_dev = (unsigned int*)cms::cuda::allocate_device(dev, size*sizeof(unsigned int), stream);
     superbin_dev = (int*)cms::cuda::allocate_device(dev, size*sizeof(int), stream);
     pixelType_dev = (int8_t*)cms::cuda::allocate_device(dev, size*sizeof(int8_t), stream);
     isQuad_dev = (short*)cms::cuda::allocate_device(dev, size*sizeof(short), stream);
@@ -839,6 +841,7 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     cudaMemcpyAsync(eta_dev, eta_host, size*sizeof(float),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(phi_dev, phi_host, size*sizeof(float),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(charge_dev, charge_host, size*sizeof(int),cudaMemcpyHostToDevice,stream);
+    cudaMemcpyAsync(seedIdx_dev, seedIdx_host, size*sizeof(unsigned int),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(superbin_dev,superbin_host,size*sizeof(int),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(pixelType_dev,pixelType_host,size*sizeof(int8_t),cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(isQuad_dev,isQuad_host,size*sizeof(short),cudaMemcpyHostToDevice,stream);
@@ -847,7 +850,7 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     unsigned int nThreads = 256;
     unsigned int nBlocks =  MAX_BLOCKS;//size % nThreads == 0 ? size/nThreads : size/nThreads + 1;
 
-    addPixelSegmentToEventKernel<<<nBlocks,nThreads,0,stream>>>(hitIndices0_dev,hitIndices1_dev,hitIndices2_dev,hitIndices3_dev,dPhiChange_dev,ptIn_dev,ptErr_dev,px_dev,py_dev,pz_dev,eta_dev, etaErr_dev, phi_dev, charge_dev, pixelModuleIndex, *modulesInGPU, *rangesInGPU, *hitsInGPU,*mdsInGPU,*segmentsInGPU,size, superbin_dev, pixelType_dev,isQuad_dev);
+    addPixelSegmentToEventKernel<<<nBlocks,nThreads,0,stream>>>(hitIndices0_dev,hitIndices1_dev,hitIndices2_dev,hitIndices3_dev,dPhiChange_dev,ptIn_dev,ptErr_dev,px_dev,py_dev,pz_dev,eta_dev, etaErr_dev, phi_dev, charge_dev, seedIdx_dev, pixelModuleIndex, *modulesInGPU, *rangesInGPU, *hitsInGPU,*mdsInGPU,*segmentsInGPU,size, superbin_dev, pixelType_dev,isQuad_dev);
 
    //cudaDeviceSynchronize();
    cudaStreamSynchronize(stream);
@@ -872,6 +875,7 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     cms::cuda::free_device(dev, eta_dev);
     cms::cuda::free_device(dev, phi_dev);
     cms::cuda::free_device(dev, charge_dev);
+    cms::cuda::free_device(dev, seedIdx_dev);
     cms::cuda::free_device(dev, superbin_dev);
     cms::cuda::free_device(dev, pixelType_dev);
     cms::cuda::free_device(dev, isQuad_dev);
@@ -2231,6 +2235,7 @@ SDL::segments* SDL::Event::getSegments()
         segmentsInCPU->ptIn = new float[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
         segmentsInCPU->eta = new float[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
         segmentsInCPU->phi = new float[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
+        segmentsInCPU->seedIdx = new unsigned int[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
         segmentsInCPU->isDup = new bool[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
         segmentsInCPU->isQuad = new bool[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
         segmentsInCPU->score = new float[N_MAX_PIXEL_SEGMENTS_PER_MODULE];
@@ -2242,6 +2247,7 @@ SDL::segments* SDL::Event::getSegments()
         cudaMemcpyAsync(segmentsInCPU->ptIn, segmentsInGPU->ptIn, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(float), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(segmentsInCPU->eta, segmentsInGPU->eta, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(float), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(segmentsInCPU->phi, segmentsInGPU->phi, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(float), cudaMemcpyDeviceToHost,stream);
+        cudaMemcpyAsync(segmentsInCPU->seedIdx, segmentsInGPU->seedIdx, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(unsigned int), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(segmentsInCPU->isDup, segmentsInGPU->isDup, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(bool), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(segmentsInCPU->isQuad, segmentsInGPU->isQuad, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(bool), cudaMemcpyDeviceToHost,stream);
         cudaMemcpyAsync(segmentsInCPU->score, segmentsInGPU->score, N_MAX_PIXEL_SEGMENTS_PER_MODULE * sizeof(float), cudaMemcpyDeviceToHost,stream);

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -633,7 +633,7 @@ __global__ void hitLoopKernel(
         int iDetId = hitsInGPU->detid[ihit];
 
         hitsInGPU->rts[ihit] = sqrt(ihit_x*ihit_x + ihit_y*ihit_y);
-        hitsInGPU->phis[ihit] = SDL::phi(ihit_x,ihit_y,ihit_z);
+        hitsInGPU->phis[ihit] = SDL::phi(ihit_x,ihit_y);
         hitsInGPU->etas[ihit] = ((ihit_z>0)-(ihit_z<0))*acosh(sqrt(ihit_x*ihit_x+ihit_y*ihit_y+ihit_z*ihit_z)/hitsInGPU->rts[ihit]);
 
         int found_index = binary_search(modulesInGPU->mapdetId, iDetId, nModules);

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -14,16 +14,6 @@
 #include <cuda_runtime.h>
 #include <omp.h>
 #include <chrono>
-#include "Module.cuh"
-#include "Hit.cuh"
-#include "MiniDoublet.cuh"
-#include "Segment.cuh"
-#include "PixelTracklet.cuh"
-#include "Triplet.cuh"
-#include "TrackCandidate.cuh"
-#include "Quintuplet.cuh"
-#include "PixelTriplet.cuh"
-#include "TrackExtensions.cuh"
 #include "Kernels.cuh"
 #include "Constants.h"
 
@@ -89,7 +79,7 @@ namespace SDL
         void resetEvent();
 
         void addHitToEvent(std::vector<float> x, std::vector<float> y, std::vector<float> z, std::vector<unsigned int> detId, std::vector<unsigned int> idxInNtuple); //call the appropriate hit function, then increment the counter here
-        void addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> eta, std::vector<float> etaErr, std::vector<float> phi, std::vector<int> charge, std::vector<int> superbin, std::vector<int8_t> pixelType, std::vector<short> isQuad);
+        void addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> eta, std::vector<float> etaErr, std::vector<float> phi, std::vector<int> charge, std::vector<unsigned int> seedIdx, std::vector<int> superbin, std::vector<int8_t> pixelType, std::vector<short> isQuad);
 
         /*functions that map the objects to the appropriate modules*/
         void addMiniDoubletsToEvent();

--- a/SDL/Hit.cu
+++ b/SDL/Hit.cu
@@ -108,7 +108,7 @@ __global__ void SDL::addHitToMemoryKernel(struct hits& hitsInGPU, struct modules
       hitsInGPU.ys[idx] = y[ihit];
       hitsInGPU.zs[idx] = z[ihit];
       hitsInGPU.rts[idx] = sqrt(x[ihit]*x[ihit] + y[ihit]*y[ihit]);
-      hitsInGPU.phis[idx] = phi(x[ihit],y[ihit],z[ihit]);
+      hitsInGPU.phis[idx] = phi(x[ihit],y[ihit]);
       hitsInGPU.moduleIndices[idx] = moduleIndex[ihit];
       hitsInGPU.idxs[idx] = ihit;
   }

--- a/SDL/Hit.cuh
+++ b/SDL/Hit.cuh
@@ -66,60 +66,40 @@ namespace SDL
     CUDA_G void addHitToMemoryGPU(struct hits& hitsInCPU,struct modules& modulesInGPU,float x, float y, float z, unsigned int detId, unsigned int idxInNtuple,unsigned int moduleIndex, float phis,struct objectRanges& rangesInGPU);
     
     CUDA_HOSTDEV inline float ATan2(float y, float x) {
-    //if (x != 0) return  x * (float(-0xf.8eed2p-4) + x * x * float(0x3.1238p-4)); // degree 3 7 bit accuracy//atan2f(y, x);
-    if (x != 0){ 
-      //float a = y/x;
-      //float z = a*a;  
-      float test = atan2f(y, x);
-      //float test1 = a * (float(-0xf.8eed2p-4) + z * float(0x3.1238p-4)); 
-      //float test2 = a * (float(-0xf.ecfc8p-4) + z * (float(0x4.9e79dp-4) + z * float(-0x1.44f924p-4)));
-      //float test3 =  a * (float(-0xf.fcc7ap-4) + z * (float(0x5.23886p-4) + z * (float(-0x2.571968p-4) + z * float(0x9.fb05p-8))));
-      //float test4 = a * (float(-0xf.ff73ep-4) +
-      //        z * (float(0x5.48ee1p-4) +
-      //             z * (float(-0x2.e1efe8p-4) + z * (float(0x1.5cce54p-4) + z * float(-0x5.56245p-8)))));
-      //float test5 = a * (float(-0xf.ffff4p-4) +
-      //        z * (float(0x5.552f9p-4 + z * (float(-0x3.30f728p-4) +
-      //                                       z * (float(0x2.39826p-4) +
-      //                                            z * (float(-0x1.8a880cp-4) +
-      //                                                 z * (float(0xe.484d6p-8) +
-      //                                                      z * (float(-0x5.93d5p-8) + z * float(0x1.0875dcp-8)))))))));
-      //printf("%f %f %f %f %f %f %f %f\n",y,x,test,test1,test2,test3,test4,test5);
-      return test;
+      if (x != 0) return atan2f(y, x);
+      if (y == 0) return  0;
+      if (y >  0) return  float(M_PI) / 2.f;
+      else        return -float(M_PI) / 2.f;
     }
-    if (y == 0) return  0;
-    if (y >  0) return  float(M_PI) / 2.f;
-    else        return -float(M_PI) / 2.f;
+    CUDA_HOSTDEV inline float eta(float x, float y, float z) {
+      float r3 = std::sqrt( x*x + y*y + z*z );
+      float rt = std::sqrt( x*x + y*y );
+      float eta = ((z > 0) - ( z < 0)) * acosh( r3 / rt );
+      return eta;
     }
     CUDA_HOSTDEV inline float phi_mpi_pi(float x) {
-    if (std::isnan(x))
-    {
-      //printf("phi_mpi_pi() function called with NaN\n");                                                
+      if (std::isnan(x))
+      {
+        //printf("phi_mpi_pi() function called with NaN\n");                                                
+          return x;
+      }
+
+      if (fabsf(x) <= float(M_PI))
         return x;
+      constexpr float o2pi = 1.f / (2.f * float(M_PI));
+      float n = std::round(x * o2pi);
+      return x - n * float(2.f * float(M_PI));
     }
-
-    //while (x >= float(M_PI))
-    //    x -= 2.f * float(M_PI);
-
-    //while (x < -float(M_PI))
-    //    x += 2.f * float(M_PI);
-
-    //return x;
-    if (fabsf(x) <= float(M_PI))
-      return x;
-    constexpr float o2pi = 1.f / (2.f * float(M_PI));
-    float n = std::round(x * o2pi);
-    return x - n * float(2.f * float(M_PI));
+    CUDA_HOSTDEV inline float phi(float x, float y) {
+      return phi_mpi_pi(float(M_PI) + ATan2(-y, -x));
     }
-    CUDA_HOSTDEV inline float phi(float x, float y, float z) {
-        return phi_mpi_pi(float(M_PI) + ATan2(-y, -x));
+    CUDA_HOSTDEV inline float deltaPhi(float x1, float y1, float x2, float y2) {
+      float phi1 = phi(x1,y1);
+      float phi2 = phi(x2,y2);
+      return phi_mpi_pi((phi2 - phi1));
     }
-    CUDA_HOSTDEV inline float deltaPhi(float x1, float y1, float z1, float x2, float y2, float z2) {
-    float phi1 = phi(x1,y1,z1);
-    float phi2 = phi(x2,y2,z2);
-    return phi_mpi_pi((phi2 - phi1));
-    }
-    CUDA_HOSTDEV inline float deltaPhiChange(float x1, float y1, float z1, float x2, float y2, float z2) {
-    return deltaPhi(x1,y1,z1,x2-x1, y2-y1, z2-z1);
+    CUDA_HOSTDEV inline float deltaPhiChange(float x1, float y1, float x2, float y2) {
+      return deltaPhi(x1, y1, x2-x1, y2-y1);
     }
     void getEdgeHits(unsigned int detId,float x, float y, float& xhigh, float& yhigh, float& xlow, float& ylow);
     CUDA_DEV void getEdgeHitsK(float phi,float x, float y, float& xhigh, float& yhigh, float& xlow, float& ylow);

--- a/SDL/Kernels.cu
+++ b/SDL/Kernels.cu
@@ -567,7 +567,6 @@ __global__ void removeDupPixelQuintupletsInGPUFromMap(struct SDL::pixelQuintuple
 __global__ void checkHitspLS(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::hits& hitsInGPU,bool secondpass)
 {
     int pixelModuleIndex = *modulesInGPU.nLowerModules;
-    unsigned int prefix = rangesInGPU.segmentModuleIndices[pixelModuleIndex];
     unsigned int nPixelSegments = segmentsInGPU.nSegments[pixelModuleIndex];
     if(nPixelSegments >  N_MAX_PIXEL_SEGMENTS_PER_MODULE)
     {

--- a/SDL/LST.cc
+++ b/SDL/LST.cc
@@ -1,0 +1,727 @@
+#include "LST.h"
+
+SDL::LST::LST() {
+  TrackLooperDir_ = getenv("LST_BASE");
+}
+
+void SDL::LST::eventSetup() {
+  loadMaps();
+  TString path = get_absolute_path_after_check_file_exists(TString::Format("%s/data/centroid_CMSSW_12_2_0_pre2.txt",TrackLooperDir_.Data()).Data());
+  SDL::initModules(path);
+}
+
+void SDL::LST::run(cudaStream_t stream,
+                   const std::vector<float> see_px,
+                   const std::vector<float> see_py,
+                   const std::vector<float> see_pz,
+                   const std::vector<float> see_dxy,
+                   const std::vector<float> see_dz,
+                   const std::vector<float> see_ptErr,
+                   const std::vector<float> see_etaErr,
+                   const std::vector<float> see_stateTrajGlbX,
+                   const std::vector<float> see_stateTrajGlbY,
+                   const std::vector<float> see_stateTrajGlbZ,
+                   const std::vector<float> see_stateTrajGlbPx,
+                   const std::vector<float> see_stateTrajGlbPy,
+                   const std::vector<float> see_stateTrajGlbPz,
+                   const std::vector<int> see_q,
+                   const std::vector<unsigned int> see_algo,
+                   const std::vector<std::vector<int>> see_hitIdx,
+                   const std::vector<unsigned int> ph2_detId,
+                   const std::vector<float> ph2_x,
+                   const std::vector<float> ph2_y,
+                   const std::vector<float> ph2_z) {
+  auto event = SDL::Event(stream);
+  prepareInput(see_px, see_py, see_pz, see_dxy, see_dz, see_ptErr, see_etaErr, see_stateTrajGlbX, see_stateTrajGlbY, see_stateTrajGlbZ, see_stateTrajGlbPx, see_stateTrajGlbPy, see_stateTrajGlbPz, see_q, see_algo, see_hitIdx, ph2_detId, ph2_x, ph2_y, ph2_z);
+
+  event.addHitToEvent(in_trkX_, in_trkY_, in_trkZ_, in_hitId_, in_hitIdxs_); // TODO : Need to fix the hitIdxs
+  event.addPixelSegmentToEvent(in_hitIndices_vec0_, in_hitIndices_vec1_, in_hitIndices_vec2_, in_hitIndices_vec3_,
+                               in_deltaPhi_vec_,
+                               in_ptIn_vec_, in_ptErr_vec_,
+                               in_px_vec_, in_py_vec_, in_pz_vec_,
+                               in_eta_vec_, in_etaErr_vec_,
+                               in_phi_vec_,
+                               in_charge_vec_,
+                               in_superbin_vec_,
+                               in_pixelType_vec_,
+                               in_isQuad_vec_);
+  event.createMiniDoublets();
+  printf("# of Mini-doublets produced: %d\n",event.getNumberOfMiniDoublets());
+  printf("# of Mini-doublets produced barrel layer 1: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(0));
+  printf("# of Mini-doublets produced barrel layer 2: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(1));
+  printf("# of Mini-doublets produced barrel layer 3: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(2));
+  printf("# of Mini-doublets produced barrel layer 4: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(3));
+  printf("# of Mini-doublets produced barrel layer 5: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(4));
+  printf("# of Mini-doublets produced barrel layer 6: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(5));
+  printf("# of Mini-doublets produced endcap layer 1: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(0));
+  printf("# of Mini-doublets produced endcap layer 2: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(1));
+  printf("# of Mini-doublets produced endcap layer 3: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(2));
+  printf("# of Mini-doublets produced endcap layer 4: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(3));
+  printf("# of Mini-doublets produced endcap layer 5: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(4));
+
+  event.createSegmentsWithModuleMap();
+  printf("# of Segments produced: %d\n",event.getNumberOfSegments());
+  printf("# of Segments produced layer 1-2:  %d\n",event.getNumberOfSegmentsByLayerBarrel(0));
+  printf("# of Segments produced layer 2-3:  %d\n",event.getNumberOfSegmentsByLayerBarrel(1));
+  printf("# of Segments produced layer 3-4:  %d\n",event.getNumberOfSegmentsByLayerBarrel(2));
+  printf("# of Segments produced layer 4-5:  %d\n",event.getNumberOfSegmentsByLayerBarrel(3));
+  printf("# of Segments produced layer 5-6:  %d\n",event.getNumberOfSegmentsByLayerBarrel(4));
+  printf("# of Segments produced endcap layer 1:  %d\n",event.getNumberOfSegmentsByLayerEndcap(0));
+  printf("# of Segments produced endcap layer 2:  %d\n",event.getNumberOfSegmentsByLayerEndcap(1));
+  printf("# of Segments produced endcap layer 3:  %d\n",event.getNumberOfSegmentsByLayerEndcap(2));
+  printf("# of Segments produced endcap layer 4:  %d\n",event.getNumberOfSegmentsByLayerEndcap(3));
+  printf("# of Segments produced endcap layer 5:  %d\n",event.getNumberOfSegmentsByLayerEndcap(4));
+
+  event.createTriplets();
+  printf("# of T3s produced: %d\n",event.getNumberOfTriplets());
+  printf("# of T3s produced layer 1-2-3: %d\n",event.getNumberOfTripletsByLayerBarrel(0));
+  printf("# of T3s produced layer 2-3-4: %d\n",event.getNumberOfTripletsByLayerBarrel(1));
+  printf("# of T3s produced layer 3-4-5: %d\n",event.getNumberOfTripletsByLayerBarrel(2));
+  printf("# of T3s produced layer 4-5-6: %d\n",event.getNumberOfTripletsByLayerBarrel(3));
+  printf("# of T3s produced endcap layer 1-2-3: %d\n",event.getNumberOfTripletsByLayerEndcap(0));
+  printf("# of T3s produced endcap layer 2-3-4: %d\n",event.getNumberOfTripletsByLayerEndcap(1));
+  printf("# of T3s produced endcap layer 3-4-5: %d\n",event.getNumberOfTripletsByLayerEndcap(2));
+  printf("# of T3s produced endcap layer 1: %d\n",event.getNumberOfTripletsByLayerEndcap(0));
+  printf("# of T3s produced endcap layer 2: %d\n",event.getNumberOfTripletsByLayerEndcap(1));
+  printf("# of T3s produced endcap layer 3: %d\n",event.getNumberOfTripletsByLayerEndcap(2));
+  printf("# of T3s produced endcap layer 4: %d\n",event.getNumberOfTripletsByLayerEndcap(3));
+  printf("# of T3s produced endcap layer 5: %d\n",event.getNumberOfTripletsByLayerEndcap(4));
+
+  event.createQuintuplets();
+  printf("# of Quintuplets produced: %d\n",event.getNumberOfQuintuplets());
+  printf("# of Quintuplets produced layer 1-2-3-4-5-6: %d\n",event.getNumberOfQuintupletsByLayerBarrel(0));
+  printf("# of Quintuplets produced layer 2: %d\n",event.getNumberOfQuintupletsByLayerBarrel(1));
+  printf("# of Quintuplets produced layer 3: %d\n",event.getNumberOfQuintupletsByLayerBarrel(2));
+  printf("# of Quintuplets produced layer 4: %d\n",event.getNumberOfQuintupletsByLayerBarrel(3));
+  printf("# of Quintuplets produced layer 5: %d\n",event.getNumberOfQuintupletsByLayerBarrel(4));
+  printf("# of Quintuplets produced layer 6: %d\n",event.getNumberOfQuintupletsByLayerBarrel(5));
+  printf("# of Quintuplets produced endcap layer 1: %d\n",event.getNumberOfQuintupletsByLayerEndcap(0));
+  printf("# of Quintuplets produced endcap layer 2: %d\n",event.getNumberOfQuintupletsByLayerEndcap(1));
+  printf("# of Quintuplets produced endcap layer 3: %d\n",event.getNumberOfQuintupletsByLayerEndcap(2));
+  printf("# of Quintuplets produced endcap layer 4: %d\n",event.getNumberOfQuintupletsByLayerEndcap(3));
+  printf("# of Quintuplets produced endcap layer 5: %d\n",event.getNumberOfQuintupletsByLayerEndcap(4));
+
+  event.pixelLineSegmentCleaning();
+
+  event.createPixelQuintuplets();
+  printf("# of Pixel Quintuplets produced: %d\n",event.getNumberOfPixelQuintuplets());
+
+  event.createPixelTriplets();
+  printf("# of Pixel T3s produced: %d\n",event.getNumberOfPixelTriplets());
+
+  event.createTrackCandidates();
+  printf("# of TrackCandidates produced: %d\n",event.getNumberOfTrackCandidates());
+  printf("    # of Pixel TrackCandidates produced: %d\n",event.getNumberOfPixelTrackCandidates());
+  printf("    # of pT5 TrackCandidates produced: %d\n",event.getNumberOfPT5TrackCandidates());
+  printf("    # of pT3 TrackCandidates produced: %d\n",event.getNumberOfPT3TrackCandidates());
+  printf("    # of pLS TrackCandidates produced: %d\n",event.getNumberOfPLSTrackCandidates());
+  printf("    # of T5 TrackCandidates produced: %d\n",event.getNumberOfT5TrackCandidates());
+
+  getOutput(event);
+  for(auto out : out_tc_pt_) printf("%f\n",out);
+  for(auto out : out_tc_eta_) printf("%f\n",out);
+  for(auto out : out_tc_phi_) printf("%f\n",out);
+  for(auto out : out_tc_len_) printf("%d\n",out);
+}
+
+
+
+void SDL::LST::loadMaps() {
+  std::cout << "Loading CMSSW_12_2_0_pre2 geometry" << std::endl;
+
+  // Module orientation information (DrDz or phi angles)
+  TString endcap_geom = get_absolute_path_after_check_file_exists(TString::Format("%s/data/endcap_orientation_data_CMSSW_12_2_0_pre2.txt", TrackLooperDir_.Data()).Data());
+  TString tilted_geom = get_absolute_path_after_check_file_exists(TString::Format("%s/data/tilted_orientation_data_CMSSW_12_2_0_pre2.txt", TrackLooperDir_.Data()).Data());
+  std::cout << "Loading module orientation information...." << std::endl;
+  std::cout << "endcap orientation:" << endcap_geom << std::endl;
+  std::cout << "tilted orientation:" << tilted_geom << std::endl;
+  SDL::endcapGeometry.load(endcap_geom.Data()); // centroid values added to the map
+  SDL::tiltedGeometry.load(tilted_geom.Data());
+
+  // Module connection map (for line segment building)
+  TString mappath = get_absolute_path_after_check_file_exists(TString::Format("%s/data/module_connection_tracing_CMSSW_12_2_0_pre2_merged.txt", TrackLooperDir_.Data()).Data());
+  std::cout << "Loading module map...." << std::endl;
+  std::cout << "module map path:" << mappath << std::endl;
+  SDL::moduleConnectionMap.load(mappath.Data());
+
+  TString pLSMapDir = TrackLooperDir_+"/data/pixelmaps_CMSSW_12_2_0_pre2_0p8minPt";
+
+  std::cout << "Loading pLS maps ... from pLSMapDir = " << pLSMapDir << std::endl;
+
+  TString path;
+  path = TString::Format("%s/pLS_map_layer1_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet5.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+  path = TString::Format("%s/pLS_map_layer2_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet5.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+  path = TString::Format("%s/pLS_map_layer1_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet4.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+  path = TString::Format("%s/pLS_map_layer2_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet4.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+
+  path = TString::Format("%s/pLS_map_neg_layer1_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet5_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+  path = TString::Format("%s/pLS_map_neg_layer2_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet5_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+  path = TString::Format("%s/pLS_map_neg_layer1_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet4_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+  path = TString::Format("%s/pLS_map_neg_layer2_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet4_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+
+  path = TString::Format("%s/pLS_map_pos_layer1_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet5_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+  path = TString::Format("%s/pLS_map_pos_layer2_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet5_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+  path = TString::Format("%s/pLS_map_pos_layer1_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet4_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+  path = TString::Format("%s/pLS_map_pos_layer2_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet4_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+
+}
+
+TString SDL::LST::get_absolute_path_after_check_file_exists(const std::string name)
+{
+  std::filesystem::path fullpath = std::filesystem::absolute(name.c_str());
+  if (not std::filesystem::exists(fullpath))
+  {
+      std::cout << "ERROR: Could not find the file = " << fullpath << std::endl;
+      exit(2);
+  }
+  return TString(fullpath.string().c_str());
+}
+
+void SDL::LST::prepareInput(const std::vector<float> see_px,
+                            const std::vector<float> see_py,
+                            const std::vector<float> see_pz,
+                            const std::vector<float> see_dxy,
+                            const std::vector<float> see_dz,
+                            const std::vector<float> see_ptErr,
+                            const std::vector<float> see_etaErr,
+                            const std::vector<float> see_stateTrajGlbX,
+                            const std::vector<float> see_stateTrajGlbY,
+                            const std::vector<float> see_stateTrajGlbZ,
+                            const std::vector<float> see_stateTrajGlbPx,
+                            const std::vector<float> see_stateTrajGlbPy,
+                            const std::vector<float> see_stateTrajGlbPz,
+                            const std::vector<int> see_q,
+                            const std::vector<unsigned int> see_algo,
+                            const std::vector<std::vector<int>> see_hitIdx,
+                            const std::vector<unsigned int> ph2_detId,
+                            const std::vector<float> ph2_x,
+                            const std::vector<float> ph2_y,
+                            const std::vector<float> ph2_z) {
+  unsigned int count = 0;
+  auto n_see = see_stateTrajGlbPx.size();
+  std::vector<float> px_vec; px_vec.reserve(n_see);
+  std::vector<float> py_vec; py_vec.reserve(n_see);
+  std::vector<float> pz_vec; pz_vec.reserve(n_see);
+  std::vector<unsigned int> hitIndices_vec0; hitIndices_vec0.reserve(n_see);
+  std::vector<unsigned int> hitIndices_vec1; hitIndices_vec1.reserve(n_see);
+  std::vector<unsigned int> hitIndices_vec2; hitIndices_vec2.reserve(n_see);
+  std::vector<unsigned int> hitIndices_vec3; hitIndices_vec3.reserve(n_see);
+  std::vector<float> ptIn_vec;   ptIn_vec.reserve(n_see);
+  std::vector<float> ptErr_vec;  ptErr_vec.reserve(n_see);
+  std::vector<float> etaErr_vec; etaErr_vec.reserve(n_see);
+  std::vector<float> eta_vec;    eta_vec.reserve(n_see);
+  std::vector<float> phi_vec;    phi_vec.reserve(n_see);
+  std::vector<int> charge_vec;    charge_vec.reserve(n_see);
+  std::vector<float> deltaPhi_vec; deltaPhi_vec.reserve(n_see);
+  std::vector<float> trkX = ph2_x;
+  std::vector<float> trkY = ph2_y;
+  std::vector<float> trkZ = ph2_z;
+  std::vector<unsigned int> hitId = ph2_detId;
+  std::vector<unsigned int> hitIdxs(ph2_detId.size());
+
+  std::vector<int> superbin_vec;
+  std::vector<int8_t> pixelType_vec;
+  std::vector<short> isQuad_vec;
+  std::iota(hitIdxs.begin(), hitIdxs.end(), 0);
+  const int hit_size = trkX.size();
+
+  int nSeeds=0;
+  for (auto &&[iSeed, _] : iter::enumerate(see_stateTrajGlbPx))
+  {
+      nSeeds++;
+      bool good_seed_type = false;
+      if (see_algo[iSeed] == 4) good_seed_type = true;
+      if (see_algo[iSeed] == 22) good_seed_type = true;
+      if (not good_seed_type) continue;
+
+      ROOT::Math::PxPyPzMVector p3LH(see_stateTrajGlbPx[iSeed], see_stateTrajGlbPy[iSeed], see_stateTrajGlbPz[iSeed],0);
+      ROOT::Math::XYZVector p3LH_helper(see_stateTrajGlbPx[iSeed], see_stateTrajGlbPy[iSeed], see_stateTrajGlbPz[iSeed]);
+      float ptIn = p3LH.Pt();
+      float eta = p3LH.Eta();
+      float ptErr = see_ptErr[iSeed];
+
+      if ((ptIn > 0.8 - 2 * ptErr))
+      {
+      ROOT::Math::XYZVector r3LH(see_stateTrajGlbX[iSeed], see_stateTrajGlbY[iSeed], see_stateTrajGlbZ[iSeed]);
+      ROOT::Math::PxPyPzMVector p3PCA(see_px[iSeed], see_py[iSeed], see_pz[iSeed],0);
+      ROOT::Math::XYZVector r3PCA(calculateR3FromPCA(p3PCA, see_dxy[iSeed], see_dz[iSeed]));
+
+      float pixelSegmentDeltaPhiChange = (r3LH-p3LH_helper).Phi();
+      float etaErr = see_etaErr[iSeed];
+      float px = p3LH.Px();
+      float py = p3LH.Py();
+      float pz = p3LH.Pz();
+
+      int charge = see_q[iSeed];
+      //extra bit
+          // get pixel superbin
+          //int ptbin = -1;
+          int pixtype =-1;
+
+          if (ptIn >= 2.0){ /*ptbin = 1;*/pixtype=0;}
+          else if (ptIn >= (0.8 - 2 * ptErr) and ptIn < 2.0){ 
+            //ptbin = 0;
+            if (pixelSegmentDeltaPhiChange >= 0){pixtype=1;}
+            else{pixtype=2;}
+          }
+          else{continue;}
+
+          unsigned int hitIdx0 = hit_size + count;
+          count++; 
+
+          unsigned int hitIdx1 = hit_size + count;
+          count++;
+
+          unsigned int hitIdx2 = hit_size + count;
+          count++;
+
+          unsigned int hitIdx3;
+          if (see_hitIdx[iSeed].size() <= 3)
+          {
+              hitIdx3 = hitIdx2;
+          }
+          else
+          {
+              hitIdx3 = hit_size + count;
+              count++;
+          }
+
+          trkX.push_back(r3PCA.X());
+          trkY.push_back(r3PCA.Y());
+          trkZ.push_back(r3PCA.Z());
+          trkX.push_back(p3PCA.Pt());
+          float p3PCA_Eta = p3PCA.Eta();
+          trkY.push_back(p3PCA_Eta);
+          float p3PCA_Phi = p3PCA.Phi();
+          trkZ.push_back(p3PCA_Phi);
+          trkX.push_back(r3LH.X());
+          trkY.push_back(r3LH.Y());
+          trkZ.push_back(r3LH.Z());
+          hitId.push_back(1);
+          hitId.push_back(1);
+          hitId.push_back(1);
+          if(see_hitIdx[iSeed].size() > 3)
+          {
+              trkX.push_back(r3LH.X());
+              trkY.push_back(see_dxy[iSeed]);
+              trkZ.push_back(see_dz[iSeed]);
+              hitId.push_back(1);
+          }
+          px_vec.push_back(px);
+          py_vec.push_back(py);
+          pz_vec.push_back(pz);
+
+          hitIndices_vec0.push_back(hitIdx0);
+          hitIndices_vec1.push_back(hitIdx1);
+          hitIndices_vec2.push_back(hitIdx2);
+          hitIndices_vec3.push_back(hitIdx3);
+          ptIn_vec.push_back(ptIn);
+          ptErr_vec.push_back(ptErr);
+          etaErr_vec.push_back(etaErr);
+          eta_vec.push_back(eta);
+          float phi = p3LH.Phi();
+          phi_vec.push_back(phi);
+          charge_vec.push_back(charge);
+          deltaPhi_vec.push_back(pixelSegmentDeltaPhiChange);
+
+          // For matching with sim tracks
+          hitIdxs.push_back(see_hitIdx[iSeed][0]);
+          hitIdxs.push_back(see_hitIdx[iSeed][1]);
+          hitIdxs.push_back(see_hitIdx[iSeed][2]);
+          bool isQuad = false;
+          if(see_hitIdx[iSeed].size() > 3)
+          {
+              isQuad = true;
+              hitIdxs.push_back(see_hitIdx[iSeed][3]);
+          }
+          //if (pt < 0){ ptbin = 0;}
+          float neta = 25.;
+          float nphi = 72.;
+          float nz = 25.;
+          int etabin = (p3PCA_Eta + 2.6) / ((2*2.6)/neta);
+          int phibin = (p3PCA_Phi + 3.14159265358979323846) / ((2.*3.14159265358979323846) / nphi);
+          int dzbin = (see_dz[iSeed] + 30) / (2*30 / nz);
+          int isuperbin = /*(nz * nphi * neta) * ptbin + (removed since pt bin is determined by pixelType)*/ (nz * nphi) * etabin + (nz) * phibin + dzbin;
+          superbin_vec.push_back(isuperbin);
+          pixelType_vec.push_back(pixtype);
+          isQuad_vec.push_back(isQuad);
+
+      }
+
+  }
+
+  for (int i = 0; i<trkX.size(); i++) std::cout << trkX[i] << "\n";
+  in_trkX_ = trkX;
+  in_trkY_ = trkY;
+  in_trkZ_ = trkZ;
+  in_hitId_ = hitId;
+  in_hitIdxs_ = hitIdxs;
+  in_hitIndices_vec0_ = hitIndices_vec0;
+  in_hitIndices_vec1_ = hitIndices_vec1;
+  in_hitIndices_vec2_ = hitIndices_vec2;
+  in_hitIndices_vec3_ = hitIndices_vec3;
+  in_deltaPhi_vec_ = deltaPhi_vec;
+  in_ptIn_vec_ = ptIn_vec;
+  in_ptErr_vec_ = ptErr_vec;
+  in_px_vec_ = px_vec;
+  in_py_vec_ = py_vec;
+  in_pz_vec_ = pz_vec;
+  in_eta_vec_ = eta_vec;
+  in_etaErr_vec_ = etaErr_vec;
+  in_phi_vec_ = phi_vec;
+  in_charge_vec_ = charge_vec;
+  in_superbin_vec_ = superbin_vec;
+  in_pixelType_vec_ = pixelType_vec;
+  in_isQuad_vec_ = isQuad_vec;
+}
+
+ROOT::Math::XYZVector SDL::LST::calculateR3FromPCA(const ROOT::Math::PxPyPzMVector& p3, const float dxy, const float dz) {
+  const float pt = p3.Pt();
+  const float p = p3.P();
+  const float vz = dz*pt*pt/p/p;
+
+  const float vx = -dxy*p3.y()/pt - p3.x()/p*p3.z()/p*dz;
+  const float vy =  dxy*p3.x()/pt - p3.y()/p*p3.z()/p*dz;
+  std::cout << "pt = " << pt << ", p = " << p << ", vz = " << vz << ", vx = " << vx << ", vy = " << vy << "\n";
+  return ROOT::Math::XYZVector(vx, vy, vz);
+}
+
+void SDL::LST::getOutput(SDL::Event& event) {
+  SDL::trackCandidates& trackCandidatesInGPU = (*event.getTrackCandidates());
+  SDL::triplets& tripletsInGPU = (*event.getTriplets());
+  SDL::segments& segmentsInGPU = (*event.getSegments());
+  SDL::miniDoublets& miniDoubletsInGPU = (*event.getMiniDoublets());
+  SDL::hits& hitsInGPU = (*event.getHits());
+  SDL::modules& modulesInGPU = (*event.getModules());
+  SDL::quintuplets& quintupletsInGPU = (*event.getQuintuplets());
+  SDL::pixelTriplets& pixelTripletsInGPU = (*event.getPixelTriplets());
+  SDL::objectRanges& rangesInGPU = (*event.getRanges());
+
+  unsigned int nTrackCandidates = *trackCandidatesInGPU.nTrackCandidates;
+  for (unsigned int jdx = 0; jdx < nTrackCandidates; jdx++)
+  {
+      int hit_array_length=0;
+      short trackCandidateType = trackCandidatesInGPU.trackCandidateType[jdx];
+      unsigned int innerTrackletIdx = trackCandidatesInGPU.objectIndices[2 * jdx];
+      unsigned int outerTrackletIdx = trackCandidatesInGPU.objectIndices[2 * jdx + 1];
+
+      unsigned int innerTrackletInnerSegmentIndex = -1;
+      unsigned int innerTrackletOuterSegmentIndex = -1;
+      unsigned int outerTrackletOuterSegmentIndex = -1;
+      unsigned int outermostSegmentIndex = -1;
+
+      float betaIn_in = 0;
+      float betaOut_in = 0;
+      float betaIn_out = 0;
+      float betaOut_out = 0;
+
+      std::vector<int> hit_idx;
+      std::vector<int> hit_types;
+      std::vector<int> module_idxs; 
+      float pt;
+      float eta_pLS = -999;
+      float phi_pLS = -999;
+      if (trackCandidateType == 8) //pLS
+      {
+          pt = segmentsInGPU.ptIn[innerTrackletIdx];
+          eta_pLS = segmentsInGPU.eta[innerTrackletIdx];
+          phi_pLS = segmentsInGPU.phi[innerTrackletIdx];
+
+          GetpLSHitIndex(modulesInGPU, rangesInGPU, segmentsInGPU, miniDoubletsInGPU, hitsInGPU, hit_idx, hit_types, hit_array_length, innerTrackletIdx, module_idxs);
+//            printf("%d ",segmentsInGPU.isQuad[innerTrackletIdx]);
+
+      }
+      else
+      {
+          if (trackCandidateType == 5 || trackCandidateType == 7) //pT3 && pT5
+          {
+              if (trackCandidateType == 5){ //pT3
+              betaIn_in = 0;
+              betaOut_in = 0;
+              betaIn_out =  __H2F(tripletsInGPU.betaIn[pixelTripletsInGPU.tripletIndices[innerTrackletIdx]]);
+              betaOut_out = __H2F(tripletsInGPU.betaOut[pixelTripletsInGPU.tripletIndices[innerTrackletIdx]]);
+
+              //getting segments
+              innerTrackletInnerSegmentIndex = pixelTripletsInGPU.pixelSegmentIndices[innerTrackletIdx]; // pixel segments
+              innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * pixelTripletsInGPU.tripletIndices[innerTrackletIdx]]; //lower segment of the outer triplet
+              outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * pixelTripletsInGPU.tripletIndices[innerTrackletIdx] + 1]; //upper segment of the outer triplet
+//                printf("%d ",segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex]);
+//                printf("%d ",segmentsInGPU.isQuad[innerTrackletOuterSegmentIndex]);
+//                printf("%d ",segmentsInGPU.isQuad[outerTrackletOuterSegmentIndex]);
+              }
+
+              if (trackCandidateType == 7){ //pT5
+              //betaIn only has the beta values of the T5s. Use the TC type = 7 criterion to then get the pixel pT value to add together with these later!!!!!!
+              betaIn_in   = __H2F(tripletsInGPU.betaIn[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]]);
+              betaOut_in  = __H2F(tripletsInGPU.betaOut[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]]);
+              betaIn_out  = __H2F(tripletsInGPU.betaIn[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]]);
+              betaOut_out = __H2F(tripletsInGPU.betaOut[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]]);
+
+              //getting segments
+              //innerTrackletIndex = pLS
+              //outerTrackletIndex = T5
+              innerTrackletInnerSegmentIndex = innerTrackletIdx; //pLS
+              innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]]; // 1,2
+              outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx] + 1]; // 2,3
+              outermostSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1] + 1]; // 4,5
+//                printf("%d ",segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex]);
+              }
+
+              //getting MDs
+              //pLS 
+              unsigned int innerTrackletInnerSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletInnerSegmentIndex];
+              unsigned int innerTrackletInnerSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletInnerSegmentIndex + 1];
+              //outer MD 
+              unsigned int innerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletOuterSegmentIndex];  // MD1
+              unsigned int outerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex]; // MD2
+              unsigned int outerTrackletOuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex + 1]; //MD3
+
+              //getting hits
+              //pLS
+              unsigned int innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex];
+              unsigned int innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex];
+              unsigned int innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletInnerSegmentOuterMiniDoubletIndex];
+              unsigned int innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletInnerSegmentOuterMiniDoubletIndex];
+              //outer hits
+              unsigned int innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex];
+              unsigned int innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex];
+              unsigned int outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex];
+              unsigned int outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex];
+              unsigned int outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex];
+              unsigned int outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex];
+
+              hit_idx = {
+              //pLS
+              (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex],
+              (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex],
+              (int) hitsInGPU.idxs[innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex]
+              };
+
+//                if(segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex])
+              if (innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex != innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex)
+                  hit_idx.push_back((int)hitsInGPU.idxs[innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex]);
+
+              //outer hits
+              hit_idx.push_back((int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex]);
+              hit_idx.push_back((int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex]);
+              hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex]);
+              hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex]);
+              hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex]);
+              hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex]);
+
+              if(trackCandidateType == 7) //pT5
+              {
+                  unsigned int outermostSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outermostSegmentIndex];
+                  unsigned int outermostSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outermostSegmentIndex + 1];
+
+                  unsigned int outermostSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[outermostSegmentInnerMiniDoubletIndex];
+                  unsigned int outermostSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[outermostSegmentInnerMiniDoubletIndex];
+                  unsigned int outermostSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outermostSegmentOuterMiniDoubletIndex];
+                  unsigned int outermostSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outermostSegmentOuterMiniDoubletIndex];
+                  
+                  hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentInnerMiniDoubletLowerHitIndex]);
+                  hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentInnerMiniDoubletUpperHitIndex]);        
+                  hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletLowerHitIndex]);
+                  hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletUpperHitIndex]);
+              }
+/*
+              if(segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex] && trackCandidateType == 5) hit_array_length = 10;
+              if(!segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex] && trackCandidateType == 5) hit_array_length = 9;
+              if(segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex] && trackCandidateType == 7) hit_array_length = 14;
+              if(!segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex] && trackCandidateType == 7) hit_array_length = 13;
+*/
+              if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex != innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 5) hit_array_length = 10;
+              if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex == innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 5) hit_array_length = 9;
+              if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex != innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 7) hit_array_length = 14;
+              if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex == innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 7) hit_array_length = 13;
+          }
+
+          if (trackCandidateType == 4) // T5
+          {
+              //getting triplets
+              unsigned int innerTrackletIndex = quintupletsInGPU.tripletIndices[2 * innerTrackletIdx]; // 1,2,3
+              unsigned int outerTrackletIndex = quintupletsInGPU.tripletIndices[2 * innerTrackletIdx + 1]; // 3,4,5
+
+              betaIn_in   = __H2F(tripletsInGPU.betaIn[innerTrackletIndex]);
+              betaOut_in  = __H2F(tripletsInGPU.betaOut[innerTrackletIndex]);
+              betaIn_out  = __H2F(tripletsInGPU.betaIn[outerTrackletIndex]);
+              betaOut_out = __H2F(tripletsInGPU.betaOut[outerTrackletIndex]);
+
+              //getting segments
+              innerTrackletInnerSegmentIndex = tripletsInGPU.segmentIndices[2 * innerTrackletIndex];  // 1,2
+              innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * innerTrackletIndex + 1]; // 2,3
+              outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * outerTrackletIndex + 1]; // 4,5
+
+              GetT5HitIndex(modulesInGPU, rangesInGPU, tripletsInGPU, segmentsInGPU, miniDoubletsInGPU, hitsInGPU, hit_idx, hit_types, hit_array_length, innerTrackletIndex, outerTrackletIndex, innerTrackletInnerSegmentIndex, innerTrackletOuterSegmentIndex, outerTrackletOuterSegmentIndex, module_idxs);
+
+          }
+
+          unsigned int iiia_idx = -1;
+          unsigned int iooa_idx = -1;
+          unsigned int oiia_idx = -1;
+          unsigned int oooa_idx = -1;
+
+          if (trackCandidateType == 5)
+          {
+              iiia_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerTrackletInnerSegmentIndex]; // for pLS the innerSegment outerMiniDoublet
+              iooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
+              oiia_idx = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
+              oooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[outerTrackletOuterSegmentIndex];
+          }
+          else
+          {
+              //this was the old definition of the oo index in pT5, used to calculate the pt. The current definition is modified to use the same version as pT3
+              if (trackCandidateType == 7) outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]];
+              iiia_idx = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerTrackletInnerSegmentIndex];
+              iooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
+              oiia_idx = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
+              oooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[outerTrackletOuterSegmentIndex];
+          }
+
+          const float dr_in = sqrt(pow(hitsInGPU.xs[iiia_idx] - hitsInGPU.xs[iooa_idx], 2) + pow(hitsInGPU.ys[iiia_idx] - hitsInGPU.ys[iooa_idx], 2));
+          const float dr_out = sqrt(pow(hitsInGPU.xs[oiia_idx] - hitsInGPU.xs[oooa_idx], 2) + pow(hitsInGPU.ys[oiia_idx] - hitsInGPU.ys[oooa_idx], 2));
+
+          const float kRinv1GeVf = (2.99792458e-3 * 3.8);
+          const float k2Rinv1GeVf = kRinv1GeVf / 2.;
+
+          const float ptAv_in = (trackCandidateType == 7 or trackCandidateType == 5) ? segmentsInGPU.ptIn[innerTrackletInnerSegmentIndex - rangesInGPU.segmentModuleIndices[*(modulesInGPU.nLowerModules)]] : dr_in * k2Rinv1GeVf / sin((betaIn_in + betaOut_in) / 2.);
+
+          const float ptAv_out = dr_out * k2Rinv1GeVf / sin((betaIn_out + betaOut_out) / 2.);
+          float ptAv;
+          if(trackCandidateType == 7)
+          {
+              float ptAv_outermost = dr_in * k2Rinv1GeVf / sin((betaIn_in + betaOut_in) / 2.);
+              ptAv =  (ptAv_in + ptAv_out + ptAv_outermost) / 3.;
+          }
+          else
+          {
+              ptAv = (ptAv_in + ptAv_out) / 2.;
+          }
+
+          pt = ptAv;
+    }// end !pLS
+
+          // Compute pt, eta, phi of TC
+          float eta = -999;
+          float phi = -999;
+//          if (trackCandidateType == 4)
+//          {
+//              SDL::CPU::Hit hitA(trk.ph2_x()[hit_idx[0]], trk.ph2_y()[hit_idx[0]], trk.ph2_z()[hit_idx[0]]);
+//              SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[9]], trk.ph2_y()[hit_idx[9]], trk.ph2_z()[hit_idx[9]]);
+//              eta = hitB.eta();
+//              phi = hitA.phi();
+//          }
+//          else if (trackCandidateType == 8) // if pLS
+//          {
+//              eta = eta_pLS;
+//              phi = phi_pLS;
+//          }
+//          else
+//          {
+//              SDL::CPU::Hit hitA(trk.pix_x()[hit_idx[0]], trk.pix_y()[hit_idx[0]], trk.pix_z()[hit_idx[0]]);
+//              SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx.back()], trk.ph2_y()[hit_idx.back()], trk.ph2_z()[hit_idx.back()]);
+//              eta = hitB.eta();
+//              phi = hitA.phi();
+//          }
+//
+//          if(trackCandidateType == 7)
+//          {
+//              SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[13]], trk.ph2_y()[hit_idx[13]], trk.ph2_z()[hit_idx[13]]);
+//              eta = hitB.eta();
+//          }
+
+          out_tc_pt_.push_back(pt);
+          out_tc_eta_.push_back(eta);
+          out_tc_phi_.push_back(phi);
+          out_tc_hitIdxs_.push_back(hit_idx);
+          out_tc_len_.push_back(hit_array_length);
+  }
+}
+
+void SDL::LST::GetpLSHitIndex(SDL::modules& modulesInGPU,
+                              SDL::objectRanges& rangesInGPU,
+                              SDL::segments& segmentsInGPU,
+                              SDL::miniDoublets& miniDoubletsInGPU,
+                              SDL::hits& hitsInGPU,
+                              std::vector<int>& hit_idx,
+                              std::vector<int>& hit_types,
+                              int& hit_array_length,
+                              unsigned int innerTrackletIdx,
+                              std::vector<int>& module_idxs) {
+
+    unsigned int pixelModuleIndex = *(modulesInGPU.nLowerModules);
+    unsigned int pixelSegmentIndex = rangesInGPU.segmentModuleIndices[pixelModuleIndex] + innerTrackletIdx;
+
+    unsigned int innerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex];
+    unsigned int outerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex + 1];
+    unsigned int innerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[innerMiniDoubletIndex];
+    unsigned int innerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[innerMiniDoubletIndex];
+    unsigned int outerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[outerMiniDoubletIndex];
+    unsigned int outerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[outerMiniDoubletIndex];
+
+    hit_idx = {
+        (int) hitsInGPU.idxs[innerMiniDoubletLowerHitIndex],
+        (int) hitsInGPU.idxs[innerMiniDoubletUpperHitIndex],
+        (int) hitsInGPU.idxs[outerMiniDoubletUpperHitIndex]
+    };
+
+    hit_array_length = 3;
+    hit_types = {0,0,0};
+    module_idxs = {pixelModuleIndex, pixelModuleIndex, pixelModuleIndex}; 
+    if(segmentsInGPU.isQuad[innerTrackletIdx]){
+        hit_idx.push_back((int)hitsInGPU.idxs[outerMiniDoubletLowerHitIndex]);
+        hit_array_length = 4;
+        hit_types.push_back(0);
+        module_idxs.push_back(pixelModuleIndex);
+    }  
+
+}
+
+void SDL::LST::GetT5HitIndex(SDL::modules& modulesInGPU,
+                             SDL::objectRanges& rangesInGPU,
+                             SDL::triplets& tripletsInGPU,
+                             SDL::segments& segmentsInGPU,
+                             SDL::miniDoublets& miniDoubletsInGPU,
+                             SDL::hits& hitsInGPU,
+                             std::vector<int>& hit_idx,
+                             std::vector<int>& hit_types,
+                             int& hit_array_length,
+                             unsigned int innerTrackletIndex,
+                             unsigned int outerTrackletIndex,
+                             int innerTrackletInnerSegmentIndex,
+                             int innerTrackletOuterSegmentIndex,
+                             int outerTrackletOuterSegmentIndex,
+                             std::vector<int>& module_idxs) {
+    //getting MDs
+    unsigned int innerTrackletInnerSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletInnerSegmentIndex]; // 1
+    unsigned int innerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletOuterSegmentIndex];  // 2
+    unsigned int innerTrackletOuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletOuterSegmentIndex + 1]; // 3  
+    unsigned int outerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex]; // 4
+    unsigned int outerTrackletOuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex + 1]; // 5
+
+    //getting hits
+    unsigned int innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex]; //1,1
+    unsigned int innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex]; //1,2
+    unsigned int innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex]; //2,1
+    unsigned int innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex]; //2,2
+    unsigned int innerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletOuterSegmentOuterMiniDoubletIndex]; //3,1
+    unsigned int innerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletOuterSegmentOuterMiniDoubletIndex]; //3,2
+    unsigned int outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex]; //4,1
+    unsigned int outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex]; //4,2
+    unsigned int outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex]; //5,1
+    unsigned int outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex]; //5,2
+
+    hit_idx = {
+        (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex],
+        (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex],
+        (int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex],
+        (int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex],
+        (int) hitsInGPU.idxs[innerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex],
+        (int) hitsInGPU.idxs[innerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex],
+        (int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex],
+        (int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex],
+        (int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex],
+        (int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex],
+        };
+    hit_array_length = 10;
+}

--- a/SDL/LST.cc
+++ b/SDL/LST.cc
@@ -46,107 +46,100 @@ void SDL::LST::run(cudaStream_t stream,
                                in_pixelType_vec_,
                                in_isQuad_vec_);
   event.createMiniDoublets();
-  printf("# of Mini-doublets produced: %d\n",event.getNumberOfMiniDoublets());
-  printf("# of Mini-doublets produced barrel layer 1: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(0));
-  printf("# of Mini-doublets produced barrel layer 2: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(1));
-  printf("# of Mini-doublets produced barrel layer 3: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(2));
-  printf("# of Mini-doublets produced barrel layer 4: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(3));
-  printf("# of Mini-doublets produced barrel layer 5: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(4));
-  printf("# of Mini-doublets produced barrel layer 6: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(5));
-  printf("# of Mini-doublets produced endcap layer 1: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(0));
-  printf("# of Mini-doublets produced endcap layer 2: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(1));
-  printf("# of Mini-doublets produced endcap layer 3: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(2));
-  printf("# of Mini-doublets produced endcap layer 4: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(3));
-  printf("# of Mini-doublets produced endcap layer 5: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(4));
+  //printf("# of Mini-doublets produced: %d\n",event.getNumberOfMiniDoublets());
+  //printf("# of Mini-doublets produced barrel layer 1: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(0));
+  //printf("# of Mini-doublets produced barrel layer 2: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(1));
+  //printf("# of Mini-doublets produced barrel layer 3: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(2));
+  //printf("# of Mini-doublets produced barrel layer 4: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(3));
+  //printf("# of Mini-doublets produced barrel layer 5: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(4));
+  //printf("# of Mini-doublets produced barrel layer 6: %d\n",event.getNumberOfMiniDoubletsByLayerBarrel(5));
+  //printf("# of Mini-doublets produced endcap layer 1: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(0));
+  //printf("# of Mini-doublets produced endcap layer 2: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(1));
+  //printf("# of Mini-doublets produced endcap layer 3: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(2));
+  //printf("# of Mini-doublets produced endcap layer 4: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(3));
+  //printf("# of Mini-doublets produced endcap layer 5: %d\n",event.getNumberOfMiniDoubletsByLayerEndcap(4));
 
   event.createSegmentsWithModuleMap();
-  printf("# of Segments produced: %d\n",event.getNumberOfSegments());
-  printf("# of Segments produced layer 1-2:  %d\n",event.getNumberOfSegmentsByLayerBarrel(0));
-  printf("# of Segments produced layer 2-3:  %d\n",event.getNumberOfSegmentsByLayerBarrel(1));
-  printf("# of Segments produced layer 3-4:  %d\n",event.getNumberOfSegmentsByLayerBarrel(2));
-  printf("# of Segments produced layer 4-5:  %d\n",event.getNumberOfSegmentsByLayerBarrel(3));
-  printf("# of Segments produced layer 5-6:  %d\n",event.getNumberOfSegmentsByLayerBarrel(4));
-  printf("# of Segments produced endcap layer 1:  %d\n",event.getNumberOfSegmentsByLayerEndcap(0));
-  printf("# of Segments produced endcap layer 2:  %d\n",event.getNumberOfSegmentsByLayerEndcap(1));
-  printf("# of Segments produced endcap layer 3:  %d\n",event.getNumberOfSegmentsByLayerEndcap(2));
-  printf("# of Segments produced endcap layer 4:  %d\n",event.getNumberOfSegmentsByLayerEndcap(3));
-  printf("# of Segments produced endcap layer 5:  %d\n",event.getNumberOfSegmentsByLayerEndcap(4));
+  //printf("# of Segments produced: %d\n",event.getNumberOfSegments());
+  //printf("# of Segments produced layer 1-2:  %d\n",event.getNumberOfSegmentsByLayerBarrel(0));
+  //printf("# of Segments produced layer 2-3:  %d\n",event.getNumberOfSegmentsByLayerBarrel(1));
+  //printf("# of Segments produced layer 3-4:  %d\n",event.getNumberOfSegmentsByLayerBarrel(2));
+  //printf("# of Segments produced layer 4-5:  %d\n",event.getNumberOfSegmentsByLayerBarrel(3));
+  //printf("# of Segments produced layer 5-6:  %d\n",event.getNumberOfSegmentsByLayerBarrel(4));
+  //printf("# of Segments produced endcap layer 1:  %d\n",event.getNumberOfSegmentsByLayerEndcap(0));
+  //printf("# of Segments produced endcap layer 2:  %d\n",event.getNumberOfSegmentsByLayerEndcap(1));
+  //printf("# of Segments produced endcap layer 3:  %d\n",event.getNumberOfSegmentsByLayerEndcap(2));
+  //printf("# of Segments produced endcap layer 4:  %d\n",event.getNumberOfSegmentsByLayerEndcap(3));
+  //printf("# of Segments produced endcap layer 5:  %d\n",event.getNumberOfSegmentsByLayerEndcap(4));
 
   event.createTriplets();
-  printf("# of T3s produced: %d\n",event.getNumberOfTriplets());
-  printf("# of T3s produced layer 1-2-3: %d\n",event.getNumberOfTripletsByLayerBarrel(0));
-  printf("# of T3s produced layer 2-3-4: %d\n",event.getNumberOfTripletsByLayerBarrel(1));
-  printf("# of T3s produced layer 3-4-5: %d\n",event.getNumberOfTripletsByLayerBarrel(2));
-  printf("# of T3s produced layer 4-5-6: %d\n",event.getNumberOfTripletsByLayerBarrel(3));
-  printf("# of T3s produced endcap layer 1-2-3: %d\n",event.getNumberOfTripletsByLayerEndcap(0));
-  printf("# of T3s produced endcap layer 2-3-4: %d\n",event.getNumberOfTripletsByLayerEndcap(1));
-  printf("# of T3s produced endcap layer 3-4-5: %d\n",event.getNumberOfTripletsByLayerEndcap(2));
-  printf("# of T3s produced endcap layer 1: %d\n",event.getNumberOfTripletsByLayerEndcap(0));
-  printf("# of T3s produced endcap layer 2: %d\n",event.getNumberOfTripletsByLayerEndcap(1));
-  printf("# of T3s produced endcap layer 3: %d\n",event.getNumberOfTripletsByLayerEndcap(2));
-  printf("# of T3s produced endcap layer 4: %d\n",event.getNumberOfTripletsByLayerEndcap(3));
-  printf("# of T3s produced endcap layer 5: %d\n",event.getNumberOfTripletsByLayerEndcap(4));
+  //printf("# of T3s produced: %d\n",event.getNumberOfTriplets());
+  //printf("# of T3s produced layer 1-2-3: %d\n",event.getNumberOfTripletsByLayerBarrel(0));
+  //printf("# of T3s produced layer 2-3-4: %d\n",event.getNumberOfTripletsByLayerBarrel(1));
+  //printf("# of T3s produced layer 3-4-5: %d\n",event.getNumberOfTripletsByLayerBarrel(2));
+  //printf("# of T3s produced layer 4-5-6: %d\n",event.getNumberOfTripletsByLayerBarrel(3));
+  //printf("# of T3s produced endcap layer 1-2-3: %d\n",event.getNumberOfTripletsByLayerEndcap(0));
+  //printf("# of T3s produced endcap layer 2-3-4: %d\n",event.getNumberOfTripletsByLayerEndcap(1));
+  //printf("# of T3s produced endcap layer 3-4-5: %d\n",event.getNumberOfTripletsByLayerEndcap(2));
+  //printf("# of T3s produced endcap layer 1: %d\n",event.getNumberOfTripletsByLayerEndcap(0));
+  //printf("# of T3s produced endcap layer 2: %d\n",event.getNumberOfTripletsByLayerEndcap(1));
+  //printf("# of T3s produced endcap layer 3: %d\n",event.getNumberOfTripletsByLayerEndcap(2));
+  //printf("# of T3s produced endcap layer 4: %d\n",event.getNumberOfTripletsByLayerEndcap(3));
+  //printf("# of T3s produced endcap layer 5: %d\n",event.getNumberOfTripletsByLayerEndcap(4));
 
   event.createQuintuplets();
-  printf("# of Quintuplets produced: %d\n",event.getNumberOfQuintuplets());
-  printf("# of Quintuplets produced layer 1-2-3-4-5-6: %d\n",event.getNumberOfQuintupletsByLayerBarrel(0));
-  printf("# of Quintuplets produced layer 2: %d\n",event.getNumberOfQuintupletsByLayerBarrel(1));
-  printf("# of Quintuplets produced layer 3: %d\n",event.getNumberOfQuintupletsByLayerBarrel(2));
-  printf("# of Quintuplets produced layer 4: %d\n",event.getNumberOfQuintupletsByLayerBarrel(3));
-  printf("# of Quintuplets produced layer 5: %d\n",event.getNumberOfQuintupletsByLayerBarrel(4));
-  printf("# of Quintuplets produced layer 6: %d\n",event.getNumberOfQuintupletsByLayerBarrel(5));
-  printf("# of Quintuplets produced endcap layer 1: %d\n",event.getNumberOfQuintupletsByLayerEndcap(0));
-  printf("# of Quintuplets produced endcap layer 2: %d\n",event.getNumberOfQuintupletsByLayerEndcap(1));
-  printf("# of Quintuplets produced endcap layer 3: %d\n",event.getNumberOfQuintupletsByLayerEndcap(2));
-  printf("# of Quintuplets produced endcap layer 4: %d\n",event.getNumberOfQuintupletsByLayerEndcap(3));
-  printf("# of Quintuplets produced endcap layer 5: %d\n",event.getNumberOfQuintupletsByLayerEndcap(4));
+  //printf("# of Quintuplets produced: %d\n",event.getNumberOfQuintuplets());
+  //printf("# of Quintuplets produced layer 1-2-3-4-5-6: %d\n",event.getNumberOfQuintupletsByLayerBarrel(0));
+  //printf("# of Quintuplets produced layer 2: %d\n",event.getNumberOfQuintupletsByLayerBarrel(1));
+  //printf("# of Quintuplets produced layer 3: %d\n",event.getNumberOfQuintupletsByLayerBarrel(2));
+  //printf("# of Quintuplets produced layer 4: %d\n",event.getNumberOfQuintupletsByLayerBarrel(3));
+  //printf("# of Quintuplets produced layer 5: %d\n",event.getNumberOfQuintupletsByLayerBarrel(4));
+  //printf("# of Quintuplets produced layer 6: %d\n",event.getNumberOfQuintupletsByLayerBarrel(5));
+  //printf("# of Quintuplets produced endcap layer 1: %d\n",event.getNumberOfQuintupletsByLayerEndcap(0));
+  //printf("# of Quintuplets produced endcap layer 2: %d\n",event.getNumberOfQuintupletsByLayerEndcap(1));
+  //printf("# of Quintuplets produced endcap layer 3: %d\n",event.getNumberOfQuintupletsByLayerEndcap(2));
+  //printf("# of Quintuplets produced endcap layer 4: %d\n",event.getNumberOfQuintupletsByLayerEndcap(3));
+  //printf("# of Quintuplets produced endcap layer 5: %d\n",event.getNumberOfQuintupletsByLayerEndcap(4));
 
   event.pixelLineSegmentCleaning();
 
   event.createPixelQuintuplets();
-  printf("# of Pixel Quintuplets produced: %d\n",event.getNumberOfPixelQuintuplets());
+  //printf("# of Pixel Quintuplets produced: %d\n",event.getNumberOfPixelQuintuplets());
 
   event.createPixelTriplets();
-  printf("# of Pixel T3s produced: %d\n",event.getNumberOfPixelTriplets());
+  //printf("# of Pixel T3s produced: %d\n",event.getNumberOfPixelTriplets());
 
   event.createTrackCandidates();
-  printf("# of TrackCandidates produced: %d\n",event.getNumberOfTrackCandidates());
-  printf("    # of Pixel TrackCandidates produced: %d\n",event.getNumberOfPixelTrackCandidates());
-  printf("    # of pT5 TrackCandidates produced: %d\n",event.getNumberOfPT5TrackCandidates());
-  printf("    # of pT3 TrackCandidates produced: %d\n",event.getNumberOfPT3TrackCandidates());
-  printf("    # of pLS TrackCandidates produced: %d\n",event.getNumberOfPLSTrackCandidates());
-  printf("    # of T5 TrackCandidates produced: %d\n",event.getNumberOfT5TrackCandidates());
+  //printf("# of TrackCandidates produced: %d\n",event.getNumberOfTrackCandidates());
+  //printf("    # of Pixel TrackCandidates produced: %d\n",event.getNumberOfPixelTrackCandidates());
+  //printf("    # of pT5 TrackCandidates produced: %d\n",event.getNumberOfPT5TrackCandidates());
+  //printf("    # of pT3 TrackCandidates produced: %d\n",event.getNumberOfPT3TrackCandidates());
+  //printf("    # of pLS TrackCandidates produced: %d\n",event.getNumberOfPLSTrackCandidates());
+  //printf("    # of T5 TrackCandidates produced: %d\n",event.getNumberOfT5TrackCandidates());
 
   getOutput(event);
-  for(auto out : out_tc_pt_) printf("%f\n",out);
-  for(auto out : out_tc_eta_) printf("%f\n",out);
-  for(auto out : out_tc_phi_) printf("%f\n",out);
-  for(auto out : out_tc_len_) printf("%d\n",out);
+  //for(auto out : out_tc_pt_) printf("%f\n",out);
+  //for(auto out : out_tc_eta_) printf("%f\n",out);
+  //printf("\n");
+  //for(auto out : out_tc_phi_) printf("%f\n",out);
+  //printf("\n");
+  //for(auto out : out_tc_len_) printf("%d\n",out);
 }
 
 
 
 void SDL::LST::loadMaps() {
-  std::cout << "Loading CMSSW_12_2_0_pre2 geometry" << std::endl;
-
   // Module orientation information (DrDz or phi angles)
   TString endcap_geom = get_absolute_path_after_check_file_exists(TString::Format("%s/data/endcap_orientation_data_CMSSW_12_2_0_pre2.txt", TrackLooperDir_.Data()).Data());
   TString tilted_geom = get_absolute_path_after_check_file_exists(TString::Format("%s/data/tilted_orientation_data_CMSSW_12_2_0_pre2.txt", TrackLooperDir_.Data()).Data());
-  std::cout << "Loading module orientation information...." << std::endl;
-  std::cout << "endcap orientation:" << endcap_geom << std::endl;
-  std::cout << "tilted orientation:" << tilted_geom << std::endl;
   SDL::endcapGeometry.load(endcap_geom.Data()); // centroid values added to the map
   SDL::tiltedGeometry.load(tilted_geom.Data());
 
   // Module connection map (for line segment building)
   TString mappath = get_absolute_path_after_check_file_exists(TString::Format("%s/data/module_connection_tracing_CMSSW_12_2_0_pre2_merged.txt", TrackLooperDir_.Data()).Data());
-  std::cout << "Loading module map...." << std::endl;
-  std::cout << "module map path:" << mappath << std::endl;
   SDL::moduleConnectionMap.load(mappath.Data());
 
   TString pLSMapDir = TrackLooperDir_+"/data/pixelmaps_CMSSW_12_2_0_pre2_0p8minPt";
-
-  std::cout << "Loading pLS maps ... from pLSMapDir = " << pLSMapDir << std::endl;
 
   TString path;
   path = TString::Format("%s/pLS_map_layer1_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet5.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
@@ -350,7 +343,6 @@ void SDL::LST::prepareInput(const std::vector<float> see_px,
 
   }
 
-  for (int i = 0; i<trkX.size(); i++) std::cout << trkX[i] << "\n";
   in_trkX_ = trkX;
   in_trkY_ = trkY;
   in_trkZ_ = trkZ;
@@ -382,11 +374,14 @@ ROOT::Math::XYZVector SDL::LST::calculateR3FromPCA(const ROOT::Math::PxPyPzMVect
 
   const float vx = -dxy*p3.y()/pt - p3.x()/p*p3.z()/p*dz;
   const float vy =  dxy*p3.x()/pt - p3.y()/p*p3.z()/p*dz;
-  std::cout << "pt = " << pt << ", p = " << p << ", vz = " << vz << ", vx = " << vx << ", vy = " << vy << "\n";
   return ROOT::Math::XYZVector(vx, vy, vz);
 }
 
 void SDL::LST::getOutput(SDL::Event& event) {
+  std::vector<float> tc_pt_, tc_eta_, tc_phi_;
+  std::vector<std::vector<int>> tc_hitIdxs_;
+  std::vector<int> tc_len_;
+
   SDL::trackCandidates& trackCandidatesInGPU = (*event.getTrackCandidates());
   SDL::triplets& tripletsInGPU = (*event.getTriplets());
   SDL::segments& segmentsInGPU = (*event.getSegments());
@@ -398,283 +393,243 @@ void SDL::LST::getOutput(SDL::Event& event) {
   SDL::objectRanges& rangesInGPU = (*event.getRanges());
 
   unsigned int nTrackCandidates = *trackCandidatesInGPU.nTrackCandidates;
-  for (unsigned int jdx = 0; jdx < nTrackCandidates; jdx++)
-  {
-      int hit_array_length=0;
-      short trackCandidateType = trackCandidatesInGPU.trackCandidateType[jdx];
-      unsigned int innerTrackletIdx = trackCandidatesInGPU.objectIndices[2 * jdx];
-      unsigned int outerTrackletIdx = trackCandidatesInGPU.objectIndices[2 * jdx + 1];
+  for (unsigned int jdx = 0; jdx < nTrackCandidates; jdx++) {
+    int hit_array_length = 0;
+    short trackCandidateType = trackCandidatesInGPU.trackCandidateType[jdx];
+    unsigned int innerTrackletIdx = trackCandidatesInGPU.objectIndices[2 * jdx];
+    unsigned int outerTrackletIdx = trackCandidatesInGPU.objectIndices[2 * jdx + 1];
 
-      unsigned int innerTrackletInnerSegmentIndex = -1;
-      unsigned int innerTrackletOuterSegmentIndex = -1;
-      unsigned int outerTrackletOuterSegmentIndex = -1;
-      unsigned int outermostSegmentIndex = -1;
+    unsigned int innerTrackletInnerSegmentIndex = -1;
+    unsigned int innerTrackletOuterSegmentIndex = -1;
+    unsigned int outerTrackletOuterSegmentIndex = -1;
+    unsigned int outermostSegmentIndex = -1;
 
-      float betaIn_in = 0;
-      float betaOut_in = 0;
-      float betaIn_out = 0;
-      float betaOut_out = 0;
+    float betaIn_in = 0.0;
+    float betaOut_in = 0.0;
+    float betaIn_out = 0.0;
+    float betaOut_out = 0.0;
 
-      std::vector<int> hit_idx;
-      std::vector<int> hit_types;
-      std::vector<int> module_idxs; 
-      float pt;
-      float eta_pLS = -999;
-      float phi_pLS = -999;
-      if (trackCandidateType == 8) //pLS
-      {
-          pt = segmentsInGPU.ptIn[innerTrackletIdx];
-          eta_pLS = segmentsInGPU.eta[innerTrackletIdx];
-          phi_pLS = segmentsInGPU.phi[innerTrackletIdx];
+    std::vector<int> hit_idx;
+    std::vector<int> module_idxs; 
+    float pt, eta_pLS, phi_pLS;
+    if (trackCandidateType == 8) { // pLS
+      pt = segmentsInGPU.ptIn[innerTrackletIdx];
+      eta_pLS = segmentsInGPU.eta[innerTrackletIdx];
+      phi_pLS = segmentsInGPU.phi[innerTrackletIdx];
 
-          GetpLSHitIndex(modulesInGPU, rangesInGPU, segmentsInGPU, miniDoubletsInGPU, hitsInGPU, hit_idx, hit_types, hit_array_length, innerTrackletIdx, module_idxs);
-//            printf("%d ",segmentsInGPU.isQuad[innerTrackletIdx]);
+      GetpLSHitIndex(modulesInGPU, rangesInGPU, segmentsInGPU, miniDoubletsInGPU, hitsInGPU, hit_idx, hit_array_length, innerTrackletIdx, module_idxs);
+    }
+    else { // not pLS
+      if (trackCandidateType == 5 || trackCandidateType == 7) { // pT3 && pT5
+        if (trackCandidateType == 5) { // pT3
+          betaIn_in = 0;
+          betaOut_in = 0;
+          betaIn_out =  __H2F(tripletsInGPU.betaIn[pixelTripletsInGPU.tripletIndices[innerTrackletIdx]]);
+          betaOut_out = __H2F(tripletsInGPU.betaOut[pixelTripletsInGPU.tripletIndices[innerTrackletIdx]]);
 
+          //getting segments
+          innerTrackletInnerSegmentIndex = pixelTripletsInGPU.pixelSegmentIndices[innerTrackletIdx]; // pixel segments
+          innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * pixelTripletsInGPU.tripletIndices[innerTrackletIdx]]; // lower segment of the outer triplet
+          outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * pixelTripletsInGPU.tripletIndices[innerTrackletIdx] + 1]; // upper segment of the outer triplet
+        }
+
+        if (trackCandidateType == 7) { // pT5
+          betaIn_in   = __H2F(tripletsInGPU.betaIn[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]]);
+          betaOut_in  = __H2F(tripletsInGPU.betaOut[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]]);
+          betaIn_out  = __H2F(tripletsInGPU.betaIn[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]]);
+          betaOut_out = __H2F(tripletsInGPU.betaOut[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]]);
+
+          //getting segments
+          innerTrackletInnerSegmentIndex = innerTrackletIdx; // pLS
+          innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]]; // 1,2
+          outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx] + 1]; // 2,3
+          outermostSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1] + 1]; // 4,5
+        }
+
+        //getting MDs
+        //pLS 
+        unsigned int innerTrackletInnerSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletInnerSegmentIndex];
+        unsigned int innerTrackletInnerSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletInnerSegmentIndex + 1];
+        //outer MD 
+        unsigned int innerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletOuterSegmentIndex];  // MD1
+        unsigned int outerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex]; // MD2
+        unsigned int outerTrackletOuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex + 1]; //MD3
+
+        //getting hits
+        //pLS
+        unsigned int innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex];
+        unsigned int innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex];
+        unsigned int innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletInnerSegmentOuterMiniDoubletIndex];
+        unsigned int innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletInnerSegmentOuterMiniDoubletIndex];
+        //outer hits
+        unsigned int innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex];
+        unsigned int innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex];
+        unsigned int outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex];
+        unsigned int outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex];
+        unsigned int outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex];
+        unsigned int outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex];
+
+        hit_idx = {
+          //pLS
+          (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex],
+          (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex],
+          (int) hitsInGPU.idxs[innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex]
+        };
+
+        // If not quad, the third and fourth hit indices are the same
+        if (innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex != innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex)
+          hit_idx.push_back((int)hitsInGPU.idxs[innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex]);
+
+        //outer hits
+        hit_idx.push_back((int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex]);
+        hit_idx.push_back((int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex]);
+        hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex]);
+        hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex]);
+        hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex]);
+        hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex]);
+
+        if(trackCandidateType == 7) { // pT5
+          unsigned int outermostSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outermostSegmentIndex];
+          unsigned int outermostSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outermostSegmentIndex + 1];
+
+          unsigned int outermostSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[outermostSegmentInnerMiniDoubletIndex];
+          unsigned int outermostSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[outermostSegmentInnerMiniDoubletIndex];
+          unsigned int outermostSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outermostSegmentOuterMiniDoubletIndex];
+          unsigned int outermostSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outermostSegmentOuterMiniDoubletIndex];
+          
+          hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentInnerMiniDoubletLowerHitIndex]);
+          hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentInnerMiniDoubletUpperHitIndex]);        
+          hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletLowerHitIndex]);
+          hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletUpperHitIndex]);
+        }
+
+        if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex != innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 5) hit_array_length = 10;
+        if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex == innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 5) hit_array_length = 9;
+        if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex != innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 7) hit_array_length = 14;
+        if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex == innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 7) hit_array_length = 13;
       }
-      else
-      {
-          if (trackCandidateType == 5 || trackCandidateType == 7) //pT3 && pT5
-          {
-              if (trackCandidateType == 5){ //pT3
-              betaIn_in = 0;
-              betaOut_in = 0;
-              betaIn_out =  __H2F(tripletsInGPU.betaIn[pixelTripletsInGPU.tripletIndices[innerTrackletIdx]]);
-              betaOut_out = __H2F(tripletsInGPU.betaOut[pixelTripletsInGPU.tripletIndices[innerTrackletIdx]]);
 
-              //getting segments
-              innerTrackletInnerSegmentIndex = pixelTripletsInGPU.pixelSegmentIndices[innerTrackletIdx]; // pixel segments
-              innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * pixelTripletsInGPU.tripletIndices[innerTrackletIdx]]; //lower segment of the outer triplet
-              outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * pixelTripletsInGPU.tripletIndices[innerTrackletIdx] + 1]; //upper segment of the outer triplet
-//                printf("%d ",segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex]);
-//                printf("%d ",segmentsInGPU.isQuad[innerTrackletOuterSegmentIndex]);
-//                printf("%d ",segmentsInGPU.isQuad[outerTrackletOuterSegmentIndex]);
-              }
+      if (trackCandidateType == 4) { // T5
+        //getting triplets
+        unsigned int innerTrackletIndex = quintupletsInGPU.tripletIndices[2 * innerTrackletIdx]; // 1,2,3
+        unsigned int outerTrackletIndex = quintupletsInGPU.tripletIndices[2 * innerTrackletIdx + 1]; // 3,4,5
 
-              if (trackCandidateType == 7){ //pT5
-              //betaIn only has the beta values of the T5s. Use the TC type = 7 criterion to then get the pixel pT value to add together with these later!!!!!!
-              betaIn_in   = __H2F(tripletsInGPU.betaIn[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]]);
-              betaOut_in  = __H2F(tripletsInGPU.betaOut[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]]);
-              betaIn_out  = __H2F(tripletsInGPU.betaIn[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]]);
-              betaOut_out = __H2F(tripletsInGPU.betaOut[quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]]);
+        betaIn_in   = __H2F(tripletsInGPU.betaIn[innerTrackletIndex]);
+        betaOut_in  = __H2F(tripletsInGPU.betaOut[innerTrackletIndex]);
+        betaIn_out  = __H2F(tripletsInGPU.betaIn[outerTrackletIndex]);
+        betaOut_out = __H2F(tripletsInGPU.betaOut[outerTrackletIndex]);
 
-              //getting segments
-              //innerTrackletIndex = pLS
-              //outerTrackletIndex = T5
-              innerTrackletInnerSegmentIndex = innerTrackletIdx; //pLS
-              innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx]]; // 1,2
-              outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx] + 1]; // 2,3
-              outermostSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1] + 1]; // 4,5
-//                printf("%d ",segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex]);
-              }
+        //getting segments
+        innerTrackletInnerSegmentIndex = tripletsInGPU.segmentIndices[2 * innerTrackletIndex];  // 1,2
+        innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * innerTrackletIndex + 1]; // 2,3
+        outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * outerTrackletIndex + 1]; // 4,5
 
-              //getting MDs
-              //pLS 
-              unsigned int innerTrackletInnerSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletInnerSegmentIndex];
-              unsigned int innerTrackletInnerSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletInnerSegmentIndex + 1];
-              //outer MD 
-              unsigned int innerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletOuterSegmentIndex];  // MD1
-              unsigned int outerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex]; // MD2
-              unsigned int outerTrackletOuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex + 1]; //MD3
+        GetT5HitIndex(modulesInGPU, rangesInGPU, tripletsInGPU, segmentsInGPU, miniDoubletsInGPU, hitsInGPU, hit_idx, hit_array_length, innerTrackletIndex, outerTrackletIndex, innerTrackletInnerSegmentIndex, innerTrackletOuterSegmentIndex, outerTrackletOuterSegmentIndex, module_idxs);
+      }
 
-              //getting hits
-              //pLS
-              unsigned int innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex];
-              unsigned int innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex];
-              unsigned int innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletInnerSegmentOuterMiniDoubletIndex];
-              unsigned int innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletInnerSegmentOuterMiniDoubletIndex];
-              //outer hits
-              unsigned int innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex];
-              unsigned int innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex];
-              unsigned int outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex];
-              unsigned int outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex];
-              unsigned int outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex];
-              unsigned int outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex];
+      unsigned int iiia_idx = -1;
+      unsigned int iooa_idx = -1;
+      unsigned int oiia_idx = -1;
+      unsigned int oooa_idx = -1;
 
-              hit_idx = {
-              //pLS
-              (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex],
-              (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex],
-              (int) hitsInGPU.idxs[innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex]
-              };
+      if (trackCandidateType == 5) { // pT3
+        iiia_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerTrackletInnerSegmentIndex]; // for pLS the innerSegment outerMiniDoublet
+        iooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
+        oiia_idx = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
+        oooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[outerTrackletOuterSegmentIndex];
+      }
+      else {
+        //this was the old definition of the oo index in pT5, used to calculate the pt. The current definition is modified to use the same version as pT3
+        if (trackCandidateType == 7) // pT5
+          outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]];
+        iiia_idx = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerTrackletInnerSegmentIndex];
+        iooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
+        oiia_idx = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
+        oooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[outerTrackletOuterSegmentIndex];
+      }
 
-//                if(segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex])
-              if (innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex != innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex)
-                  hit_idx.push_back((int)hitsInGPU.idxs[innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex]);
+      const float dr_in = std::sqrt(pow(hitsInGPU.xs[iiia_idx] - hitsInGPU.xs[iooa_idx], 2) + pow(hitsInGPU.ys[iiia_idx] - hitsInGPU.ys[iooa_idx], 2));
+      const float dr_out = std::sqrt(pow(hitsInGPU.xs[oiia_idx] - hitsInGPU.xs[oooa_idx], 2) + pow(hitsInGPU.ys[oiia_idx] - hitsInGPU.ys[oooa_idx], 2));
 
-              //outer hits
-              hit_idx.push_back((int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex]);
-              hit_idx.push_back((int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex]);
-              hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex]);
-              hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex]);
-              hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex]);
-              hit_idx.push_back((int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex]);
+      const float kRinv1GeVf = (2.99792458e-3 * 3.8);
+      const float k2Rinv1GeVf = kRinv1GeVf / 2.;
 
-              if(trackCandidateType == 7) //pT5
-              {
-                  unsigned int outermostSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outermostSegmentIndex];
-                  unsigned int outermostSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outermostSegmentIndex + 1];
+      const float ptAv_in = (trackCandidateType == 7 or trackCandidateType == 5) ? // pT3 or pT5
+        segmentsInGPU.ptIn[innerTrackletInnerSegmentIndex - rangesInGPU.segmentModuleIndices[*(modulesInGPU.nLowerModules)]] :
+        dr_in * k2Rinv1GeVf / fabs(sin((betaIn_in + betaOut_in) / 2.));
 
-                  unsigned int outermostSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[outermostSegmentInnerMiniDoubletIndex];
-                  unsigned int outermostSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[outermostSegmentInnerMiniDoubletIndex];
-                  unsigned int outermostSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outermostSegmentOuterMiniDoubletIndex];
-                  unsigned int outermostSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outermostSegmentOuterMiniDoubletIndex];
-                  
-                  hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentInnerMiniDoubletLowerHitIndex]);
-                  hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentInnerMiniDoubletUpperHitIndex]);        
-                  hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletLowerHitIndex]);
-                  hit_idx.push_back((int)hitsInGPU.idxs[outermostSegmentOuterMiniDoubletUpperHitIndex]);
-              }
-/*
-              if(segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex] && trackCandidateType == 5) hit_array_length = 10;
-              if(!segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex] && trackCandidateType == 5) hit_array_length = 9;
-              if(segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex] && trackCandidateType == 7) hit_array_length = 14;
-              if(!segmentsInGPU.isQuad[innerTrackletInnerSegmentIndex] && trackCandidateType == 7) hit_array_length = 13;
-*/
-              if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex != innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 5) hit_array_length = 10;
-              if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex == innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 5) hit_array_length = 9;
-              if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex != innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 7) hit_array_length = 14;
-              if(innerTrackletInnerSegmentOuterMiniDoubletLowerHitIndex == innerTrackletInnerSegmentOuterMiniDoubletUpperHitIndex && trackCandidateType == 7) hit_array_length = 13;
-          }
+      const float ptAv_out = dr_out * k2Rinv1GeVf / fabs(sin((betaIn_out + betaOut_out) / 2.));
 
-          if (trackCandidateType == 4) // T5
-          {
-              //getting triplets
-              unsigned int innerTrackletIndex = quintupletsInGPU.tripletIndices[2 * innerTrackletIdx]; // 1,2,3
-              unsigned int outerTrackletIndex = quintupletsInGPU.tripletIndices[2 * innerTrackletIdx + 1]; // 3,4,5
+      float ptAv;
+      if(trackCandidateType == 7) { // pT5
+        float ptAv_outermost = dr_in * k2Rinv1GeVf / fabs(sin((betaIn_in + betaOut_in) / 2.));
+        ptAv =  (ptAv_in + ptAv_out + ptAv_outermost) / 3.;
+      }
+      else { // not pT5
+        ptAv = (ptAv_in + ptAv_out) / 2.;
+      }
 
-              betaIn_in   = __H2F(tripletsInGPU.betaIn[innerTrackletIndex]);
-              betaOut_in  = __H2F(tripletsInGPU.betaOut[innerTrackletIndex]);
-              betaIn_out  = __H2F(tripletsInGPU.betaIn[outerTrackletIndex]);
-              betaOut_out = __H2F(tripletsInGPU.betaOut[outerTrackletIndex]);
+      pt = ptAv;
+    } // not pLS
 
-              //getting segments
-              innerTrackletInnerSegmentIndex = tripletsInGPU.segmentIndices[2 * innerTrackletIndex];  // 1,2
-              innerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * innerTrackletIndex + 1]; // 2,3
-              outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * outerTrackletIndex + 1]; // 4,5
+    // Compute pt, eta, phi of TC
+    float eta = -999;
+    float phi = -999;
+    if (trackCandidateType == 8) { // pLS
+      eta = eta_pLS;
+      phi = phi_pLS;
+    }
+    else { // Consistent definitions for T5, pT3 and pT5
+      eta = SDL::eta(in_trkX_[hit_idx.back()], in_trkY_[hit_idx.back()], in_trkZ_[hit_idx.back()]); // eta from outermost hit
+      phi = SDL::phi(in_trkX_[hit_idx[0]], in_trkY_[hit_idx[0]]); // phi from innermost hit
+    }
 
-              GetT5HitIndex(modulesInGPU, rangesInGPU, tripletsInGPU, segmentsInGPU, miniDoubletsInGPU, hitsInGPU, hit_idx, hit_types, hit_array_length, innerTrackletIndex, outerTrackletIndex, innerTrackletInnerSegmentIndex, innerTrackletOuterSegmentIndex, outerTrackletOuterSegmentIndex, module_idxs);
-
-          }
-
-          unsigned int iiia_idx = -1;
-          unsigned int iooa_idx = -1;
-          unsigned int oiia_idx = -1;
-          unsigned int oooa_idx = -1;
-
-          if (trackCandidateType == 5)
-          {
-              iiia_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerTrackletInnerSegmentIndex]; // for pLS the innerSegment outerMiniDoublet
-              iooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
-              oiia_idx = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
-              oooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[outerTrackletOuterSegmentIndex];
-          }
-          else
-          {
-              //this was the old definition of the oo index in pT5, used to calculate the pt. The current definition is modified to use the same version as pT3
-              if (trackCandidateType == 7) outerTrackletOuterSegmentIndex = tripletsInGPU.segmentIndices[2 * quintupletsInGPU.tripletIndices[2 * outerTrackletIdx + 1]];
-              iiia_idx = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerTrackletInnerSegmentIndex];
-              iooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
-              oiia_idx = segmentsInGPU.innerMiniDoubletAnchorHitIndices[innerTrackletOuterSegmentIndex];
-              oooa_idx = segmentsInGPU.outerMiniDoubletAnchorHitIndices[outerTrackletOuterSegmentIndex];
-          }
-
-          const float dr_in = sqrt(pow(hitsInGPU.xs[iiia_idx] - hitsInGPU.xs[iooa_idx], 2) + pow(hitsInGPU.ys[iiia_idx] - hitsInGPU.ys[iooa_idx], 2));
-          const float dr_out = sqrt(pow(hitsInGPU.xs[oiia_idx] - hitsInGPU.xs[oooa_idx], 2) + pow(hitsInGPU.ys[oiia_idx] - hitsInGPU.ys[oooa_idx], 2));
-
-          const float kRinv1GeVf = (2.99792458e-3 * 3.8);
-          const float k2Rinv1GeVf = kRinv1GeVf / 2.;
-
-          const float ptAv_in = (trackCandidateType == 7 or trackCandidateType == 5) ? segmentsInGPU.ptIn[innerTrackletInnerSegmentIndex - rangesInGPU.segmentModuleIndices[*(modulesInGPU.nLowerModules)]] : dr_in * k2Rinv1GeVf / sin((betaIn_in + betaOut_in) / 2.);
-
-          const float ptAv_out = dr_out * k2Rinv1GeVf / sin((betaIn_out + betaOut_out) / 2.);
-          float ptAv;
-          if(trackCandidateType == 7)
-          {
-              float ptAv_outermost = dr_in * k2Rinv1GeVf / sin((betaIn_in + betaOut_in) / 2.);
-              ptAv =  (ptAv_in + ptAv_out + ptAv_outermost) / 3.;
-          }
-          else
-          {
-              ptAv = (ptAv_in + ptAv_out) / 2.;
-          }
-
-          pt = ptAv;
-    }// end !pLS
-
-          // Compute pt, eta, phi of TC
-          float eta = -999;
-          float phi = -999;
-//          if (trackCandidateType == 4)
-//          {
-//              SDL::CPU::Hit hitA(trk.ph2_x()[hit_idx[0]], trk.ph2_y()[hit_idx[0]], trk.ph2_z()[hit_idx[0]]);
-//              SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[9]], trk.ph2_y()[hit_idx[9]], trk.ph2_z()[hit_idx[9]]);
-//              eta = hitB.eta();
-//              phi = hitA.phi();
-//          }
-//          else if (trackCandidateType == 8) // if pLS
-//          {
-//              eta = eta_pLS;
-//              phi = phi_pLS;
-//          }
-//          else
-//          {
-//              SDL::CPU::Hit hitA(trk.pix_x()[hit_idx[0]], trk.pix_y()[hit_idx[0]], trk.pix_z()[hit_idx[0]]);
-//              SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx.back()], trk.ph2_y()[hit_idx.back()], trk.ph2_z()[hit_idx.back()]);
-//              eta = hitB.eta();
-//              phi = hitA.phi();
-//          }
-//
-//          if(trackCandidateType == 7)
-//          {
-//              SDL::CPU::Hit hitB(trk.ph2_x()[hit_idx[13]], trk.ph2_y()[hit_idx[13]], trk.ph2_z()[hit_idx[13]]);
-//              eta = hitB.eta();
-//          }
-
-          out_tc_pt_.push_back(pt);
-          out_tc_eta_.push_back(eta);
-          out_tc_phi_.push_back(phi);
-          out_tc_hitIdxs_.push_back(hit_idx);
-          out_tc_len_.push_back(hit_array_length);
+    tc_pt_.push_back(pt);
+    tc_eta_.push_back(eta);
+    tc_phi_.push_back(phi);
+    tc_hitIdxs_.push_back(hit_idx);
+    tc_len_.push_back(hit_array_length);
   }
+  out_tc_pt_ = tc_pt_;
+  out_tc_eta_ = tc_eta_;
+  out_tc_phi_ = tc_phi_;
+  out_tc_hitIdxs_ = tc_hitIdxs_;
+  out_tc_len_ = tc_len_;
 }
 
 void SDL::LST::GetpLSHitIndex(SDL::modules& modulesInGPU,
-                              SDL::objectRanges& rangesInGPU,
-                              SDL::segments& segmentsInGPU,
-                              SDL::miniDoublets& miniDoubletsInGPU,
-                              SDL::hits& hitsInGPU,
-                              std::vector<int>& hit_idx,
-                              std::vector<int>& hit_types,
-                              int& hit_array_length,
-                              unsigned int innerTrackletIdx,
-                              std::vector<int>& module_idxs) {
+                            SDL::objectRanges& rangesInGPU,
+                            SDL::segments& segmentsInGPU,
+                            SDL::miniDoublets& miniDoubletsInGPU,
+                            SDL::hits& hitsInGPU,
+                            std::vector<int>& hit_idx,
+                            int& hit_array_length,
+                            unsigned int innerTrackletIdx,
+                            std::vector<int>& module_idxs) {
 
-    unsigned int pixelModuleIndex = *(modulesInGPU.nLowerModules);
-    unsigned int pixelSegmentIndex = rangesInGPU.segmentModuleIndices[pixelModuleIndex] + innerTrackletIdx;
+  unsigned int pixelModuleIndex = *(modulesInGPU.nLowerModules);
+  unsigned int pixelSegmentIndex = rangesInGPU.segmentModuleIndices[pixelModuleIndex] + innerTrackletIdx;
 
-    unsigned int innerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex];
-    unsigned int outerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex + 1];
-    unsigned int innerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[innerMiniDoubletIndex];
-    unsigned int innerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[innerMiniDoubletIndex];
-    unsigned int outerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[outerMiniDoubletIndex];
-    unsigned int outerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[outerMiniDoubletIndex];
+  unsigned int innerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex];
+  unsigned int outerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * pixelSegmentIndex + 1];
+  unsigned int innerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[innerMiniDoubletIndex];
+  unsigned int innerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[innerMiniDoubletIndex];
+  unsigned int outerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[outerMiniDoubletIndex];
+  unsigned int outerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[outerMiniDoubletIndex];
 
-    hit_idx = {
-        (int) hitsInGPU.idxs[innerMiniDoubletLowerHitIndex],
-        (int) hitsInGPU.idxs[innerMiniDoubletUpperHitIndex],
-        (int) hitsInGPU.idxs[outerMiniDoubletUpperHitIndex]
-    };
+  hit_idx = {
+    (int) hitsInGPU.idxs[innerMiniDoubletLowerHitIndex],
+    (int) hitsInGPU.idxs[innerMiniDoubletUpperHitIndex],
+    (int) hitsInGPU.idxs[outerMiniDoubletUpperHitIndex]
+  };
 
-    hit_array_length = 3;
-    hit_types = {0,0,0};
-    module_idxs = {pixelModuleIndex, pixelModuleIndex, pixelModuleIndex}; 
-    if(segmentsInGPU.isQuad[innerTrackletIdx]){
-        hit_idx.push_back((int)hitsInGPU.idxs[outerMiniDoubletLowerHitIndex]);
-        hit_array_length = 4;
-        hit_types.push_back(0);
-        module_idxs.push_back(pixelModuleIndex);
-    }  
-
+  hit_array_length = 3;
+  module_idxs = {pixelModuleIndex, pixelModuleIndex, pixelModuleIndex}; 
+  if(segmentsInGPU.isQuad[innerTrackletIdx]) {
+    hit_idx.push_back((int)hitsInGPU.idxs[outerMiniDoubletLowerHitIndex]);
+    hit_array_length = 4;
+    module_idxs.push_back(pixelModuleIndex);
+  }  
 }
 
 void SDL::LST::GetT5HitIndex(SDL::modules& modulesInGPU,
@@ -684,7 +639,6 @@ void SDL::LST::GetT5HitIndex(SDL::modules& modulesInGPU,
                              SDL::miniDoublets& miniDoubletsInGPU,
                              SDL::hits& hitsInGPU,
                              std::vector<int>& hit_idx,
-                             std::vector<int>& hit_types,
                              int& hit_array_length,
                              unsigned int innerTrackletIndex,
                              unsigned int outerTrackletIndex,
@@ -692,36 +646,36 @@ void SDL::LST::GetT5HitIndex(SDL::modules& modulesInGPU,
                              int innerTrackletOuterSegmentIndex,
                              int outerTrackletOuterSegmentIndex,
                              std::vector<int>& module_idxs) {
-    //getting MDs
-    unsigned int innerTrackletInnerSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletInnerSegmentIndex]; // 1
-    unsigned int innerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletOuterSegmentIndex];  // 2
-    unsigned int innerTrackletOuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletOuterSegmentIndex + 1]; // 3  
-    unsigned int outerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex]; // 4
-    unsigned int outerTrackletOuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex + 1]; // 5
+  //getting MDs
+  unsigned int innerTrackletInnerSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletInnerSegmentIndex]; // 1
+  unsigned int innerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletOuterSegmentIndex];  // 2
+  unsigned int innerTrackletOuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * innerTrackletOuterSegmentIndex + 1]; // 3  
+  unsigned int outerTrackletOuterSegmentInnerMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex]; // 4
+  unsigned int outerTrackletOuterSegmentOuterMiniDoubletIndex = segmentsInGPU.mdIndices[2 * outerTrackletOuterSegmentIndex + 1]; // 5
 
-    //getting hits
-    unsigned int innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex]; //1,1
-    unsigned int innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex]; //1,2
-    unsigned int innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex]; //2,1
-    unsigned int innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex]; //2,2
-    unsigned int innerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletOuterSegmentOuterMiniDoubletIndex]; //3,1
-    unsigned int innerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletOuterSegmentOuterMiniDoubletIndex]; //3,2
-    unsigned int outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex]; //4,1
-    unsigned int outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex]; //4,2
-    unsigned int outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex]; //5,1
-    unsigned int outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex]; //5,2
+  //getting hits
+  unsigned int innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex]; // 1,1
+  unsigned int innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[innerTrackletInnerSegmentInnerMiniDoubletIndex]; // 1,2
+  unsigned int innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex]; // 2,1
+  unsigned int innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletOuterSegmentInnerMiniDoubletIndex]; // 2,2
+  unsigned int innerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ innerTrackletOuterSegmentOuterMiniDoubletIndex]; // 3,1
+  unsigned int innerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ innerTrackletOuterSegmentOuterMiniDoubletIndex]; // 3,2
+  unsigned int outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex]; // 4,1
+  unsigned int outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentInnerMiniDoubletIndex]; // 4,2
+  unsigned int outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex = miniDoubletsInGPU.anchorHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex]; // 5,1
+  unsigned int outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex = miniDoubletsInGPU.outerHitIndices[ outerTrackletOuterSegmentOuterMiniDoubletIndex]; // 5,2
 
-    hit_idx = {
-        (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex],
-        (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex],
-        (int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex],
-        (int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex],
-        (int) hitsInGPU.idxs[innerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex],
-        (int) hitsInGPU.idxs[innerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex],
-        (int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex],
-        (int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex],
-        (int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex],
-        (int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex],
-        };
-    hit_array_length = 10;
+  hit_idx = {
+    (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletLowerHitIndex],
+    (int) hitsInGPU.idxs[innerTrackletInnerSegmentInnerMiniDoubletUpperHitIndex],
+    (int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex],
+    (int) hitsInGPU.idxs[innerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex],
+    (int) hitsInGPU.idxs[innerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex],
+    (int) hitsInGPU.idxs[innerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex],
+    (int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletLowerHitIndex],
+    (int) hitsInGPU.idxs[outerTrackletOuterSegmentInnerMiniDoubletUpperHitIndex],
+    (int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletLowerHitIndex],
+    (int) hitsInGPU.idxs[outerTrackletOuterSegmentOuterMiniDoubletUpperHitIndex],
+  };
+  hit_array_length = 10;
 }

--- a/SDL/LST.cc
+++ b/SDL/LST.cc
@@ -369,7 +369,8 @@ ROOT::Math::XYZVector SDL::LST::calculateR3FromPCA(const ROOT::Math::PxPyPzMVect
 void SDL::LST::getOutput(SDL::Event& event) {
   std::vector<float> tc_pt_, tc_eta_, tc_phi_;
   std::vector<std::vector<unsigned int>> tc_hitIdxs_;
-  std::vector<int> tc_len_, tc_seedIdx_;
+  std::vector<unsigned int> tc_len_;
+  std::vector<int> tc_seedIdx_;
 
   SDL::modules& modulesInGPU = (*event.getModules());
   SDL::objectRanges& rangesInGPU = (*event.getRanges());
@@ -387,7 +388,7 @@ void SDL::LST::getOutput(SDL::Event& event) {
 
   unsigned int nTrackCandidates = *trackCandidatesInGPU.nTrackCandidates;
   for (unsigned int idx = 0; idx < nTrackCandidates; idx++) {
-    int hit_array_length = 0;
+    unsigned int hit_array_length = 0;
     short trackCandidateType = trackCandidatesInGPU.trackCandidateType[idx];
 
     std::vector<unsigned int> hit_idx;

--- a/SDL/LST.cc
+++ b/SDL/LST.cc
@@ -371,10 +371,16 @@ void SDL::LST::getOutput(SDL::Event& event) {
   std::vector<std::vector<unsigned int>> tc_hitIdxs_;
   std::vector<int> tc_len_, tc_seedIdx_;
 
-  SDL::trackCandidates& trackCandidatesInGPU = (*event.getTrackCandidates());
-  SDL::triplets& tripletsInGPU = (*event.getTriplets());
-  SDL::segments& segmentsInGPU = (*event.getSegments());
+  SDL::modules& modulesInGPU = (*event.getModules());
+  SDL::objectRanges& rangesInGPU = (*event.getRanges());
   SDL::hits& hitsInGPU = (*event.getHits());
+  SDL::miniDoublets& miniDoubletsInGPU = *(event.getMiniDoublets());
+  SDL::segments& segmentsInGPU = *(event.getSegments());
+  SDL::triplets& tripletsInGPU = (*event.getTriplets());
+  SDL::quintuplets& quintupletsInGPU = *(event.getQuintuplets());
+  SDL::pixelTriplets& pixelTripletsInGPU = *(event.getPixelTriplets());
+  SDL::pixelQuintuplets& pixelQuintupletsInGPU = *(event.getPixelQuintuplets());
+  SDL::trackCandidates& trackCandidatesInGPU = (*event.getTrackCandidates());
 
   const float kRinv1GeVf = (2.99792458e-3 * 3.8);
   const float k2Rinv1GeVf = kRinv1GeVf / 2.;
@@ -395,18 +401,18 @@ void SDL::LST::getOutput(SDL::Event& event) {
       phi = segmentsInGPU.phi[pLS];
       seedIdx = segmentsInGPU.seedIdx[pLS];
 
-      hit_idx = getPixelHitIdxsFrompLS(event, pLS);
+      hit_idx = getPixelHitIdxsFrompLS(modulesInGPU, rangesInGPU, hitsInGPU, miniDoubletsInGPU, segmentsInGPU, pLS);
       hit_array_length = hit_idx.size();
     }
     else if (trackCandidateType == 5) { // pT3
       unsigned int pT3 = trackCandidatesInGPU.directObjectIndices[idx];
 
-      std::vector<unsigned int> Hits = getOuterTrackerHitsFrompT3(event, pT3);
+      std::vector<unsigned int> Hits = getOuterTrackerHitsFrompT3(miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, pixelTripletsInGPU, pT3);
       unsigned int Hit_0 = Hits[0];
       unsigned int Hit_4 = Hits[4];
 
-      unsigned int T3 = getT3FrompT3(event, pT3);
-      unsigned int pLS = getPixelLSFrompT3(event, pT3);
+      unsigned int T3 = getT3FrompT3(pixelTripletsInGPU, pT3);
+      unsigned int pLS = getPixelLSFrompT3(modulesInGPU, rangesInGPU, pixelTripletsInGPU, pT3);
 
       const float dr = sqrt(pow(hitsInGPU.xs[Hit_4] - hitsInGPU.xs[Hit_0], 2) + pow(hitsInGPU.ys[Hit_4] - hitsInGPU.ys[Hit_0], 2));
 
@@ -422,22 +428,22 @@ void SDL::LST::getOutput(SDL::Event& event) {
 
       pt = (pt_pLS + pt_T3) / 2.;
 
-      hit_idx = getHitIdxsFrompT3(event, pT3);
+      hit_idx = getHitIdxsFrompT3(modulesInGPU, rangesInGPU, hitsInGPU, miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, pixelTripletsInGPU, pT3);
       hit_array_length = hit_idx.size();
     }
     else if (trackCandidateType == 7) { // pT5
       unsigned int pT5 = trackCandidatesInGPU.directObjectIndices[idx];
 
-      std::vector<unsigned int> Hits = getOuterTrackerHitsFrompT5(event, pT5);
+      std::vector<unsigned int> Hits = getOuterTrackerHitsFrompT5(miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, pixelQuintupletsInGPU, pT5);
       unsigned int Hit_0 = Hits[0];
       unsigned int Hit_4 = Hits[4];
       unsigned int Hit_8 = Hits[8];
 
-      std::vector<unsigned int> T3s = getT3sFrompT5(event, pT5);
+      std::vector<unsigned int> T3s = getT3sFrompT5(quintupletsInGPU, pixelQuintupletsInGPU, pT5);
       unsigned int T3_0 = T3s[0];
       unsigned int T3_1 = T3s[1];
 
-      unsigned int pLS = getPixelLSFrompT5(event, pT5);
+      unsigned int pLS = getPixelLSFrompT5(modulesInGPU, rangesInGPU, pixelQuintupletsInGPU, pT5);
 
       const float dr_in = sqrt(pow(hitsInGPU.xs[Hit_4] - hitsInGPU.xs[Hit_0], 2) + pow(hitsInGPU.ys[Hit_4] - hitsInGPU.ys[Hit_0], 2));
       const float dr_out = sqrt(pow(hitsInGPU.xs[Hit_8] - hitsInGPU.xs[Hit_4], 2) + pow(hitsInGPU.ys[Hit_8] - hitsInGPU.ys[Hit_4], 2));
@@ -458,13 +464,13 @@ void SDL::LST::getOutput(SDL::Event& event) {
 
       pt = (pt_pLS + pt_T5) / 2.;
 
-      hit_idx = getHitIdxsFrompT5(event, pT5);
+      hit_idx = getHitIdxsFrompT5(modulesInGPU, rangesInGPU, hitsInGPU, miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, pixelQuintupletsInGPU, pT5);
       hit_array_length = hit_idx.size();
     }
     else if (trackCandidateType == 4) { // T5
       unsigned int T5 = trackCandidatesInGPU.directObjectIndices[idx];
-      std::vector<unsigned int> T3s = getT3sFromT5(event, T5);
-      std::vector<unsigned int> hits = getHitsFromT5(event, T5);
+      std::vector<unsigned int> T3s = getT3sFromT5(quintupletsInGPU, T5);
+      std::vector<unsigned int> hits = getHitsFromT5(miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, T5);
 
       unsigned int Hit_0 = hits[0];
       unsigned int Hit_4 = hits[4];
@@ -486,7 +492,7 @@ void SDL::LST::getOutput(SDL::Event& event) {
       eta = SDL::eta(in_trkX_[Hit_8], in_trkY_[Hit_8], in_trkZ_[Hit_8]); // eta from outermost hit
       phi = SDL::phi(in_trkX_[Hit_0], in_trkY_[Hit_0]); // phi from innermost hit
 
-      hit_idx = getHitIdxsFromT5(event, T5);
+      hit_idx = getHitIdxsFromT5(hitsInGPU, miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, T5);
       hit_array_length = hit_idx.size();
     }
 
@@ -521,18 +527,14 @@ void SDL::LST::getOutput(SDL::Event& event) {
 // ===============
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getPixelHitsFrompLS(SDL::Event& event, unsigned int pLS) {
-  SDL::segments& segments_ = *(event.getSegments());
-  SDL::miniDoublets& miniDoublets_ = *(event.getMiniDoublets());
-  SDL::objectRanges& rangesInGPU = (*event.getRanges());
-  SDL::modules& modulesInGPU = (*event.getModules());
+std::vector<unsigned int> SDL::LST::getPixelHitsFrompLS(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, unsigned int pLS) {
   const unsigned int pLS_offset = rangesInGPU.segmentModuleIndices[*(modulesInGPU.nLowerModules)];
-  unsigned int MD_1 = segments_.mdIndices[2 * (pLS + pLS_offset)];
-  unsigned int MD_2 = segments_.mdIndices[2 * (pLS + pLS_offset) + 1];
-  unsigned int hit_1 = miniDoublets_.anchorHitIndices[MD_1];
-  unsigned int hit_2 = miniDoublets_.outerHitIndices [MD_1];
-  unsigned int hit_3 = miniDoublets_.anchorHitIndices[MD_2];
-  unsigned int hit_4 = miniDoublets_.outerHitIndices [MD_2];
+  unsigned int MD_1 = segmentsInGPU.mdIndices[2 * (pLS + pLS_offset)];
+  unsigned int MD_2 = segmentsInGPU.mdIndices[2 * (pLS + pLS_offset) + 1];
+  unsigned int hit_1 = miniDoubletsInGPU.anchorHitIndices[MD_1];
+  unsigned int hit_2 = miniDoubletsInGPU.outerHitIndices [MD_1];
+  unsigned int hit_3 = miniDoubletsInGPU.anchorHitIndices[MD_2];
+  unsigned int hit_4 = miniDoubletsInGPU.outerHitIndices [MD_2];
   if (hit_3 == hit_4)
     return {hit_1, hit_2, hit_3};
   else
@@ -540,20 +542,12 @@ std::vector<unsigned int> SDL::LST::getPixelHitsFrompLS(SDL::Event& event, unsig
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getPixelHitIdxsFrompLS(SDL::Event& event, unsigned int pLS) {
-  SDL::hits& hitsInGPU = *(event.getHits());
-  std::vector<unsigned int> hits = getPixelHitsFrompLS(event, pLS);
+std::vector<unsigned int> SDL::LST::getPixelHitIdxsFrompLS(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::hits& hitsInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, unsigned int pLS) {
+  std::vector<unsigned int> hits = getPixelHitsFrompLS(modulesInGPU, rangesInGPU, miniDoubletsInGPU, segmentsInGPU, pLS);
   std::vector<unsigned int> hitidxs;
   for (auto& hit : hits)
     hitidxs.push_back(hitsInGPU.idxs[hit]);
   return hitidxs;
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getPixelHitTypesFrompLS(SDL::Event& event, unsigned int pLS) {
-  std::vector<unsigned int> hits = getPixelHitsFrompLS(event, pLS);
-  std::vector<unsigned int> hittypes(hits.size(), 0);
-  return hittypes;
 }
 
 // ==============
@@ -561,10 +555,9 @@ std::vector<unsigned int> SDL::LST::getPixelHitTypesFrompLS(SDL::Event& event, u
 // ==============
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitsFromMD(SDL::Event& event, unsigned int MD) {
-  SDL::miniDoublets& miniDoublets_ = *(event.getMiniDoublets());
-  unsigned int hit_1 = miniDoublets_.anchorHitIndices[MD];
-  unsigned int hit_2 = miniDoublets_.outerHitIndices [MD];
+std::vector<unsigned int> SDL::LST::getHitsFromMD(const SDL::miniDoublets& miniDoubletsInGPU, unsigned int MD) {
+  unsigned int hit_1 = miniDoubletsInGPU.anchorHitIndices[MD];
+  unsigned int hit_2 = miniDoubletsInGPU.outerHitIndices [MD];
   return {hit_1, hit_2};
 }
 
@@ -573,19 +566,10 @@ std::vector<unsigned int> SDL::LST::getHitsFromMD(SDL::Event& event, unsigned in
 // ==============
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getMDsFromLS(SDL::Event& event, unsigned int LS) {
-  SDL::segments& segments_ = *(event.getSegments());
-  unsigned int MD_1 = segments_.mdIndices[2 * LS];
-  unsigned int MD_2 = segments_.mdIndices[2 * LS + 1];
+std::vector<unsigned int> SDL::LST::getMDsFromLS(const SDL::segments& segmentsInGPU, unsigned int LS) {
+  unsigned int MD_1 = segmentsInGPU.mdIndices[2 * LS];
+  unsigned int MD_2 = segmentsInGPU.mdIndices[2 * LS + 1];
   return {MD_1, MD_2};
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitsFromLS(SDL::Event& event, unsigned int LS) {
-  std::vector<unsigned int> MDs = getMDsFromLS(event, LS);
-  std::vector<unsigned int> hits_0 = getHitsFromMD(event, MDs[0]);
-  std::vector<unsigned int> hits_1 = getHitsFromMD(event, MDs[1]);
-  return {hits_0[0], hits_0[1], hits_1[0], hits_1[1]};
 }
 
 // ==============
@@ -593,27 +577,26 @@ std::vector<unsigned int> SDL::LST::getHitsFromLS(SDL::Event& event, unsigned in
 // ==============
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getLSsFromT3(SDL::Event& event, unsigned int T3) {
-  SDL::triplets& triplets_ = *(event.getTriplets());
-  unsigned int LS_1 = triplets_.segmentIndices[2 * T3];
-  unsigned int LS_2 = triplets_.segmentIndices[2 * T3 + 1];
+std::vector<unsigned int> SDL::LST::getLSsFromT3(const SDL::triplets& tripletsInGPU, unsigned int T3) {
+  unsigned int LS_1 = tripletsInGPU.segmentIndices[2 * T3];
+  unsigned int LS_2 = tripletsInGPU.segmentIndices[2 * T3 + 1];
   return {LS_1, LS_2};
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getMDsFromT3(SDL::Event& event, unsigned int T3) {
-  std::vector<unsigned int> LSs = getLSsFromT3(event, T3);
-  std::vector<unsigned int> MDs_0 = getMDsFromLS(event, LSs[0]);
-  std::vector<unsigned int> MDs_1 = getMDsFromLS(event, LSs[1]);
+std::vector<unsigned int> SDL::LST::getMDsFromT3(const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, unsigned int T3) {
+  std::vector<unsigned int> LSs = getLSsFromT3(tripletsInGPU, T3);
+  std::vector<unsigned int> MDs_0 = getMDsFromLS(segmentsInGPU, LSs[0]);
+  std::vector<unsigned int> MDs_1 = getMDsFromLS(segmentsInGPU, LSs[1]);
   return {MDs_0[0], MDs_0[1], MDs_1[1]};
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitsFromT3(SDL::Event& event, unsigned int T3) {
-  std::vector<unsigned int> MDs = getMDsFromT3(event, T3);
-  std::vector<unsigned int> hits_0 = getHitsFromMD(event, MDs[0]);
-  std::vector<unsigned int> hits_1 = getHitsFromMD(event, MDs[1]);
-  std::vector<unsigned int> hits_2 = getHitsFromMD(event, MDs[2]);
+std::vector<unsigned int> SDL::LST::getHitsFromT3(const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, unsigned int T3) {
+  std::vector<unsigned int> MDs = getMDsFromT3(segmentsInGPU, tripletsInGPU, T3);
+  std::vector<unsigned int> hits_0 = getHitsFromMD(miniDoubletsInGPU, MDs[0]);
+  std::vector<unsigned int> hits_1 = getHitsFromMD(miniDoubletsInGPU, MDs[1]);
+  std::vector<unsigned int> hits_2 = getHitsFromMD(miniDoubletsInGPU, MDs[2]);
   return {hits_0[0], hits_0[1], hits_1[0], hits_1[1], hits_2[0], hits_2[1]};
 }
 
@@ -622,55 +605,48 @@ std::vector<unsigned int> SDL::LST::getHitsFromT3(SDL::Event& event, unsigned in
 // ==============
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getT3sFromT5(SDL::Event& event, unsigned int T5) {
-  SDL::quintuplets& quintuplets_ = *(event.getQuintuplets());
-  unsigned int T3_1 = quintuplets_.tripletIndices[2 * T5];
-  unsigned int T3_2 = quintuplets_.tripletIndices[2 * T5 + 1];
+std::vector<unsigned int> SDL::LST::getT3sFromT5(const SDL::quintuplets& quintupletsInGPU, unsigned int T5) {
+  unsigned int T3_1 = quintupletsInGPU.tripletIndices[2 * T5];
+  unsigned int T3_2 = quintupletsInGPU.tripletIndices[2 * T5 + 1];
   return {T3_1, T3_2};
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getLSsFromT5(SDL::Event& event, unsigned int T5) {
-  std::vector<unsigned int> T3s = getT3sFromT5(event, T5);
-  std::vector<unsigned int> LSs_0 = getLSsFromT3(event, T3s[0]);
-  std::vector<unsigned int> LSs_1 = getLSsFromT3(event, T3s[1]);
+std::vector<unsigned int> SDL::LST::getLSsFromT5(const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, unsigned int T5) {
+  std::vector<unsigned int> T3s = getT3sFromT5(quintupletsInGPU, T5);
+  std::vector<unsigned int> LSs_0 = getLSsFromT3(tripletsInGPU, T3s[0]);
+  std::vector<unsigned int> LSs_1 = getLSsFromT3(tripletsInGPU, T3s[1]);
   return {LSs_0[0], LSs_0[1], LSs_1[0], LSs_1[1]};
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getMDsFromT5(SDL::Event& event, unsigned int T5) {
-  std::vector<unsigned int> LSs = getLSsFromT5(event, T5);
-  std::vector<unsigned int> MDs_0 = getMDsFromLS(event, LSs[0]);
-  std::vector<unsigned int> MDs_1 = getMDsFromLS(event, LSs[1]);
-  std::vector<unsigned int> MDs_2 = getMDsFromLS(event, LSs[2]);
-  std::vector<unsigned int> MDs_3 = getMDsFromLS(event, LSs[3]);
+std::vector<unsigned int> SDL::LST::getMDsFromT5(const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, unsigned int T5) {
+  std::vector<unsigned int> LSs = getLSsFromT5(tripletsInGPU, quintupletsInGPU, T5);
+  std::vector<unsigned int> MDs_0 = getMDsFromLS(segmentsInGPU, LSs[0]);
+  std::vector<unsigned int> MDs_1 = getMDsFromLS(segmentsInGPU, LSs[1]);
+  std::vector<unsigned int> MDs_2 = getMDsFromLS(segmentsInGPU, LSs[2]);
+  std::vector<unsigned int> MDs_3 = getMDsFromLS(segmentsInGPU, LSs[3]);
   return {MDs_0[0], MDs_0[1], MDs_1[1], MDs_2[1], MDs_3[1]};
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitsFromT5(SDL::Event& event, unsigned int T5) {
-  std::vector<unsigned int> MDs = getMDsFromT5(event, T5);
-  std::vector<unsigned int> hits_0 = getHitsFromMD(event, MDs[0]);
-  std::vector<unsigned int> hits_1 = getHitsFromMD(event, MDs[1]);
-  std::vector<unsigned int> hits_2 = getHitsFromMD(event, MDs[2]);
-  std::vector<unsigned int> hits_3 = getHitsFromMD(event, MDs[3]);
-  std::vector<unsigned int> hits_4 = getHitsFromMD(event, MDs[4]);
+std::vector<unsigned int> SDL::LST::getHitsFromT5(const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, unsigned int T5) {
+  std::vector<unsigned int> MDs = getMDsFromT5(segmentsInGPU, tripletsInGPU, quintupletsInGPU, T5);
+  std::vector<unsigned int> hits_0 = getHitsFromMD(miniDoubletsInGPU, MDs[0]);
+  std::vector<unsigned int> hits_1 = getHitsFromMD(miniDoubletsInGPU, MDs[1]);
+  std::vector<unsigned int> hits_2 = getHitsFromMD(miniDoubletsInGPU, MDs[2]);
+  std::vector<unsigned int> hits_3 = getHitsFromMD(miniDoubletsInGPU, MDs[3]);
+  std::vector<unsigned int> hits_4 = getHitsFromMD(miniDoubletsInGPU, MDs[4]);
   return {hits_0[0], hits_0[1], hits_1[0], hits_1[1], hits_2[0], hits_2[1], hits_3[0], hits_3[1], hits_4[0], hits_4[1]};
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitIdxsFromT5(SDL::Event& event, unsigned int T5) {
-  SDL::hits& hitsInGPU = *(event.getHits());
-  std::vector<unsigned int> hits = getHitsFromT5(event, T5);
+std::vector<unsigned int> SDL::LST::getHitIdxsFromT5(const SDL::hits& hitsInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, unsigned int T5) {
+  std::vector<unsigned int> hits = getHitsFromT5(miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, T5);
   std::vector<unsigned int> hitidxs;
   for (auto& hit : hits)
     hitidxs.push_back(hitsInGPU.idxs[hit]);
   return hitidxs;
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitTypesFromT5(SDL::Event& event, unsigned int T5) {
-  return {4, 4, 4, 4, 4, 4, 4, 4, 4, 4};;
 }
 
 // ===============
@@ -678,73 +654,39 @@ std::vector<unsigned int> SDL::LST::getHitTypesFromT5(SDL::Event& event, unsigne
 // ===============
 
 //____________________________________________________________________________________________
-unsigned int SDL::LST::getPixelLSFrompT3(SDL::Event& event, unsigned int pT3) {
-  SDL::pixelTriplets& pixelTriplets_ = *(event.getPixelTriplets());
-  SDL::objectRanges& rangesInGPU = (*event.getRanges());
-  SDL::modules& modulesInGPU = (*event.getModules());
+unsigned int SDL::LST::getPixelLSFrompT3(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3) {
   const unsigned int pLS_offset = rangesInGPU.segmentModuleIndices[*(modulesInGPU.nLowerModules)];
-  return pixelTriplets_.pixelSegmentIndices[pT3] - pLS_offset;
+  return pixelTripletsInGPU.pixelSegmentIndices[pT3] - pLS_offset;
 }
 
 //____________________________________________________________________________________________
-unsigned int SDL::LST::getT3FrompT3(SDL::Event& event, unsigned int pT3) {
-  SDL::pixelTriplets& pixelTriplets_ = *(event.getPixelTriplets());
-  return pixelTriplets_.tripletIndices[pT3];
+unsigned int SDL::LST::getT3FrompT3(const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3) {
+  return pixelTripletsInGPU.tripletIndices[pT3];
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getLSsFrompT3(SDL::Event& event, unsigned int pT3) {
-  unsigned int T3 = getT3FrompT3(event, pT3);
-  return getLSsFromT3(event, T3);
+std::vector<unsigned int> SDL::LST::getOuterTrackerHitsFrompT3(const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3) {
+  unsigned int T3 = getT3FrompT3(pixelTripletsInGPU, pT3);
+  return getHitsFromT3(miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, T3);
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getMDsFrompT3(SDL::Event& event, unsigned int pT3) {
-  unsigned int T3 = getT3FrompT3(event, pT3);
-  return getMDsFromT3(event, T3);
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getOuterTrackerHitsFrompT3(SDL::Event& event, unsigned int pT3) {
-  unsigned int T3 = getT3FrompT3(event, pT3);
-  return getHitsFromT3(event, T3);
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getPixelHitsFrompT3(SDL::Event& event, unsigned int pT3) {
-  unsigned int pLS = getPixelLSFrompT3(event, pT3);
-  return getPixelHitsFrompLS(event, pLS);
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitsFrompT3(SDL::Event& event, unsigned int pT3) {
-  unsigned int pLS = getPixelLSFrompT3(event, pT3);
-  unsigned int T3 = getT3FrompT3(event, pT3);
-  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(event, pLS);
-  std::vector<unsigned int> outerTrackerHits = getHitsFromT3(event, T3);
+std::vector<unsigned int> SDL::LST::getHitsFrompT3(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3) {
+  unsigned int pLS = getPixelLSFrompT3(modulesInGPU, rangesInGPU, pixelTripletsInGPU, pT3);
+  unsigned int T3 = getT3FrompT3(pixelTripletsInGPU, pT3);
+  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(modulesInGPU, rangesInGPU, miniDoubletsInGPU, segmentsInGPU, pLS);
+  std::vector<unsigned int> outerTrackerHits = getHitsFromT3(miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, T3);
   pixelHits.insert(pixelHits.end(), outerTrackerHits.begin(), outerTrackerHits.end());
   return pixelHits;
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitIdxsFrompT3(SDL::Event& event, unsigned int pT3) {
-  SDL::hits& hitsInGPU = *(event.getHits());
-  std::vector<unsigned int> hits = getHitsFrompT3(event, pT3);
+std::vector<unsigned int> SDL::LST::getHitIdxsFrompT3(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::hits& hitsInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3) {
+  std::vector<unsigned int> hits = getHitsFrompT3(modulesInGPU, rangesInGPU, miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, pixelTripletsInGPU, pT3);
   std::vector<unsigned int> hitidxs;
   for (auto& hit : hits)
     hitidxs.push_back(hitsInGPU.idxs[hit]);
   return hitidxs;
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitTypesFrompT3(SDL::Event& event, unsigned int pT3) {
-  unsigned int pLS = getPixelLSFrompT3(event, pT3);
-  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(event, pLS);
-  // pixel Hits list will be either 3 or 4 and depending on it return accordingly
-  if (pixelHits.size() == 3)
-    return {0, 0, 0, 4, 4, 4, 4, 4, 4};
-  else
-    return {0, 0, 0, 0, 4, 4, 4, 4, 4, 4};
 }
 
 // ===============
@@ -752,78 +694,43 @@ std::vector<unsigned int> SDL::LST::getHitTypesFrompT3(SDL::Event& event, unsign
 // ===============
 
 //____________________________________________________________________________________________
-unsigned int SDL::LST::getPixelLSFrompT5(SDL::Event& event, unsigned int pT5) {
-  SDL::pixelQuintuplets& pixelQuintuplets_ = *(event.getPixelQuintuplets());
-  SDL::objectRanges& rangesInGPU = (*event.getRanges());
-  SDL::modules& modulesInGPU = (*event.getModules());
+unsigned int SDL::LST::getPixelLSFrompT5(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5) {
   const unsigned int pLS_offset = rangesInGPU.segmentModuleIndices[*(modulesInGPU.nLowerModules)];
-  return pixelQuintuplets_.pixelIndices[pT5] - pLS_offset;
+  return pixelQuintupletsInGPU.pixelIndices[pT5] - pLS_offset;
 }
 
 //____________________________________________________________________________________________
-unsigned int SDL::LST::getT5FrompT5(SDL::Event& event, unsigned int pT5) {
-  SDL::pixelQuintuplets& pixelQuintuplets_ = *(event.getPixelQuintuplets());
-  return pixelQuintuplets_.T5Indices[pT5];
+unsigned int SDL::LST::getT5FrompT5(const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5) {
+  return pixelQuintupletsInGPU.T5Indices[pT5];
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getT3sFrompT5(SDL::Event& event, unsigned int pT5) {
-  unsigned int T5 = getT5FrompT5(event, pT5);
-  return getT3sFromT5(event, T5);
+std::vector<unsigned int> SDL::LST::getT3sFrompT5(const SDL::quintuplets& quintupletsInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5) {
+  unsigned int T5 = getT5FrompT5(pixelQuintupletsInGPU, pT5);
+  return getT3sFromT5(quintupletsInGPU, T5);
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getLSsFrompT5(SDL::Event& event, unsigned int pT5) {
-  unsigned int T5 = getT5FrompT5(event, pT5);
-  return getLSsFromT5(event, T5);
+std::vector<unsigned int> SDL::LST::getOuterTrackerHitsFrompT5(const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5) {
+  unsigned int T5 = getT5FrompT5(pixelQuintupletsInGPU, pT5);
+  return getHitsFromT5(miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, T5);
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getMDsFrompT5(SDL::Event& event, unsigned int pT5) {
-  unsigned int T5 = getT5FrompT5(event, pT5);
-  return getMDsFromT5(event, T5);
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getOuterTrackerHitsFrompT5(SDL::Event& event, unsigned int pT5) {
-  unsigned int T5 = getT5FrompT5(event, pT5);
-  return getHitsFromT5(event, T5);
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getPixelHitsFrompT5(SDL::Event& event, unsigned int pT5) {
-  unsigned int pLS = getPixelLSFrompT5(event, pT5);
-  return getPixelHitsFrompLS(event, pLS);
-}
-
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitsFrompT5(SDL::Event& event, unsigned int pT5) {
-  unsigned int pLS = getPixelLSFrompT5(event, pT5);
-  unsigned int T5 = getT5FrompT5(event, pT5);
-  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(event, pLS);
-  std::vector<unsigned int> outerTrackerHits = getHitsFromT5(event, T5);
+std::vector<unsigned int> SDL::LST::getHitsFrompT5(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5) {
+  unsigned int pLS = getPixelLSFrompT5(modulesInGPU, rangesInGPU, pixelQuintupletsInGPU, pT5);
+  unsigned int T5 = getT5FrompT5(pixelQuintupletsInGPU, pT5);
+  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(modulesInGPU, rangesInGPU, miniDoubletsInGPU, segmentsInGPU, pLS);
+  std::vector<unsigned int> outerTrackerHits = getHitsFromT5(miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, T5);
   pixelHits.insert(pixelHits.end(), outerTrackerHits.begin(), outerTrackerHits.end());
   return pixelHits;
 }
 
 //____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitIdxsFrompT5(SDL::Event& event, unsigned int pT5) {
-  SDL::hits& hitsInGPU = *(event.getHits());
-  std::vector<unsigned int> hits = getHitsFrompT5(event, pT5);
+std::vector<unsigned int> SDL::LST::getHitIdxsFrompT5(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::hits& hitsInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5) {
+  std::vector<unsigned int> hits = getHitsFrompT5(modulesInGPU, rangesInGPU, miniDoubletsInGPU, segmentsInGPU, tripletsInGPU, quintupletsInGPU, pixelQuintupletsInGPU, pT5);
   std::vector<unsigned int> hitidxs;
   for (auto& hit : hits)
     hitidxs.push_back(hitsInGPU.idxs[hit]);
   return hitidxs;
-}
-
-//____________________________________________________________________________________________
-std::vector<unsigned int> SDL::LST::getHitTypesFrompT5(SDL::Event& event, unsigned int pT5) {
-  unsigned int pLS = getPixelLSFrompT5(event, pT5);
-  std::vector<unsigned int> pixelHits = getPixelHitsFrompLS(event, pLS);
-  // pixel Hits list will be either 3 or 4 and depending on it return accordingly
-  if (pixelHits.size() == 3)
-    return {0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
-  else
-    return {0, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
 }

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -1,0 +1,129 @@
+#include <filesystem>
+#include <cstdlib>
+#include <numeric>
+
+#include "code/cppitertools/enumerate.hpp"
+
+#include "TString.h"
+#include "Math/Vector3D.h"
+#include <Math/Vector4D.h>
+
+#include "Event.cuh"
+
+namespace SDL {
+  
+  class LST {
+  public:
+    LST();
+
+    void eventSetup();
+    void run(cudaStream_t stream,
+             const std::vector<float> see_px,
+             const std::vector<float> see_py,
+             const std::vector<float> see_pz,
+             const std::vector<float> see_dxy,
+             const std::vector<float> see_dz,
+             const std::vector<float> see_ptErr,
+             const std::vector<float> see_etaErr,
+             const std::vector<float> see_stateTrajGlbX,
+             const std::vector<float> see_stateTrajGlbY,
+             const std::vector<float> see_stateTrajGlbZ,
+             const std::vector<float> see_stateTrajGlbPx,
+             const std::vector<float> see_stateTrajGlbPy,
+             const std::vector<float> see_stateTrajGlbPz,
+             const std::vector<int> see_q,
+             const std::vector<unsigned int> see_algo,
+             const std::vector<std::vector<int>> see_hitIdx,
+             const std::vector<unsigned int> ph2_detId,
+             const std::vector<float> ph2_x,
+             const std::vector<float> ph2_y,
+             const std::vector<float> ph2_z);
+    std::vector<float> pt() { return out_tc_pt_; }
+    std::vector<float> eta() { return out_tc_eta_; }
+    std::vector<float> phi() { return out_tc_phi_; }
+    std::vector<std::vector<int>> hits() { return out_tc_hitIdxs_; }
+    std::vector<int> len() { return out_tc_len_; }
+  private:
+    void loadMaps();
+    TString get_absolute_path_after_check_file_exists(const std::string name);
+    void prepareInput(const std::vector<float> see_px,
+                      const std::vector<float> see_py,
+                      const std::vector<float> see_pz,
+                      const std::vector<float> see_dxy,
+                      const std::vector<float> see_dz,
+                      const std::vector<float> see_ptErr,
+                      const std::vector<float> see_etaErr,
+                      const std::vector<float> see_stateTrajGlbX,
+                      const std::vector<float> see_stateTrajGlbY,
+                      const std::vector<float> see_stateTrajGlbZ,
+                      const std::vector<float> see_stateTrajGlbPx,
+                      const std::vector<float> see_stateTrajGlbPy,
+                      const std::vector<float> see_stateTrajGlbPz,
+                      const std::vector<int> see_q,
+                      const std::vector<unsigned int> see_algo,
+                      const std::vector<std::vector<int>> see_hitIdx,
+                      const std::vector<unsigned int> ph2_detId,
+                      const std::vector<float> ph2_x,
+                      const std::vector<float> ph2_y,
+                      const std::vector<float> ph2_z);
+
+    ROOT::Math::XYZVector calculateR3FromPCA(const ROOT::Math::PxPyPzMVector& p3, const float dxy, const float dz);
+
+    void getOutput(SDL::Event& event);
+    void GetpLSHitIndex(SDL::modules& modulesInGPU,
+                        SDL::objectRanges& rangesInGPU,
+                        SDL::segments& segmentsInGPU,
+                        SDL::miniDoublets& miniDoubletsInGPU,
+                        SDL::hits& hitsInGPU,
+                        std::vector<int>& hit_idx,
+                        std::vector<int>& hit_types,
+                        int& hit_array_length,
+                        unsigned int innerTrackletIdx,
+                        std::vector<int>& module_idxs);
+    void GetT5HitIndex(SDL::modules& modulesInGPU,
+                       SDL::objectRanges& rangesInGPU,
+                       SDL::triplets& tripletsInGPU,
+                       SDL::segments& segmentsInGPU,
+                       SDL::miniDoublets& miniDoubletsInGPU,
+                       SDL::hits& hitsInGPU,
+                       std::vector<int>& hit_idx,
+                       std::vector<int>& hit_types,
+                       int& hit_array_length,
+                       unsigned int innerTrackletIndex,
+                       unsigned int outerTrackletIndex,
+                       int innerTrackletInnerSegmentIndex,
+                       int innerTrackletOuterSegmentIndex,
+                       int outerTrackletOuterSegmentIndex,
+                       std::vector<int>& module_idxs);
+
+    TString TrackLooperDir_;
+    std::vector<float> in_trkX_;
+    std::vector<float> in_trkY_;
+    std::vector<float> in_trkZ_;
+    std::vector<unsigned int> in_hitId_;
+    std::vector<unsigned int> in_hitIdxs_;
+    std::vector<unsigned int> in_hitIndices_vec0_;
+    std::vector<unsigned int> in_hitIndices_vec1_;
+    std::vector<unsigned int> in_hitIndices_vec2_;
+    std::vector<unsigned int> in_hitIndices_vec3_;
+    std::vector<float> in_deltaPhi_vec_;
+    std::vector<float> in_ptIn_vec_;
+    std::vector<float> in_ptErr_vec_;
+    std::vector<float> in_px_vec_;
+    std::vector<float> in_py_vec_;
+    std::vector<float> in_pz_vec_;
+    std::vector<float> in_eta_vec_;
+    std::vector<float> in_etaErr_vec_;
+    std::vector<float> in_phi_vec_;
+    std::vector<int> in_charge_vec_;
+    std::vector<int> in_superbin_vec_;
+    std::vector<int8_t> in_pixelType_vec_;
+    std::vector<short> in_isQuad_vec_;
+    std::vector<float> out_tc_pt_;
+    std::vector<float> out_tc_eta_;
+    std::vector<float> out_tc_phi_;
+    std::vector<std::vector<int>> out_tc_hitIdxs_;
+    std::vector<int> out_tc_len_;
+  };
+
+} //namespace

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -73,46 +73,35 @@ namespace SDL {
     void getOutput(SDL::Event& event);
     // Object accessors
     // ----* pLS *----
-    std::vector<unsigned int> getPixelHitsFrompLS(SDL::Event& event, unsigned int pLS);
-    std::vector<unsigned int> getPixelHitIdxsFrompLS(SDL::Event& event, unsigned int pLS);
-    std::vector<unsigned int> getPixelHitTypesFrompLS(SDL::Event& event, unsigned int pLS);
+    std::vector<unsigned int> getPixelHitsFrompLS(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, unsigned int pLS);
+    std::vector<unsigned int> getPixelHitIdxsFrompLS(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::hits& hitsInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, unsigned int pLS);
     // ----* MD *----
-    std::vector<unsigned int> getHitsFromMD(SDL::Event& event, unsigned int MD);
+    std::vector<unsigned int> getHitsFromMD(const SDL::miniDoublets& miniDoubletsInGPU, unsigned int MD);
     // ----* LS *----
-    std::vector<unsigned int> getMDsFromLS(SDL::Event& event, unsigned int LS);
-    std::vector<unsigned int> getHitsFromLS(SDL::Event& event, unsigned int LS);
+    std::vector<unsigned int> getMDsFromLS(const SDL::segments& segmentsInGPU, unsigned int LS);
     // ----* T3 *----
-    std::vector<unsigned int> getLSsFromT3(SDL::Event& event, unsigned int T3);
-    std::vector<unsigned int> getMDsFromT3(SDL::Event& event, unsigned int T3);
-    std::vector<unsigned int> getHitsFromT3(SDL::Event& event, unsigned int T3);
+    std::vector<unsigned int> getLSsFromT3(const SDL::triplets& tripletsInGPU, unsigned int T3);
+    std::vector<unsigned int> getMDsFromT3(const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, unsigned int T3);
+    std::vector<unsigned int> getHitsFromT3(const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, unsigned int T3);
     // ----* T5 *----
-    std::vector<unsigned int> getT3sFromT5(SDL::Event& event, unsigned int T5);
-    std::vector<unsigned int> getLSsFromT5(SDL::Event& event, unsigned int T5);
-    std::vector<unsigned int> getMDsFromT5(SDL::Event& event, unsigned int T5);
-    std::vector<unsigned int> getHitsFromT5(SDL::Event& event, unsigned int T5);
-    std::vector<unsigned int> getHitIdxsFromT5(SDL::Event& event, unsigned int T5);
-    std::vector<unsigned int> getHitTypesFromT5(SDL::Event& event, unsigned int T5);
+    std::vector<unsigned int> getT3sFromT5(const SDL::quintuplets& quintupletsInGPU, unsigned int T5);
+    std::vector<unsigned int> getLSsFromT5(const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, unsigned int T5);
+    std::vector<unsigned int> getMDsFromT5(const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, unsigned int T5);
+    std::vector<unsigned int> getHitsFromT5(const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, unsigned int T5);
+    std::vector<unsigned int> getHitIdxsFromT5(const SDL::hits& hitsInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, unsigned int T5);
     // ----* pT3 *----
-    unsigned int getPixelLSFrompT3(SDL::Event& event, unsigned int pT3);
-    unsigned int getT3FrompT3(SDL::Event& event, unsigned int pT3);
-    std::vector<unsigned int> getLSsFrompT3(SDL::Event& event, unsigned int pT3);
-    std::vector<unsigned int> getMDsFrompT3(SDL::Event& event, unsigned int pT3);
-    std::vector<unsigned int> getOuterTrackerHitsFrompT3(SDL::Event& event, unsigned int pT3);
-    std::vector<unsigned int> getPixelHitsFrompT3(SDL::Event& event, unsigned int pT3);
-    std::vector<unsigned int> getHitsFrompT3(SDL::Event& event, unsigned int pT3);
-    std::vector<unsigned int> getHitIdxsFrompT3(SDL::Event& event, unsigned int pT3);
-    std::vector<unsigned int> getHitTypesFrompT3(SDL::Event& event, unsigned int pT3);
+    unsigned int getPixelLSFrompT3(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3);
+    unsigned int getT3FrompT3(const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3);
+    std::vector<unsigned int> getOuterTrackerHitsFrompT3(const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3);
+    std::vector<unsigned int> getHitsFrompT3(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3);
+    std::vector<unsigned int> getHitIdxsFrompT3(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::hits& hitsInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::pixelTriplets& pixelTripletsInGPU, unsigned int pT3);
     // ----* pT5 *----
-    unsigned int getPixelLSFrompT5(SDL::Event& event, unsigned int pT5);
-    unsigned int getT5FrompT5(SDL::Event& event, unsigned int pT5);
-    std::vector<unsigned int> getT3sFrompT5(SDL::Event& event, unsigned int pT5);
-    std::vector<unsigned int> getLSsFrompT5(SDL::Event& event, unsigned int pT5);
-    std::vector<unsigned int> getMDsFrompT5(SDL::Event& event, unsigned int pT5);
-    std::vector<unsigned int> getOuterTrackerHitsFrompT5(SDL::Event& event, unsigned int pT5);
-    std::vector<unsigned int> getPixelHitsFrompT5(SDL::Event& event, unsigned int pT5);
-    std::vector<unsigned int> getHitsFrompT5(SDL::Event& event, unsigned int pT5);
-    std::vector<unsigned int> getHitIdxsFrompT5(SDL::Event& event, unsigned int pT5);
-    std::vector<unsigned int> getHitTypesFrompT5(SDL::Event& event, unsigned int pT3);
+    unsigned int getPixelLSFrompT5(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5);
+    unsigned int getT5FrompT5(const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5);
+    std::vector<unsigned int> getT3sFrompT5(const SDL::quintuplets& quintupletsInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5);
+    std::vector<unsigned int> getOuterTrackerHitsFrompT5(const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5);
+    std::vector<unsigned int> getHitsFrompT5(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5);
+    std::vector<unsigned int> getHitIdxsFrompT5(const SDL::modules& modulesInGPU, const SDL::objectRanges& rangesInGPU, const SDL::hits& hitsInGPU, const SDL::miniDoublets& miniDoubletsInGPU, const SDL::segments& segmentsInGPU, const SDL::triplets& tripletsInGPU, const SDL::quintuplets& quintupletsInGPU, const SDL::pixelQuintuplets& pixelQuintupletsInGPU, unsigned int pT5);
 
     // Input and output vectors
     TString TrackLooperDir_;

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -41,7 +41,7 @@ namespace SDL {
     std::vector<float> pt() { return out_tc_pt_; }
     std::vector<float> eta() { return out_tc_eta_; }
     std::vector<float> phi() { return out_tc_phi_; }
-    std::vector<std::vector<int>> hits() { return out_tc_hitIdxs_; }
+    std::vector<std::vector<unsigned int>> hits() { return out_tc_hitIdxs_; }
     std::vector<int> len() { return out_tc_len_; }
     std::vector<int> seedIdx() { return out_tc_seedIdx_; }
   private:
@@ -71,27 +71,48 @@ namespace SDL {
     ROOT::Math::XYZVector calculateR3FromPCA(const ROOT::Math::PxPyPzMVector& p3, const float dxy, const float dz);
 
     void getOutput(SDL::Event& event);
-    void GetpLSHitIndex(SDL::modules& modulesInGPU,
-                        SDL::objectRanges& rangesInGPU,
-                        SDL::segments& segmentsInGPU,
-                        SDL::miniDoublets& miniDoubletsInGPU,
-                        SDL::hits& hitsInGPU,
-                        std::vector<int>& hit_idx,
-                        int& hit_array_length,
-                        unsigned int innerTrackletIdx);
-    void GetT5HitIndex(SDL::modules& modulesInGPU,
-                       SDL::objectRanges& rangesInGPU,
-                       SDL::triplets& tripletsInGPU,
-                       SDL::segments& segmentsInGPU,
-                       SDL::miniDoublets& miniDoubletsInGPU,
-                       SDL::hits& hitsInGPU,
-                       std::vector<int>& hit_idx,
-                       int& hit_array_length,
-                       unsigned int innerTrackletIndex,
-                       unsigned int outerTrackletIndex,
-                       int innerTrackletInnerSegmentIndex,
-                       int innerTrackletOuterSegmentIndex,
-                       int outerTrackletOuterSegmentIndex);
+    // Object accessors
+    // ----* pLS *----
+    std::vector<unsigned int> getPixelHitsFrompLS(SDL::Event& event, unsigned int pLS);
+    std::vector<unsigned int> getPixelHitIdxsFrompLS(SDL::Event& event, unsigned int pLS);
+    std::vector<unsigned int> getPixelHitTypesFrompLS(SDL::Event& event, unsigned int pLS);
+    // ----* MD *----
+    std::vector<unsigned int> getHitsFromMD(SDL::Event& event, unsigned int MD);
+    // ----* LS *----
+    std::vector<unsigned int> getMDsFromLS(SDL::Event& event, unsigned int LS);
+    std::vector<unsigned int> getHitsFromLS(SDL::Event& event, unsigned int LS);
+    // ----* T3 *----
+    std::vector<unsigned int> getLSsFromT3(SDL::Event& event, unsigned int T3);
+    std::vector<unsigned int> getMDsFromT3(SDL::Event& event, unsigned int T3);
+    std::vector<unsigned int> getHitsFromT3(SDL::Event& event, unsigned int T3);
+    // ----* T5 *----
+    std::vector<unsigned int> getT3sFromT5(SDL::Event& event, unsigned int T5);
+    std::vector<unsigned int> getLSsFromT5(SDL::Event& event, unsigned int T5);
+    std::vector<unsigned int> getMDsFromT5(SDL::Event& event, unsigned int T5);
+    std::vector<unsigned int> getHitsFromT5(SDL::Event& event, unsigned int T5);
+    std::vector<unsigned int> getHitIdxsFromT5(SDL::Event& event, unsigned int T5);
+    std::vector<unsigned int> getHitTypesFromT5(SDL::Event& event, unsigned int T5);
+    // ----* pT3 *----
+    unsigned int getPixelLSFrompT3(SDL::Event& event, unsigned int pT3);
+    unsigned int getT3FrompT3(SDL::Event& event, unsigned int pT3);
+    std::vector<unsigned int> getLSsFrompT3(SDL::Event& event, unsigned int pT3);
+    std::vector<unsigned int> getMDsFrompT3(SDL::Event& event, unsigned int pT3);
+    std::vector<unsigned int> getOuterTrackerHitsFrompT3(SDL::Event& event, unsigned int pT3);
+    std::vector<unsigned int> getPixelHitsFrompT3(SDL::Event& event, unsigned int pT3);
+    std::vector<unsigned int> getHitsFrompT3(SDL::Event& event, unsigned int pT3);
+    std::vector<unsigned int> getHitIdxsFrompT3(SDL::Event& event, unsigned int pT3);
+    std::vector<unsigned int> getHitTypesFrompT3(SDL::Event& event, unsigned int pT3);
+    // ----* pT5 *----
+    unsigned int getPixelLSFrompT5(SDL::Event& event, unsigned int pT5);
+    unsigned int getT5FrompT5(SDL::Event& event, unsigned int pT5);
+    std::vector<unsigned int> getT3sFrompT5(SDL::Event& event, unsigned int pT5);
+    std::vector<unsigned int> getLSsFrompT5(SDL::Event& event, unsigned int pT5);
+    std::vector<unsigned int> getMDsFrompT5(SDL::Event& event, unsigned int pT5);
+    std::vector<unsigned int> getOuterTrackerHitsFrompT5(SDL::Event& event, unsigned int pT5);
+    std::vector<unsigned int> getPixelHitsFrompT5(SDL::Event& event, unsigned int pT5);
+    std::vector<unsigned int> getHitsFrompT5(SDL::Event& event, unsigned int pT5);
+    std::vector<unsigned int> getHitIdxsFrompT5(SDL::Event& event, unsigned int pT5);
+    std::vector<unsigned int> getHitTypesFrompT5(SDL::Event& event, unsigned int pT3);
 
     // Input and output vectors
     TString TrackLooperDir_;
@@ -121,7 +142,7 @@ namespace SDL {
     std::vector<float> out_tc_pt_;
     std::vector<float> out_tc_eta_;
     std::vector<float> out_tc_phi_;
-    std::vector<std::vector<int>> out_tc_hitIdxs_;
+    std::vector<std::vector<unsigned int>> out_tc_hitIdxs_;
     std::vector<int> out_tc_len_;
     std::vector<int> out_tc_seedIdx_;
   };

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -76,7 +76,6 @@ namespace SDL {
                         SDL::miniDoublets& miniDoubletsInGPU,
                         SDL::hits& hitsInGPU,
                         std::vector<int>& hit_idx,
-                        std::vector<int>& hit_types,
                         int& hit_array_length,
                         unsigned int innerTrackletIdx,
                         std::vector<int>& module_idxs);
@@ -87,7 +86,6 @@ namespace SDL {
                        SDL::miniDoublets& miniDoubletsInGPU,
                        SDL::hits& hitsInGPU,
                        std::vector<int>& hit_idx,
-                       std::vector<int>& hit_types,
                        int& hit_array_length,
                        unsigned int innerTrackletIndex,
                        unsigned int outerTrackletIndex,

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -42,7 +42,7 @@ namespace SDL {
     std::vector<float> eta() { return out_tc_eta_; }
     std::vector<float> phi() { return out_tc_phi_; }
     std::vector<std::vector<unsigned int>> hits() { return out_tc_hitIdxs_; }
-    std::vector<int> len() { return out_tc_len_; }
+    std::vector<unsigned int> len() { return out_tc_len_; }
     std::vector<int> seedIdx() { return out_tc_seedIdx_; }
   private:
     void loadMaps();
@@ -132,7 +132,7 @@ namespace SDL {
     std::vector<float> out_tc_eta_;
     std::vector<float> out_tc_phi_;
     std::vector<std::vector<unsigned int>> out_tc_hitIdxs_;
-    std::vector<int> out_tc_len_;
+    std::vector<unsigned int> out_tc_len_;
     std::vector<int> out_tc_seedIdx_;
   };
 

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -43,6 +43,7 @@ namespace SDL {
     std::vector<float> phi() { return out_tc_phi_; }
     std::vector<std::vector<int>> hits() { return out_tc_hitIdxs_; }
     std::vector<int> len() { return out_tc_len_; }
+    std::vector<int> seedIdx() { return out_tc_seedIdx_; }
   private:
     void loadMaps();
     TString get_absolute_path_after_check_file_exists(const std::string name);
@@ -77,8 +78,7 @@ namespace SDL {
                         SDL::hits& hitsInGPU,
                         std::vector<int>& hit_idx,
                         int& hit_array_length,
-                        unsigned int innerTrackletIdx,
-                        std::vector<int>& module_idxs);
+                        unsigned int innerTrackletIdx);
     void GetT5HitIndex(SDL::modules& modulesInGPU,
                        SDL::objectRanges& rangesInGPU,
                        SDL::triplets& tripletsInGPU,
@@ -91,9 +91,9 @@ namespace SDL {
                        unsigned int outerTrackletIndex,
                        int innerTrackletInnerSegmentIndex,
                        int innerTrackletOuterSegmentIndex,
-                       int outerTrackletOuterSegmentIndex,
-                       std::vector<int>& module_idxs);
+                       int outerTrackletOuterSegmentIndex);
 
+    // Input and output vectors
     TString TrackLooperDir_;
     std::vector<float> in_trkX_;
     std::vector<float> in_trkY_;
@@ -114,6 +114,7 @@ namespace SDL {
     std::vector<float> in_etaErr_vec_;
     std::vector<float> in_phi_vec_;
     std::vector<int> in_charge_vec_;
+    std::vector<unsigned int> in_seedIdx_vec_;
     std::vector<int> in_superbin_vec_;
     std::vector<int8_t> in_pixelType_vec_;
     std::vector<short> in_isQuad_vec_;
@@ -122,6 +123,7 @@ namespace SDL {
     std::vector<float> out_tc_phi_;
     std::vector<std::vector<int>> out_tc_hitIdxs_;
     std::vector<int> out_tc_len_;
+    std::vector<int> out_tc_seedIdx_;
   };
 
 } //namespace

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -18,7 +18,8 @@ LIB=libsdl.so
 
 # AMD Opteron and Intel EM64T (64 bit mode) Linux with gcc 3.x
 CXX                  = nvcc
-CXXFLAGS             =  -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 -I/mnt/data1/dsr/cub --use_fast_math --default-stream per-thread
+CXXFLAGS             =  -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 -I/mnt/data1/dsr/cub --use_fast_math --default-stream per-thread -I..
+ROOTCFLAGS           = --compiler-options -pthread --compiler-options -std=c++17 -m64 -I/cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0_pre5/external/slc7_amd64_gcc900/bin/../../../../../../../slc7_amd64_gcc900/lcg/root/6.20.06-ghbfee3/include
 LD                   = nvcc 
 SOFLAGS              = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70 -code=sm_72
 PRINTFLAG            = -DAddObjects -DT4FromT3 #-DWarnings
@@ -42,7 +43,7 @@ CUTVALUEFLAG_FLAGS = -DCUT_VALUE_DEBUG
 	$(LD) -x cu $(PT0P8) $(PRELOAD) $(T3T3EXTENSION) $(CXXFLAGS) $(LDFLAGS) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUDALAUNCHFLAG) $(CUTVALUEFLAG) $(FINALSTATE) $(DUPLICATES) $< -o $@
 
 %_cpu.o : %.cc %.h
-	$(LD) -O2   $(PT0P8) $(PRELOAD) $(T3T3EXTENSION) $(CXXFLAGS) $(LDFLAGS) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUDALAUNCHFLAG) $(FINALSTATE) $(DUPLICATES) $< -o $@
+	$(LD) -O2   $(PT0P8) $(PRELOAD) $(T3T3EXTENSION) $(CXXFLAGS) $(LDFLAGS) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUDALAUNCHFLAG) $(FINALSTATE) $(DUPLICATES) $(ROOTCFLAGS) $< -o $@
 
 $(LIB):$(CCOBJECTS) $(CUOBJECTS)
 #$(LIB):$(CUOBJECTS)

--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -256,8 +256,8 @@ __device__  bool SDL::runMiniDoubletDefaultAlgoBarrel(struct modules& modulesInG
             shiftedZ = zUpper;
             shiftedRt = sqrt(xn * xn + yn * yn);
 
-            dPhi = deltaPhi(xLower,yLower,zLower,shiftedX, shiftedY, shiftedZ); //function from Hit.cu
-            noShiftedDphi = deltaPhi(xLower, yLower, zLower, xUpper, yUpper, zUpper);
+            dPhi = deltaPhi(xLower,yLower,shiftedX, shiftedY); //function from Hit.cu
+            noShiftedDphi = deltaPhi(xLower, yLower, xUpper, yUpper);
         }
         else
         {
@@ -265,14 +265,14 @@ __device__  bool SDL::runMiniDoubletDefaultAlgoBarrel(struct modules& modulesInG
             shiftedY = yn;
             shiftedZ = zLower;
             shiftedRt = sqrt(xn * xn + yn * yn);
-            dPhi = deltaPhi(shiftedX, shiftedY, shiftedZ, xUpper, yUpper, zUpper);
-            noShiftedDphi = deltaPhi(xLower,yLower,zLower,xUpper,yUpper,zUpper);
+            dPhi = deltaPhi(shiftedX, shiftedY, xUpper, yUpper);
+            noShiftedDphi = deltaPhi(xLower,yLower,xUpper,yUpper);
 
         }
     }
     else
     {
-        dPhi = deltaPhi(xLower, yLower, zLower, xUpper, yUpper, zUpper);
+        dPhi = deltaPhi(xLower, yLower, xUpper, yUpper);
         noShiftedDphi = dPhi;
     }
 
@@ -294,8 +294,8 @@ __device__  bool SDL::runMiniDoubletDefaultAlgoBarrel(struct modules& modulesInG
             // setDeltaPhiChange(lowerHit.rt() < upperHitMod.rt() ? lowerHit.deltaPhiChange(upperHitMod) : upperHitMod.deltaPhiChange(lowerHit));
 
 
-            dPhiChange = (rtLower < shiftedRt) ? deltaPhiChange(xLower, yLower, zLower, shiftedX, shiftedY, shiftedZ) : deltaPhiChange(shiftedX, shiftedY, shiftedZ, xLower, yLower, zLower); 
-            noShiftedDphiChange = rtLower < rtUpper ? deltaPhiChange(xLower,yLower, zLower, xUpper, yUpper, zUpper) : deltaPhiChange(xUpper, yUpper, zUpper, xLower, yLower, zLower);
+            dPhiChange = (rtLower < shiftedRt) ? deltaPhiChange(xLower, yLower, shiftedX, shiftedY) : deltaPhiChange(shiftedX, shiftedY, xLower, yLower); 
+            noShiftedDphiChange = rtLower < rtUpper ? deltaPhiChange(xLower,yLower, xUpper, yUpper) : deltaPhiChange(xUpper, yUpper, xLower, yLower);
         }
         else
         {
@@ -304,14 +304,14 @@ __device__  bool SDL::runMiniDoubletDefaultAlgoBarrel(struct modules& modulesInG
             // (i.e. the strip hit is shifted to be aligned in the line of sight from interaction point to pixel hit of PS module guaranteeing rt ordering)
             // But I still placed this check for safety. (TODO: After cheking explicitly if not needed remove later?)
 
-            dPhiChange = (shiftedRt < rtUpper) ? deltaPhiChange(shiftedX, shiftedY, shiftedZ, xUpper, yUpper, zUpper) : deltaPhiChange(xUpper, yUpper, zUpper, shiftedX, shiftedY, shiftedZ);
-            noShiftedDphiChange = rtLower < rtUpper ? deltaPhiChange(xLower,yLower, zLower, xUpper, yUpper, zUpper) : deltaPhiChange(xUpper, yUpper, zUpper, xLower, yLower, zLower);
+            dPhiChange = (shiftedRt < rtUpper) ? deltaPhiChange(shiftedX, shiftedY, xUpper, yUpper) : deltaPhiChange(xUpper, yUpper, shiftedX, shiftedY);
+            noShiftedDphiChange = rtLower < rtUpper ? deltaPhiChange(xLower,yLower, xUpper, yUpper) : deltaPhiChange(xUpper, yUpper, xLower, yLower);
         }
     }
     else
     {
         // When it is flat lying module, whichever is the lowerSide will always have rt lower
-        dPhiChange = deltaPhiChange(xLower, yLower, zLower, xUpper, yUpper, zUpper);
+        dPhiChange = deltaPhiChange(xLower, yLower, xUpper, yUpper);
         noShiftedDphiChange = dPhiChange;
     }
 
@@ -364,8 +364,8 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoEndcap(struct modules& modulesInGP
             shiftedX = xn;
             shiftedY = yn;
             shiftedZ = zUpper;
-            dPhi = deltaPhi(xLower, yLower, zLower, shiftedX, shiftedY, shiftedZ);
-            noShiftedDphi = deltaPhi(xLower, yLower, zLower, xUpper, yUpper, zUpper);
+            dPhi = deltaPhi(xLower, yLower, shiftedX, shiftedY);
+            noShiftedDphi = deltaPhi(xLower, yLower, xUpper, yUpper);
         }
         else
         {
@@ -375,8 +375,8 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoEndcap(struct modules& modulesInGP
             shiftedX = xn;
             shiftedY = yn;
             shiftedZ = zLower;
-            dPhi = deltaPhi(shiftedX, shiftedY, shiftedZ, xUpper, yUpper, zUpper);
-            noShiftedDphi = deltaPhi(xLower, yLower, zLower, xUpper, yUpper, zUpper);
+            dPhi = deltaPhi(shiftedX, shiftedY, xUpper, yUpper);
+            noShiftedDphi = deltaPhi(xLower, yLower, xUpper, yUpper);
         }
     }
     else
@@ -384,8 +384,8 @@ __device__ bool SDL::runMiniDoubletDefaultAlgoEndcap(struct modules& modulesInGP
         shiftedX = xn;
         shiftedY = yn;
         shiftedZ = zUpper;
-        dPhi = deltaPhi(xLower, yLower, zLower, xn, yn, zUpper);
-        noShiftedDphi = deltaPhi(xLower, yLower, zLower, xUpper, yUpper, zUpper);
+        dPhi = deltaPhi(xLower, yLower, xn, yn);
+        noShiftedDphi = deltaPhi(xLower, yLower, xUpper, yUpper);
     }
 
     // dz needs to change if it is a PS module where the strip hits are shifted in order to properly account for the case when a tilted module falls under "endcap logic"

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -486,12 +486,6 @@ void SDL::fillPixelMap(struct modules& modulesInGPU, struct pixelMap& pixelMappi
     std::vector<unsigned int> connectedModuleDetIds;
     std::vector<unsigned int> connectedModuleDetIds_pos;
     std::vector<unsigned int> connectedModuleDetIds_neg;
-    unsigned int* connectedPixelsIndex;
-    unsigned int* connectedPixelsIndexPos;
-    unsigned int* connectedPixelsIndexNeg;
-    unsigned int* connectedPixelsSizes;
-    unsigned int* connectedPixelsSizesPos;
-    unsigned int* connectedPixelsSizesNeg;
     cudaMallocHost(&pixelMapping.connectedPixelsIndex,size_superbins * sizeof(unsigned int));
     cudaMallocHost(&pixelMapping.connectedPixelsSizes,size_superbins * sizeof(unsigned int));
     cudaMallocHost(&pixelMapping.connectedPixelsIndexPos,size_superbins * sizeof(unsigned int));

--- a/SDL/Module.cu
+++ b/SDL/Module.cu
@@ -263,7 +263,7 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, 
     (*detIdToIndex)[1] = counter; //pixel module is the last module in the module list
     counter++;
     nModules = counter;
-    std::cout<<"Number of modules = "<<nModules<<std::endl;
+    //std::cout<<"Number of modules = "<<nModules<<std::endl;
     createModulesInExplicitMemory(modulesInGPU,nModules,stream);
     unsigned int* host_detIds;
     short* host_layers;
@@ -457,7 +457,7 @@ void SDL::loadModulesFromFile(struct modules& modulesInGPU, uint16_t& nModules, 
     cms::cuda::free_host(host_slopes);
     cms::cuda::free_host(host_drdzs);
     cms::cuda::free_host(host_partnerModuleIndices);
-    std::cout<<"number of lower modules (without fake pixel module)= "<<lowerModuleCounter<<std::endl;
+    //std::cout<<"number of lower modules (without fake pixel module)= "<<lowerModuleCounter<<std::endl;
     fillConnectedModuleArrayExplicit(modulesInGPU,nModules,stream);
     fillMapArraysExplicit(modulesInGPU, nModules, stream);
     fillPixelMap(modulesInGPU,pixelMapping,stream);

--- a/SDL/PixelTracklet.cuh
+++ b/SDL/PixelTracklet.cuh
@@ -99,7 +99,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     float& rt_InOut = rt_InUp;
     //float& z_InOut = z_InUp;
 
-    pass = pass and (fabsf(deltaPhi(x_InUp, y_InUp, z_InUp, x_OutLo, y_OutLo, z_OutLo)) <= 0.5f * float(M_PI));
+    pass = pass and (fabsf(deltaPhi(x_InUp, y_InUp, x_OutLo, y_OutLo)) <= 0.5f * float(M_PI));
     if(not pass) return pass;
 
     unsigned int pixelSegmentArrayIndex = innerSegmentIndex - rangesInGPU.segmentModuleIndices[pixelModuleIndex]; 
@@ -166,7 +166,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     const float sdlPVoff = 0.1f / rt_OutLo;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    dPhiPos = deltaPhi(x_InUp, y_InUp, z_InUp, x_OutUp, y_OutUp, z_OutUp);
+    dPhiPos = deltaPhi(x_InUp, y_InUp, x_OutUp, y_OutUp);
 
     //no dphipos cut
     float midPointX = 0.5f * (x_InLo + x_OutLo);
@@ -178,7 +178,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     float diffZ = z_OutLo - z_InLo;
 
 
-    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
 
     pass = pass and (fabsf(dPhi) <= sdlCut);
     if(not pass) return pass;
@@ -191,7 +191,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     bool isEC_lastLayer = modulesInGPU.subdets[outerOuterLowerModuleIndex] == SDL::Endcap and modulesInGPU.moduleType[outerOuterLowerModuleIndex] == SDL::TwoS;
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
-    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, z_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo, z_OutUp - z_OutLo);
+    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
 
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
@@ -206,27 +206,27 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = -deltaPhi(px, py, pz, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = -deltaPhi(px, py, tl_axis_x, tl_axis_y);
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
 
-    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, z_OutUp, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
  
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
-        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
-        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
+        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo);
+        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_InUp;
         tl_axis_lowEdge_x = mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_InUp;
 
-        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z);
+        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y);
     }
 
     //beta computation
@@ -398,7 +398,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
     const float sdlPVoff = 0.1f / rt_OutLo;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = deltaPhi(x_InUp, y_InUp, z_InUp, x_OutUp, y_OutUp, z_OutUp);
+    deltaPhiPos = deltaPhi(x_InUp, y_InUp, x_OutUp, y_OutUp);
 
     float midPointX = 0.5f * (x_InLo + x_OutLo);
     float midPointY = 0.5f * (y_InLo + y_OutLo);
@@ -408,7 +408,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
     float diffY = y_OutLo - y_InLo;
     float diffZ = z_OutLo - z_InLo;
 
-    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #5: deltaPhiChange
     pass =  pass and (fabsf(dPhi) <= sdlCut);
@@ -421,7 +421,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
 
-    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, z_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo, z_OutUp - z_OutLo);
+    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
 
@@ -435,27 +435,27 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = -deltaPhi(px, py, pz, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = -deltaPhi(px, py, tl_axis_x, tl_axis_y);
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
 
-    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, z_OutUp, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
 
-        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
-        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
+        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo);
+        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_InUp;
         tl_axis_lowEdge_x = mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_InUp;
 
-        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z);
+        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y);
     }
 
     //beta computation

--- a/SDL/PixelTracklet.cuh
+++ b/SDL/PixelTracklet.cuh
@@ -81,10 +81,8 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     rt_OutLo = mdsInGPU.anchorRt[thirdMDIndex];
     float rt_OutUp = mdsInGPU.anchorRt[fourthMDIndex];
 
-    float z_InLo = mdsInGPU.anchorZ[firstMDIndex];
     float z_InUp = mdsInGPU.anchorZ[secondMDIndex];
     z_OutLo = mdsInGPU.anchorZ[thirdMDIndex];
-    float z_OutUp = mdsInGPU.anchorZ[fourthMDIndex];
 
     float x_InLo = mdsInGPU.anchorX[firstMDIndex];
     float x_InUp = mdsInGPU.anchorX[secondMDIndex];
@@ -130,15 +128,10 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     if(not pass) return pass;
 
     const float coshEta = sqrtf(ptIn * ptIn + pz * pz) / ptIn;
-    // const float drt_OutLo_InLo = (rt_OutLo - rt_InLo);
     const float drt_OutLo_InUp = (rt_OutLo - rt_InUp);
-    //const float invRt_InLo = 1.f / rt_InLo;
-    //const float r3_InLo = sqrtf(z_InLo * z_InLo + rt_InLo * rt_InLo);
     const float r3_InUp = sqrtf(z_InUp * z_InUp + rt_InUp * rt_InUp);
     
     float drt_InSeg = rt_InOut - rt_InLo;
-    //float dz_InSeg = z_InOut - z_InLo;
-    //float dr3_InSeg = sqrtf(rt_InOut * rt_InOut + z_InOut * z_InOut) - sqrtf(rt_InLo * rt_InLo + z_InLo * z_InLo);
 
     const float sdlThetaMulsF = 0.015f * sqrtf(0.1f + 0.2f * (rt_OutLo - rt_InUp) / 50.f) * sqrtf(r3_InUp / rt_InUp);
     const float sdlMuls = sdlThetaMulsF * 3.f / ptCut * 4.f; // will need a better guess than x4?
@@ -171,11 +164,9 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     //no dphipos cut
     float midPointX = 0.5f * (x_InLo + x_OutLo);
     float midPointY = 0.5f * (y_InLo + y_OutLo);
-    float midPointZ = 0.5f * (z_InLo + z_OutLo);
 
     float diffX = x_OutLo - x_InLo;
     float diffY = y_OutLo - y_InLo;
-    float diffZ = z_OutLo - z_InLo;
 
 
     dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
@@ -198,7 +189,6 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
 
     float tl_axis_x = x_OutUp - x_InUp;
     float tl_axis_y = y_OutUp - y_InUp;
-    float tl_axis_z = z_OutUp - z_InUp;
  
     float tl_axis_highEdge_x = tl_axis_x;
     float tl_axis_highEdge_y = tl_axis_y;
@@ -241,8 +231,6 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     float betaAv = 0.5f * (betaIn + betaOut);
     pt_beta = ptIn;
 
-    const float pt_betaMax = 7.0f;
-
     int lIn = 0;
     int lOut = isEC_lastLayer ? 11 : 5;
     float sdOut_dr = sqrtf((x_OutUp - x_OutLo) * (x_OutUp - x_OutLo) + (y_OutUp - y_OutLo) * (y_OutUp - y_OutLo));
@@ -259,7 +247,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPBB(struct modules& modulesInGPU, st
     betaOutRHmin *= betaOutMMSF;
     betaOutRHmax *= betaOutMMSF;
 
-    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), SDL::pt_betaMax); //need to confirm the range-out value of 7 GeV
     const float alphaInAbsReg =  fmaxf(fabsf(alpha_InLo), asinf(fminf(rt_InUp * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float alphaOutAbsReg = fmaxf(fabsf(alpha_OutLo), asinf(fminf(rt_OutLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float dBetaInLum = lIn < 11 ? 0.0f : fabsf(alphaInAbsReg*deltaZLum / z_InUp);
@@ -303,10 +291,8 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
     bool isPS_OutLo = (modulesInGPU.moduleType[outerInnerLowerModuleIndex] == SDL::PS);
 
 
-    float z_InLo = mdsInGPU.anchorZ[firstMDIndex];
     float z_InUp = mdsInGPU.anchorZ[secondMDIndex];
     z_OutLo = mdsInGPU.anchorZ[thirdMDIndex];
-    float z_OutUp = mdsInGPU.anchorZ[fourthMDIndex];
 
     pass =  pass and (z_InUp * z_OutLo > 0);
     if(not pass) return pass;
@@ -402,11 +388,9 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
 
     float midPointX = 0.5f * (x_InLo + x_OutLo);
     float midPointY = 0.5f * (y_InLo + y_OutLo);
-    float midPointZ = 0.5f * (z_InLo + z_OutLo);
 
     float diffX = x_OutLo - x_InLo;
     float diffY = y_OutLo - y_InLo;
-    float diffZ = z_OutLo - z_InLo;
 
     dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
 
@@ -427,7 +411,6 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
 
     float tl_axis_x = x_OutUp - x_InUp;
     float tl_axis_y = y_OutUp - y_InUp;
-    float tl_axis_z = z_OutUp - z_InUp;
 
     float tl_axis_highEdge_x = tl_axis_x;
     float tl_axis_highEdge_y = tl_axis_y;
@@ -468,8 +451,6 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
     float betaAv = 0.5f * (betaIn + betaOut);
     pt_beta = ptIn;
 
-    const float pt_betaMax = 7.0f;
-
     int lIn = 0;
     int lOut = isEC_lastLayer ? 11 : 5;
     float sdOut_dr = sqrtf((x_OutUp - x_OutLo) * (x_OutUp - x_OutLo) + (y_OutUp - y_OutLo) * (y_OutUp - y_OutLo));
@@ -486,7 +467,7 @@ CUDA_DEV bool inline runTrackletDefaultAlgoPPEE(struct modules& modulesInGPU, st
     betaOutRHmin *= betaOutMMSF;
     betaOutRHmax *= betaOutMMSF;
 
-    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), SDL::pt_betaMax); //need to confirm the range-out value of 7 GeV
 
     const float alphaInAbsReg =  fmaxf(fabsf(alpha_InLo), asinf(fminf(rt_InUp * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float alphaOutAbsReg = fmaxf(fabsf(alpha_OutLo), asinf(fminf(rt_OutLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));

--- a/SDL/PixelTriplet.cu
+++ b/SDL/PixelTriplet.cu
@@ -1050,7 +1050,7 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPBB(struct modules& modulesInG
     float rt_InOut = rt_InUp;
     //float& z_InOut = z_InUp;
 
-    pass = pass and (fabsf(deltaPhi(x_InUp, y_InUp, z_InUp, x_OutLo, y_OutLo, z_OutLo)) <= 0.5f * float(M_PI));
+    pass = pass and (fabsf(deltaPhi(x_InUp, y_InUp, x_OutLo, y_OutLo)) <= 0.5f * float(M_PI));
     if(not pass) return pass;
 
     unsigned int pixelSegmentArrayIndex = innerSegmentIndex - rangesInGPU.segmentModuleIndices[pixelModuleIndex];
@@ -1118,7 +1118,7 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPBB(struct modules& modulesInG
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
 #ifdef CUT_VALUE_DEBUG
-    dPhiPos = deltaPhi(x_InUp, y_InUp, z_InUp, x_OutUp, y_OutUp, z_OutUp);
+    dPhiPos = deltaPhi(x_InUp, y_InUp, x_OutUp, y_OutUp);
     //no dphipos cut
 #endif
 
@@ -1131,7 +1131,7 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPBB(struct modules& modulesInG
     float diffZ = z_OutLo - z_InLo;
 
 
-    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
 
     pass = pass and (fabsf(dPhi) <= sdlCut);
     if(not pass) return pass;
@@ -1144,7 +1144,7 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPBB(struct modules& modulesInG
     bool isEC_lastLayer = modulesInGPU.subdets[outerOuterLowerModuleIndex] == SDL::Endcap and modulesInGPU.moduleType[outerOuterLowerModuleIndex] == SDL::TwoS;
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
-    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, z_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo, z_OutUp - z_OutLo);
+    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
 
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
@@ -1159,27 +1159,27 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPBB(struct modules& modulesInG
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = -deltaPhi(px, py, pz, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = -deltaPhi(px, py, tl_axis_x, tl_axis_y);
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
 
-    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, z_OutUp, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
-        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
-        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
+        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo);
+        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_InUp;
         tl_axis_lowEdge_x = mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_InUp;
 
-        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z);
+        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y);
     }
 
     //beta computation
@@ -1353,7 +1353,7 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPEE(struct modules& modulesInG
     const float sdlPVoff = 0.1f / rt_OutLo;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = deltaPhi(x_InUp, y_InUp, z_InUp, x_OutUp, y_OutUp, z_OutUp);
+    deltaPhiPos = deltaPhi(x_InUp, y_InUp, x_OutUp, y_OutUp);
 
     float midPointX = 0.5f * (x_InLo + x_OutLo);
     float midPointY = 0.5f * (y_InLo + y_OutLo);
@@ -1363,7 +1363,7 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPEE(struct modules& modulesInG
     float diffY = y_OutLo - y_InLo;
     float diffZ = z_OutLo - z_InLo;
 
-    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #5: deltaPhiChange
     pass =  pass and (fabsf(dPhi) <= sdlCut);
@@ -1376,7 +1376,7 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPEE(struct modules& modulesInG
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
 
-    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, z_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo, z_OutUp - z_OutLo);
+    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
 
@@ -1390,27 +1390,27 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPEE(struct modules& modulesInG
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = -deltaPhi(px, py, pz, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = -deltaPhi(px, py, tl_axis_x, tl_axis_y);
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
 
-    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, z_OutUp, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
 
-        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
-        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
+        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo);
+        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_InUp;
         tl_axis_lowEdge_x = mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_InUp;
 
-        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z);
+        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y);
     }
 
     //beta computation
@@ -2548,7 +2548,7 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPBB(struct modules& modulesInGPU, 
     float& rt_InOut = rt_InUp;
     //float& z_InOut = z_InUp;
 
-    pass = pass and (fabsf(deltaPhi(x_InUp, y_InUp, z_InUp, x_OutLo, y_OutLo, z_OutLo)) <= 0.5f * float(M_PI));
+    pass = pass and (fabsf(deltaPhi(x_InUp, y_InUp, x_OutLo, y_OutLo)) <= 0.5f * float(M_PI));
     if(not pass) return pass;
 
     unsigned int pixelSegmentArrayIndex = innerSegmentIndex - rangesInGPU.segmentModuleIndices[pixelModuleIndex];
@@ -2615,7 +2615,7 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPBB(struct modules& modulesInGPU, 
     const float sdlPVoff = 0.1f / rt_OutLo;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    dPhiPos = deltaPhi(x_InUp, y_InUp, z_InUp, x_OutUp, y_OutUp, z_OutUp);
+    dPhiPos = deltaPhi(x_InUp, y_InUp, x_OutUp, y_OutUp);
 
     //no dphipos cut
     float midPointX = 0.5f * (x_InLo + x_OutLo);
@@ -2627,7 +2627,7 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPBB(struct modules& modulesInGPU, 
     float diffZ = z_OutLo - z_InLo;
 
 
-    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
 
     pass = pass and (fabsf(dPhi) <= sdlCut);
     if(not pass) return pass;
@@ -2640,7 +2640,7 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPBB(struct modules& modulesInGPU, 
     bool isEC_lastLayer = modulesInGPU.subdets[outerOuterLowerModuleIndex] == SDL::Endcap and modulesInGPU.moduleType[outerOuterLowerModuleIndex] == SDL::TwoS;
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
-    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, z_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo, z_OutUp - z_OutLo);
+    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
 
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
@@ -2655,27 +2655,27 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPBB(struct modules& modulesInGPU, 
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = -deltaPhi(px, py, pz, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = -deltaPhi(px, py, tl_axis_x, tl_axis_y);
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
 
-    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, z_OutUp, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
-        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
-        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
+        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo);
+        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_InUp;
         tl_axis_lowEdge_x = mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_InUp;
 
-        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z);
+        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y);
     }
 
     //beta computation
@@ -2847,7 +2847,7 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPEE(struct modules& modulesInGPU, 
     const float sdlPVoff = 0.1f / rt_OutLo;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = deltaPhi(x_InUp, y_InUp, z_InUp, x_OutUp, y_OutUp, z_OutUp);
+    deltaPhiPos = deltaPhi(x_InUp, y_InUp, x_OutUp, y_OutUp);
 
     float midPointX = 0.5f * (x_InLo + x_OutLo);
     float midPointY = 0.5f * (y_InLo + y_OutLo);
@@ -2857,7 +2857,7 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPEE(struct modules& modulesInGPU, 
     float diffY = y_OutLo - y_InLo;
     float diffZ = z_OutLo - z_InLo;
 
-    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #5: deltaPhiChange
     pass =  pass and (fabsf(dPhi) <= sdlCut);
@@ -2870,7 +2870,7 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPEE(struct modules& modulesInGPU, 
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
 
-    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, z_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo, z_OutUp - z_OutLo);
+    alpha_OutUp = deltaPhi(x_OutUp, y_OutUp, x_OutUp - x_OutLo, y_OutUp - y_OutLo);
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
 
@@ -2884,27 +2884,27 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPEE(struct modules& modulesInGPU, 
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = -deltaPhi(px, py, pz, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = -deltaPhi(px, py, tl_axis_x, tl_axis_y);
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
 
-    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, z_OutUp, tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + deltaPhi(x_OutUp, y_OutUp, tl_axis_x, tl_axis_y);
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
 
-        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
-        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo, z_OutUp - z_OutLo);
+        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_OutLo);
+        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_OutLo, mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_OutLo);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - y_InUp;
         tl_axis_lowEdge_x = mdsInGPU.anchorLowEdgeX[fourthMDIndex] - x_InUp;
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - y_InUp;
 
-        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], z_OutUp, tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], z_OutUp, tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z);
+        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y);
     }
 
     //beta computation

--- a/SDL/PixelTriplet.cu
+++ b/SDL/PixelTriplet.cu
@@ -289,8 +289,6 @@ __device__ bool SDL::runPixelTripletDefaultAlgo(struct modules& modulesInGPU, st
     unsigned int pixelSegmentArrayIndex = pixelSegmentIndex - rangesInGPU.segmentModuleIndices[pixelModuleIndex];
     float pixelSegmentPt = segmentsInGPU.ptIn[pixelSegmentArrayIndex];
     float pixelSegmentPtError = segmentsInGPU.ptErr[pixelSegmentArrayIndex];
-    float pixelSegmentEta = segmentsInGPU.eta[pixelSegmentArrayIndex];
-    float pixelSegmentEtaError = segmentsInGPU.etaErr[pixelSegmentArrayIndex];
     float pixelSegmentPx = segmentsInGPU.px[pixelSegmentArrayIndex];
     float pixelSegmentPy = segmentsInGPU.py[pixelSegmentArrayIndex];
     float pixelSegmentPz = segmentsInGPU.pz[pixelSegmentArrayIndex];
@@ -506,7 +504,7 @@ __device__ float SDL::computePT3RZChiSquared(struct modules& modulesInGPU, uint1
     //hardcoded array indices!!!
     float RMSE = 0;
 
-    float Pt=pixelSegmentPt, Px=pixelSegmentPx, Py=pixelSegmentPy, Pz=pixelSegmentPz;
+    float Px=pixelSegmentPx, Py=pixelSegmentPy, Pz=pixelSegmentPz;
     int charge=pixelSegmentCharge;
     float x1 = xPix[1]/100;
     float y1 = yPix[1]/100;
@@ -1194,8 +1192,6 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPBB(struct modules& modulesInG
     float betaAv = 0.5f * (betaIn + betaOut);
     pt_beta = ptIn;
 
-    const float pt_betaMax = 7.0f;
-
     int lIn = 0;
     int lOut = isEC_lastLayer ? 11 : 5;
     float sdOut_dr = sqrtf((x_OutUp - x_OutLo) * (x_OutUp - x_OutLo) + (y_OutUp - y_OutLo) * (y_OutUp - y_OutLo));
@@ -1212,7 +1208,7 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPBB(struct modules& modulesInG
     betaOutRHmin *= betaOutMMSF;
     betaOutRHmax *= betaOutMMSF;
 
-    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), SDL::pt_betaMax); //need to confirm the range-out value of 7 GeV
     const float alphaInAbsReg =  fmaxf(fabsf(alpha_InLo), asinf(fminf(rt_InUp * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float alphaOutAbsReg = fmaxf(fabsf(alpha_OutLo), asinf(fminf(rt_OutLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float dBetaInLum = lIn < 11 ? 0.0f : fabsf(alphaInAbsReg*deltaZLum / z_InUp);
@@ -1423,8 +1419,6 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPEE(struct modules& modulesInG
     float betaAv = 0.5f * (betaIn + betaOut);
     pt_beta = ptIn;
 
-    const float pt_betaMax = 7.0f;
-
     int lIn = 0;
     int lOut = isEC_lastLayer ? 11 : 5;
     float sdOut_dr = sqrtf((x_OutUp - x_OutLo) * (x_OutUp - x_OutLo) + (y_OutUp - y_OutLo) * (y_OutUp - y_OutLo));
@@ -1434,14 +1428,14 @@ __device__ bool inline SDL::runTripletDefaultAlgoPPEE(struct modules& modulesInG
 
     runDeltaBetaIterationspT3(betaIn, betaOut, betaAv, pt_beta, rt_InSeg, sdOut_dr, drt_tl_axis, lIn);
 
-     const float betaInMMSF = (fabsf(betaInRHmin + betaInRHmax) > 0) ? (2.f * betaIn / fabsf(betaInRHmin + betaInRHmax)) : 0.; //mean value of min,max is the old betaIn
+    const float betaInMMSF = (fabsf(betaInRHmin + betaInRHmax) > 0) ? (2.f * betaIn / fabsf(betaInRHmin + betaInRHmax)) : 0.; //mean value of min,max is the old betaIn
     const float betaOutMMSF = (fabsf(betaOutRHmin + betaOutRHmax) > 0) ? (2.f * betaOut / fabsf(betaOutRHmin + betaOutRHmax)) : 0.;
     betaInRHmin *= betaInMMSF;
     betaInRHmax *= betaInMMSF;
     betaOutRHmin *= betaOutMMSF;
     betaOutRHmax *= betaOutMMSF;
 
-    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), SDL::pt_betaMax); //need to confirm the range-out value of 7 GeV
 
     const float alphaInAbsReg =  fmaxf(fabsf(alpha_InLo), asinf(fminf(rt_InUp * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float alphaOutAbsReg = fmaxf(fabsf(alpha_OutLo), asinf(fminf(rt_OutLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
@@ -2690,8 +2684,6 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPBB(struct modules& modulesInGPU, 
     float betaAv = 0.5f * (betaIn + betaOut);
     pt_beta = ptIn;
 
-    const float pt_betaMax = 7.0f;
-
     int lIn = 0;
     int lOut = isEC_lastLayer ? 11 : 5;
     float sdOut_dr = sqrtf((x_OutUp - x_OutLo) * (x_OutUp - x_OutLo) + (y_OutUp - y_OutLo) * (y_OutUp - y_OutLo));
@@ -2708,7 +2700,7 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPBB(struct modules& modulesInGPU, 
     betaOutRHmin *= betaOutMMSF;
     betaOutRHmax *= betaOutMMSF;
 
-    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), SDL::pt_betaMax); //need to confirm the range-out value of 7 GeV
     const float alphaInAbsReg =  fmaxf(fabsf(alpha_InLo), asinf(fminf(rt_InUp * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float alphaOutAbsReg = fmaxf(fabsf(alpha_OutLo), asinf(fminf(rt_OutLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float dBetaInLum = lIn < 11 ? 0.0f : fabsf(alphaInAbsReg*deltaZLum / z_InUp);
@@ -2917,8 +2909,6 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPEE(struct modules& modulesInGPU, 
     float betaAv = 0.5f * (betaIn + betaOut);
     pt_beta = ptIn;
 
-    const float pt_betaMax = 7.0f;
-
     int lIn = 0;
     int lOut = isEC_lastLayer ? 11 : 5;
     float sdOut_dr = sqrtf((x_OutUp - x_OutLo) * (x_OutUp - x_OutLo) + (y_OutUp - y_OutLo) * (y_OutUp - y_OutLo));
@@ -2928,14 +2918,14 @@ __device__ bool inline SDL::runpT5DefaultAlgoPPEE(struct modules& modulesInGPU, 
 
     runDeltaBetaIterationspT5(betaIn, betaOut, betaAv, pt_beta, rt_InSeg, sdOut_dr, drt_tl_axis, lIn);
 
-     const float betaInMMSF = (fabsf(betaInRHmin + betaInRHmax) > 0) ? (2.f * betaIn / fabsf(betaInRHmin + betaInRHmax)) : 0.; //mean value of min,max is the old betaIn
+    const float betaInMMSF = (fabsf(betaInRHmin + betaInRHmax) > 0) ? (2.f * betaIn / fabsf(betaInRHmin + betaInRHmax)) : 0.; //mean value of min,max is the old betaIn
     const float betaOutMMSF = (fabsf(betaOutRHmin + betaOutRHmax) > 0) ? (2.f * betaOut / fabsf(betaOutRHmin + betaOutRHmax)) : 0.;
     betaInRHmin *= betaInMMSF;
     betaInRHmax *= betaInMMSF;
     betaOutRHmin *= betaOutMMSF;
     betaOutRHmax *= betaOutMMSF;
 
-    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), SDL::pt_betaMax); //need to confirm the range-out value of 7 GeV
 
     const float alphaInAbsReg =  fmaxf(fabsf(alpha_InLo), asinf(fminf(rt_InUp * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float alphaOutAbsReg = fmaxf(fabsf(alpha_OutLo), asinf(fminf(rt_OutLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -1483,7 +1483,7 @@ __device__ bool SDL::runQuintupletDefaultAlgoBBBB(struct SDL::modules& modulesIn
     float sdlPVoff = 0.1f/rt_OutLo;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
     // Cut #3: FIXME:deltaPhiPos can be tighter
     pass = pass and (fabsf(deltaPhiPos) <= sdlCut);
     if(not pass) return pass;
@@ -1495,7 +1495,7 @@ __device__ bool SDL::runQuintupletDefaultAlgoBBBB(struct SDL::modules& modulesIn
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = SDL::deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = SDL::deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #4: deltaPhiChange
     pass = pass and (fabsf(dPhi) <= sdlCut);
@@ -1511,7 +1511,7 @@ __device__ bool SDL::runQuintupletDefaultAlgoBBBB(struct SDL::modules& modulesIn
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
 
-    alpha_OutUp = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+    alpha_OutUp = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
@@ -1524,19 +1524,19 @@ __device__ bool SDL::runQuintupletDefaultAlgoBBBB(struct SDL::modules& modulesIn
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = alpha_InLo - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = alpha_InLo - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    betaOut = -alpha_OutUp + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
-        alpha_OutUp_highEdge = SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
-        alpha_OutUp_lowEdge = SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+        alpha_OutUp_highEdge = SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
+        alpha_OutUp_lowEdge = SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[firstMDIndex];
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
@@ -1544,8 +1544,8 @@ __device__ bool SDL::runQuintupletDefaultAlgoBBBB(struct SDL::modules& modulesIn
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
 
 
-        betaOutRHmin = -alpha_OutUp_highEdge + SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z);
+        betaOutRHmin = -alpha_OutUp_highEdge + SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y);
     }
 
     //beta computation
@@ -1701,7 +1701,7 @@ __device__ bool SDL::runQuintupletDefaultAlgoBBEE(struct SDL::modules& modulesIn
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff*sdlPVoff);
 
 
-    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
 
     //Cut #4: deltaPhiPos can be tighter
@@ -1715,7 +1715,7 @@ __device__ bool SDL::runQuintupletDefaultAlgoBBEE(struct SDL::modules& modulesIn
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = SDL::deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = SDL::deltaPhi(midPointX, midPointY, diffX, diffY);
     // Cut #5: deltaPhiChange
     pass =  pass and (fabsf(dPhi) <= sdlCut);
     if(not pass) return pass;
@@ -1725,7 +1725,7 @@ __device__ bool SDL::runQuintupletDefaultAlgoBBEE(struct SDL::modules& modulesIn
     float sdIn_alpha_max = __H2F(segmentsInGPU.dPhiChangeMaxs[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha; //weird
 
-    float sdOut_alphaOut = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+    float sdOut_alphaOut = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
     float sdOut_alphaOut_min = SDL::phi_mpi_pi(__H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMins[outerSegmentIndex]));
     float sdOut_alphaOut_max = SDL::phi_mpi_pi(__H2F(segmentsInGPU.dPhiChangeMaxs[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMaxs[outerSegmentIndex]));
@@ -1734,11 +1734,11 @@ __device__ bool SDL::runQuintupletDefaultAlgoBBEE(struct SDL::modules& modulesIn
     float tl_axis_y = mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float tl_axis_z = mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
@@ -1921,7 +1921,7 @@ __device__ bool SDL::runQuintupletDefaultAlgoEEEE(struct SDL::modules& modulesIn
     float sdlPVoff = 0.1f/rtOut;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
     pass =  pass and (fabsf(deltaPhiPos) <= sdlCut);
     if(not pass) return pass;
@@ -1933,7 +1933,7 @@ __device__ bool SDL::runQuintupletDefaultAlgoEEEE(struct SDL::modules& modulesIn
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = SDL::deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = SDL::deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #5: deltaPhiChange
     pass =  pass and ((fabsf(dPhi) <= sdlCut));
@@ -1941,7 +1941,7 @@ __device__ bool SDL::runQuintupletDefaultAlgoEEEE(struct SDL::modules& modulesIn
 
     float sdIn_alpha = __H2F(segmentsInGPU.dPhiChanges[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha; //weird
-    float sdOut_dPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[thirdMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    float sdOut_dPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
     float sdOut_dPhiChange = __H2F(segmentsInGPU.dPhiChanges[outerSegmentIndex]);
     float sdOut_dPhiChange_min = __H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]);
@@ -1955,14 +1955,14 @@ __device__ bool SDL::runQuintupletDefaultAlgoEEEE(struct SDL::modules& modulesIn
     float tl_axis_y = mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float tl_axis_z = mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float sdIn_alphaRHmin = __H2F(segmentsInGPU.dPhiChangeMins[innerSegmentIndex]);
     float sdIn_alphaRHmax = __H2F(segmentsInGPU.dPhiChangeMaxs[innerSegmentIndex]);
     float betaInRHmin = betaIn + sdIn_alphaRHmin - sdIn_alpha;
     float betaInRHmax = betaIn + sdIn_alphaRHmax - sdIn_alpha;
 
-    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut - sdOut_alphaOutRHmin + sdOut_alphaOut;
     float betaOutRHmax = betaOut - sdOut_alphaOutRHmax + sdOut_alphaOut;

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -464,13 +464,13 @@ __device__ bool SDL::runSegmentDefaultAlgoEndcap(struct modules& modulesInGPU, s
     pass =  pass and ((rtOut >= rtLo) & (rtOut <= rtHi));
     if(not pass) return pass;
 
-    dPhi = deltaPhi(xIn, yIn, zIn, xOut, yOut, zOut);
+    dPhi = deltaPhi(xIn, yIn, xOut, yOut);
 
     sdCut = sdSlope;
     if(outerLayerEndcapTwoS)
     {
-        float dPhiPos_high = deltaPhi(xIn, yIn, zIn, xOutHigh, yOutHigh, zOut);
-        float dPhiPos_low = deltaPhi(xIn, yIn, zIn, xOutLow, yOutLow, zOut);
+        float dPhiPos_high = deltaPhi(xIn, yIn, xOutHigh, yOutHigh);
+        float dPhiPos_low = deltaPhi(xIn, yIn, xOutLow, yOutLow);
         
         dPhiMax = fabsf(dPhiPos_high) > fabsf(dPhiPos_low) ? dPhiPos_high : dPhiPos_low;
         dPhiMin = fabsf(dPhiPos_high) > fabsf(dPhiPos_low) ? dPhiPos_low : dPhiPos_high;
@@ -548,12 +548,12 @@ __device__ bool SDL::runSegmentDefaultAlgoBarrel(struct modules& modulesInGPU, s
 
     sdCut = sdSlope + sqrtf(sdMuls * sdMuls + sdPVoff * sdPVoff);
 
-    dPhi  = deltaPhi(xIn, yIn, zIn, xOut, yOut, zOut);
+    dPhi  = deltaPhi(xIn, yIn, xOut, yOut);
 
     pass =  pass and (fabsf(dPhi) <= sdCut);
     if(not pass) return pass;
 
-    dPhiChange = deltaPhiChange(xIn, yIn, zIn, xOut, yOut, zOut);
+    dPhiChange = deltaPhiChange(xIn, yIn, xOut, yOut);
 
     pass =  pass and (fabsf(dPhiChange) <= sdCut);
     if(not pass) return pass;

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -52,6 +52,7 @@ namespace SDL
         float* eta;
         float* phi;
         int* charge;
+        unsigned int* seedIdx;
         int* superbin;
         int8_t* pixelType;
         bool* isQuad;
@@ -81,18 +82,13 @@ namespace SDL
 //    CUDA_DEV void rmPixelSegmentFromMemory(struct segments& segmentsInGPU, unsigned int pixelSegmentArrayIndex);
 
 
-    CUDA_DEV void addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, uint16_t pixelModuleIndex, unsigned int hitIdxs[4], unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, float eta, float phi, int charge, unsigned int idx, unsigned int pixelSegmentArrayIndex, int superbin,
-            int8_t pixelType, short isQuad, float score);
+    CUDA_DEV void addPixelSegmentToMemory(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct modules& modulesInGPU, unsigned int innerMDIndex, unsigned int outerMDIndex, uint16_t pixelModuleIndex, unsigned int hitIdxs[4], unsigned int innerAnchorHitIndex, unsigned int outerAnchorHitIndex, float dPhiChange, float ptIn, float ptErr, float px, float py, float pz, float etaErr, float eta, float phi, int charge, unsigned int seedIdx, unsigned int idx, unsigned int pixelSegmentArrayIndex, int superbin, int8_t pixelType, short isQuad, float score);
 
-    CUDA_DEV bool runSegmentDefaultAlgo(struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, uint16_t& innerLowerModuleIndex, uint16_t& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float&
-        dAlphaInnerMDOuterMD, float& zLo, float& zHi, float& rtLo, float& rtHi, float& sdCut, float& dAlphaInnerMDSegmentThreshold, float& dAlphaOuterMDSegmentThreshold, float& dAlphaInnerMDOuterMDThreshold);
+    CUDA_DEV bool runSegmentDefaultAlgo(struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, uint16_t& innerLowerModuleIndex, uint16_t& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float& dAlphaInnerMDOuterMD, float& zLo, float& zHi, float& rtLo, float& rtHi, float& sdCut, float& dAlphaInnerMDSegmentThreshold, float& dAlphaOuterMDSegmentThreshold, float& dAlphaInnerMDOuterMDThreshold);
 
-    CUDA_DEV bool runSegmentDefaultAlgoBarrel(struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, uint16_t& innerLowerModuleIndex, uint16_t& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float&
-        dAlphaInnerMDOuterMD, float& zLo, float& zHi, float& sdCut, float& dAlphaInnerMDSegmentThreshold, float& dAlphaOuterMDSegmentThreshold, float& dAlphaInnerMDOuterMDThreshold);
+    CUDA_DEV bool runSegmentDefaultAlgoBarrel(struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, uint16_t& innerLowerModuleIndex, uint16_t& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float& dAlphaInnerMDOuterMD, float& zLo, float& zHi, float& sdCut, float& dAlphaInnerMDSegmentThreshold, float& dAlphaOuterMDSegmentThreshold, float& dAlphaInnerMDOuterMDThreshold);
 
-    CUDA_DEV bool runSegmentDefaultAlgoEndcap(struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, uint16_t& innerLowerModuleIndex, uint16_t& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment,
-        float& rtLo, float& rtHi, float& sdCut, float& dAlphaInnerMDSegmentThreshold, float& dAlphaOuterMDSegmentThreshold, float& dAlphaInnerMDOuterMDThreshold, float&
-        dAlphaInnerMDOuterMD);
+    CUDA_DEV bool runSegmentDefaultAlgoEndcap(struct modules& modulesInGPU, struct miniDoublets& mdsInGPU, uint16_t& innerLowerModuleIndex, uint16_t& outerLowerModuleIndex, unsigned int& innerMDIndex, unsigned int& outerMDIndex, float& zIn, float& zOut, float& rtIn, float& rtOut, float& dPhi, float& dPhiMin, float& dPhiMax, float& dPhiChange, float& dPhiChangeMin, float& dPhiChangeMax, float& dAlphaInnerMDSegment, float& dAlphaOuterMDSegment, float& rtLo, float& rtHi, float& sdCut, float& dAlphaInnerMDSegmentThreshold, float& dAlphaOuterMDSegmentThreshold, float& dAlphaInnerMDOuterMDThreshold, float& dAlphaInnerMDOuterMD);
 
     void printSegment(struct segments& segmentsInGPU, struct miniDoublets& mdsInGPU, struct hits& hitsInGPU, struct modules& modulesInGPU, unsigned int segmentIndex);
     CUDA_DEV float moduleGapSize_seg(struct modules& modulesInGPU, unsigned int moduleIndex);

--- a/SDL/TrackExtensions.cu
+++ b/SDL/TrackExtensions.cu
@@ -3555,7 +3555,7 @@ __device__ bool SDL::runExtensionDefaultAlgoBBBB(struct SDL::modules& modulesInG
     float sdlPVoff = 0.1f/rt_OutLo;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
     // Cut #3: FIXME:deltaPhiPos can be tighter
     pass = pass and (fabsf(deltaPhiPos) <= sdlCut);
     if(not pass) return pass;
@@ -3567,7 +3567,7 @@ __device__ bool SDL::runExtensionDefaultAlgoBBBB(struct SDL::modules& modulesInG
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = SDL::deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = SDL::deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #4: deltaPhiChange
     pass = pass and (fabsf(dPhi) <= sdlCut);
@@ -3583,7 +3583,7 @@ __device__ bool SDL::runExtensionDefaultAlgoBBBB(struct SDL::modules& modulesInG
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
 
-    alpha_OutUp = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+    alpha_OutUp = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
@@ -3596,19 +3596,19 @@ __device__ bool SDL::runExtensionDefaultAlgoBBBB(struct SDL::modules& modulesInG
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = alpha_InLo - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = alpha_InLo - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    betaOut = -alpha_OutUp + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
-        alpha_OutUp_highEdge = SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
-        alpha_OutUp_lowEdge = SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+        alpha_OutUp_highEdge = SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
+        alpha_OutUp_lowEdge = SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[firstMDIndex];
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
@@ -3616,8 +3616,8 @@ __device__ bool SDL::runExtensionDefaultAlgoBBBB(struct SDL::modules& modulesInG
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
 
 
-        betaOutRHmin = -alpha_OutUp_highEdge + SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z);
+        betaOutRHmin = -alpha_OutUp_highEdge + SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y);
     }
 
     //beta computation
@@ -3773,7 +3773,7 @@ __device__ bool SDL::runExtensionDefaultAlgoBBEE(struct SDL::modules& modulesInG
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff*sdlPVoff);
 
 
-    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
 
     //Cut #4: deltaPhiPos can be tighter
@@ -3787,7 +3787,7 @@ __device__ bool SDL::runExtensionDefaultAlgoBBEE(struct SDL::modules& modulesInG
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = SDL::deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = SDL::deltaPhi(midPointX, midPointY, diffX, diffY);
     // Cut #5: deltaPhiChange
     pass =  pass and (fabsf(dPhi) <= sdlCut);
     if(not pass) return pass;
@@ -3797,7 +3797,7 @@ __device__ bool SDL::runExtensionDefaultAlgoBBEE(struct SDL::modules& modulesInG
     float sdIn_alpha_max = __H2F(segmentsInGPU.dPhiChangeMaxs[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha; //weird
 
-    float sdOut_alphaOut = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+    float sdOut_alphaOut = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
     float sdOut_alphaOut_min = SDL::phi_mpi_pi(__H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMins[outerSegmentIndex]));
     float sdOut_alphaOut_max = SDL::phi_mpi_pi(__H2F(segmentsInGPU.dPhiChangeMaxs[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMaxs[outerSegmentIndex]));
@@ -3806,11 +3806,11 @@ __device__ bool SDL::runExtensionDefaultAlgoBBEE(struct SDL::modules& modulesInG
     float tl_axis_y = mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float tl_axis_z = mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
@@ -3993,7 +3993,7 @@ __device__ bool SDL::runExtensionDefaultAlgoEEEE(struct SDL::modules& modulesInG
     float sdlPVoff = 0.1f/rtOut;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
     pass =  pass and (fabsf(deltaPhiPos) <= sdlCut);
     if(not pass) return pass;
@@ -4005,7 +4005,7 @@ __device__ bool SDL::runExtensionDefaultAlgoEEEE(struct SDL::modules& modulesInG
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = SDL::deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = SDL::deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #5: deltaPhiChange
     pass =  pass and ((fabsf(dPhi) <= sdlCut));
@@ -4013,7 +4013,7 @@ __device__ bool SDL::runExtensionDefaultAlgoEEEE(struct SDL::modules& modulesInG
 
     float sdIn_alpha = __H2F(segmentsInGPU.dPhiChanges[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha; //weird
-    float sdOut_dPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[thirdMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    float sdOut_dPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
     float sdOut_dPhiChange = __H2F(segmentsInGPU.dPhiChanges[outerSegmentIndex]);
     float sdOut_dPhiChange_min = __H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]);
@@ -4027,14 +4027,14 @@ __device__ bool SDL::runExtensionDefaultAlgoEEEE(struct SDL::modules& modulesInG
     float tl_axis_y = mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float tl_axis_z = mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float sdIn_alphaRHmin = __H2F(segmentsInGPU.dPhiChangeMins[innerSegmentIndex]);
     float sdIn_alphaRHmax = __H2F(segmentsInGPU.dPhiChangeMaxs[innerSegmentIndex]);
     float betaInRHmin = betaIn + sdIn_alphaRHmin - sdIn_alpha;
     float betaInRHmax = betaIn + sdIn_alphaRHmax - sdIn_alpha;
 
-    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut - sdOut_alphaOutRHmin + sdOut_alphaOut;
     float betaOutRHmax = betaOut - sdOut_alphaOutRHmax + sdOut_alphaOut;

--- a/SDL/Tracklet.cu
+++ b/SDL/Tracklet.cu
@@ -296,7 +296,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBBB(struct modules& modulesInGPU, st
     betaOutRHmin *= betaOutMMSF;
     betaOutRHmax *= betaOutMMSF;
 
-    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), SDL::pt_betaMax); //need to confirm the range-out value of 7 GeV
 
 
     const float alphaInAbsReg = fmaxf(fabsf(alpha_InLo), asinf(fminf(rt_InLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
@@ -514,7 +514,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBEE(struct modules& modulesInGPU, st
     betaOutRHmin *= betaOutMMSF;
     betaOutRHmax *= betaOutMMSF;
 
-    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), SDL::pt_betaMax); //need to confirm the range-out value of 7 GeV
 
     const float alphaInAbsReg = fmaxf(fabsf(sdIn_alpha), asinf(fminf(rt_InLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float alphaOutAbsReg = fmaxf(fabsf(sdOut_alpha), asinf(fminf(rt_OutLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
@@ -729,7 +729,7 @@ __device__ bool SDL::runTrackletDefaultAlgoEEEE(struct modules& modulesInGPU, st
     betaOutRHmin *= betaOutMMSF;
     betaOutRHmax *= betaOutMMSF;
 
-    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), pt_betaMax); //need to confirm the range-out value of 7 GeV
+    const float dBetaMuls = sdlThetaMulsF * 4.f / fminf(fabsf(pt_beta), SDL::pt_betaMax); //need to confirm the range-out value of 7 GeV
 
     const float alphaInAbsReg = fmaxf(fabsf(sdIn_alpha), asinf(fminf(rt_InLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
     const float alphaOutAbsReg = fmaxf(fabsf(sdOut_alpha), asinf(fminf(rt_OutLo * k2Rinv1GeVf / 3.0f, sinAlphaMax)));
@@ -770,7 +770,7 @@ __device__ void SDL::runDeltaBetaIterations(float& betaIn, float& betaOut, float
         return;
     }
 
-    if (betaIn * betaOut > 0.f and (fabsf(pt_beta) < 4.f * pt_betaMax or (lIn >= 11 and fabsf(pt_beta) < 8.f * pt_betaMax)))   //and the pt_beta is well-defined; less strict for endcap-endcap
+    if (betaIn * betaOut > 0.f and (fabsf(pt_beta) < 4.f * SDL::pt_betaMax or (lIn >= 11 and fabsf(pt_beta) < 8.f * SDL::pt_betaMax)))   //and the pt_beta is well-defined; less strict for endcap-endcap
     {
 
         const float betaInUpd  = betaIn + copysignf(asinf(fminf(sdIn_dr * k2Rinv1GeVf / fabsf(pt_beta), sinAlphaMax)), betaIn); //FIXME: need a faster version
@@ -788,7 +788,7 @@ __device__ void SDL::runDeltaBetaIterations(float& betaIn, float& betaOut, float
         //2nd update
         pt_beta = dr * k2Rinv1GeVf / sinf(betaAv); //get a better pt estimate
     }
-    else if (lIn < 11 && fabsf(betaOut) < 0.2f * fabsf(betaIn) && fabsf(pt_beta) < 12.f * pt_betaMax)   //use betaIn sign as ref
+    else if (lIn < 11 && fabsf(betaOut) < 0.2f * fabsf(betaIn) && fabsf(pt_beta) < 12.f * SDL::pt_betaMax)   //use betaIn sign as ref
     {
    
         const float pt_betaIn = dr * k2Rinv1GeVf / sinf(betaIn);

--- a/SDL/Tracklet.cu
+++ b/SDL/Tracklet.cu
@@ -199,7 +199,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBBB(struct modules& modulesInGPU, st
     float sdlPVoff = 0.1f/rt_OutLo;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
     
-    deltaPhiPos = deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]); 
+    deltaPhiPos = deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]); 
     // Cut #3: FIXME:deltaPhiPos can be tighter
     pass = pass and (fabsf(deltaPhiPos) <= sdlCut);
     if(not pass) return pass;
@@ -211,7 +211,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBBB(struct modules& modulesInGPU, st
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #4: deltaPhiChange
     pass = pass and (fabsf(dPhi) <= sdlCut);
@@ -227,7 +227,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBBB(struct modules& modulesInGPU, st
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
    
-    alpha_OutUp = deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+    alpha_OutUp = deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
@@ -240,19 +240,19 @@ __device__ bool SDL::runTrackletDefaultAlgoBBBB(struct modules& modulesInGPU, st
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = alpha_InLo - deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = alpha_InLo - deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    betaOut = -alpha_OutUp + deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
-        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
-        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+        alpha_OutUp_highEdge = deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
+        alpha_OutUp_lowEdge = deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[firstMDIndex];
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
@@ -260,8 +260,8 @@ __device__ bool SDL::runTrackletDefaultAlgoBBBB(struct modules& modulesInGPU, st
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
    
   
-        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z); 
+        betaOutRHmin = -alpha_OutUp_highEdge + deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y); 
     }
 
     //beta computation
@@ -417,7 +417,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBEE(struct modules& modulesInGPU, st
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff*sdlPVoff);
 
 
-    deltaPhiPos = deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]); 
+    deltaPhiPos = deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]); 
 
 
     //Cut #4: deltaPhiPos can be tighter
@@ -431,7 +431,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBEE(struct modules& modulesInGPU, st
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
     // Cut #5: deltaPhiChange
     pass =  pass and (fabsf(dPhi) <= sdlCut);
     if(not pass) return pass;
@@ -441,7 +441,7 @@ __device__ bool SDL::runTrackletDefaultAlgoBBEE(struct modules& modulesInGPU, st
     float sdIn_alpha_max = __H2F(segmentsInGPU.dPhiChangeMaxs[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha; //weird
 
-    float sdOut_alphaOut = deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+    float sdOut_alphaOut = deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
     float sdOut_alphaOut_min = phi_mpi_pi(__H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMins[outerSegmentIndex]));
     float sdOut_alphaOut_max = phi_mpi_pi(__H2F(segmentsInGPU.dPhiChangeMaxs[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMaxs[outerSegmentIndex]));
@@ -450,11 +450,11 @@ __device__ bool SDL::runTrackletDefaultAlgoBBEE(struct modules& modulesInGPU, st
     float tl_axis_y = mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float tl_axis_z = mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    betaIn = sdIn_alpha - deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = sdIn_alpha - deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    betaOut = -sdOut_alphaOut + deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -sdOut_alphaOut + deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
@@ -637,7 +637,7 @@ __device__ bool SDL::runTrackletDefaultAlgoEEEE(struct modules& modulesInGPU, st
     float sdlPVoff = 0.1f/rtOut;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]); 
+    deltaPhiPos = deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]); 
 
     pass =  pass and (fabsf(deltaPhiPos) <= sdlCut);
     if(not pass) return pass;
@@ -649,7 +649,7 @@ __device__ bool SDL::runTrackletDefaultAlgoEEEE(struct modules& modulesInGPU, st
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
    
-    dPhi = deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #5: deltaPhiChange
     pass =  pass and ((fabsf(dPhi) <= sdlCut));
@@ -657,7 +657,7 @@ __device__ bool SDL::runTrackletDefaultAlgoEEEE(struct modules& modulesInGPU, st
 
     float sdIn_alpha = __H2F(segmentsInGPU.dPhiChanges[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha; //weird
-    float sdOut_dPhiPos = deltaPhi(mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[thirdMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    float sdOut_dPhiPos = deltaPhi(mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
     float sdOut_dPhiChange = __H2F(segmentsInGPU.dPhiChanges[outerSegmentIndex]);
     float sdOut_dPhiChange_min = __H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]);
@@ -671,14 +671,14 @@ __device__ bool SDL::runTrackletDefaultAlgoEEEE(struct modules& modulesInGPU, st
     float tl_axis_y = mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float tl_axis_z = mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
     
-    betaIn = sdIn_alpha - deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = sdIn_alpha - deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float sdIn_alphaRHmin = __H2F(segmentsInGPU.dPhiChangeMins[innerSegmentIndex]);
     float sdIn_alphaRHmax = __H2F(segmentsInGPU.dPhiChangeMaxs[innerSegmentIndex]);
     float betaInRHmin = betaIn + sdIn_alphaRHmin - sdIn_alpha;
     float betaInRHmax = betaIn + sdIn_alphaRHmax - sdIn_alpha;
 
-    betaOut = -sdOut_alphaOut + deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -sdOut_alphaOut + deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut - sdOut_alphaOutRHmin + sdOut_alphaOut;
     float betaOutRHmax = betaOut - sdOut_alphaOutRHmax + sdOut_alphaOut;

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -779,7 +779,7 @@ __device__ bool SDL::runTripletDefaultAlgoBBBB(struct SDL::modules& modulesInGPU
     float sdlPVoff = 0.1f/rt_OutLo;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
     // Cut #3: FIXME:deltaPhiPos can be tighter
     pass = pass and (fabsf(deltaPhiPos) <= sdlCut);
     if(not pass) return pass;
@@ -791,7 +791,7 @@ __device__ bool SDL::runTripletDefaultAlgoBBBB(struct SDL::modules& modulesInGPU
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = SDL::deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = SDL::deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #4: deltaPhiChange
     pass = pass and (fabsf(dPhi) <= sdlCut);
@@ -807,7 +807,7 @@ __device__ bool SDL::runTripletDefaultAlgoBBBB(struct SDL::modules& modulesInGPU
 
     float alpha_OutUp,alpha_OutUp_highEdge,alpha_OutUp_lowEdge;
 
-    alpha_OutUp = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+    alpha_OutUp = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
     alpha_OutUp_highEdge = alpha_OutUp;
     alpha_OutUp_lowEdge = alpha_OutUp;
@@ -820,19 +820,19 @@ __device__ bool SDL::runTripletDefaultAlgoBBBB(struct SDL::modules& modulesInGPU
     float tl_axis_lowEdge_x = tl_axis_x;
     float tl_axis_lowEdge_y = tl_axis_y;
 
-    betaIn = alpha_InLo - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = alpha_InLo - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    betaOut = -alpha_OutUp + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -alpha_OutUp + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
 
     if(isEC_lastLayer)
     {
-        alpha_OutUp_highEdge = SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
-        alpha_OutUp_lowEdge = SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+        alpha_OutUp_highEdge = SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
+        alpha_OutUp_lowEdge = SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorLowEdgeX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
         tl_axis_highEdge_x = mdsInGPU.anchorHighEdgeX[fourthMDIndex] - mdsInGPU.anchorX[firstMDIndex];
         tl_axis_highEdge_y = mdsInGPU.anchorHighEdgeY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
@@ -840,8 +840,8 @@ __device__ bool SDL::runTripletDefaultAlgoBBBB(struct SDL::modules& modulesInGPU
         tl_axis_lowEdge_y = mdsInGPU.anchorLowEdgeY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
 
 
-        betaOutRHmin = -alpha_OutUp_highEdge + SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y, tl_axis_z);
-        betaOutRHmax = -alpha_OutUp_lowEdge + SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y, tl_axis_z);
+        betaOutRHmin = -alpha_OutUp_highEdge + SDL::deltaPhi(mdsInGPU.anchorHighEdgeX[fourthMDIndex], mdsInGPU.anchorHighEdgeY[fourthMDIndex], tl_axis_highEdge_x, tl_axis_highEdge_y);
+        betaOutRHmax = -alpha_OutUp_lowEdge + SDL::deltaPhi(mdsInGPU.anchorLowEdgeX[fourthMDIndex], mdsInGPU.anchorLowEdgeY[fourthMDIndex], tl_axis_lowEdge_x, tl_axis_lowEdge_y);
     }
 
     //beta computation
@@ -997,7 +997,7 @@ __device__ bool SDL::runTripletDefaultAlgoBBEE(struct SDL::modules& modulesInGPU
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff*sdlPVoff);
 
 
-    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
 
     //Cut #4: deltaPhiPos can be tighter
@@ -1011,7 +1011,7 @@ __device__ bool SDL::runTripletDefaultAlgoBBEE(struct SDL::modules& modulesInGPU
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = SDL::deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = SDL::deltaPhi(midPointX, midPointY, diffX, diffY);
     // Cut #5: deltaPhiChange
     pass =  pass and (fabsf(dPhi) <= sdlCut);
     if(not pass) return pass;
@@ -1021,7 +1021,7 @@ __device__ bool SDL::runTripletDefaultAlgoBBEE(struct SDL::modules& modulesInGPU
     float sdIn_alpha_max = __H2F(segmentsInGPU.dPhiChangeMaxs[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha; //weird
 
-    float sdOut_alphaOut = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[thirdMDIndex]);
+    float sdOut_alphaOut = SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]);
 
     float sdOut_alphaOut_min = SDL::phi_mpi_pi(__H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMins[outerSegmentIndex]));
     float sdOut_alphaOut_max = SDL::phi_mpi_pi(__H2F(segmentsInGPU.dPhiChangeMaxs[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMaxs[outerSegmentIndex]));
@@ -1030,11 +1030,11 @@ __device__ bool SDL::runTripletDefaultAlgoBBEE(struct SDL::modules& modulesInGPU
     float tl_axis_y = mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float tl_axis_z = mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut;
     float betaOutRHmax = betaOut;
@@ -1217,7 +1217,7 @@ __device__ bool SDL::runTripletDefaultAlgoEEEE(struct SDL::modules& modulesInGPU
     float sdlPVoff = 0.1f/rtOut;
     sdlCut = alpha1GeV_OutLo + sqrtf(sdlMuls * sdlMuls + sdlPVoff * sdlPVoff);
 
-    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    deltaPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
     pass =  pass and (fabsf(deltaPhiPos) <= sdlCut);
     if(not pass) return pass;
@@ -1229,7 +1229,7 @@ __device__ bool SDL::runTripletDefaultAlgoEEEE(struct SDL::modules& modulesInGPU
     float diffY = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float diffZ = mdsInGPU.anchorZ[thirdMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    dPhi = SDL::deltaPhi(midPointX, midPointY, midPointZ, diffX, diffY, diffZ);
+    dPhi = SDL::deltaPhi(midPointX, midPointY, diffX, diffY);
 
     // Cut #5: deltaPhiChange
     pass =  pass and ((fabsf(dPhi) <= sdlCut));
@@ -1237,7 +1237,7 @@ __device__ bool SDL::runTripletDefaultAlgoEEEE(struct SDL::modules& modulesInGPU
 
     float sdIn_alpha = __H2F(segmentsInGPU.dPhiChanges[innerSegmentIndex]);
     float sdOut_alpha = sdIn_alpha; //weird
-    float sdOut_dPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorZ[thirdMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex]);
+    float sdOut_dPhiPos = SDL::deltaPhi(mdsInGPU.anchorX[thirdMDIndex], mdsInGPU.anchorY[thirdMDIndex], mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex]);
 
     float sdOut_dPhiChange = __H2F(segmentsInGPU.dPhiChanges[outerSegmentIndex]);
     float sdOut_dPhiChange_min = __H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]);
@@ -1251,14 +1251,14 @@ __device__ bool SDL::runTripletDefaultAlgoEEEE(struct SDL::modules& modulesInGPU
     float tl_axis_y = mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
     float tl_axis_z = mdsInGPU.anchorZ[fourthMDIndex] - mdsInGPU.anchorZ[firstMDIndex];
 
-    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorZ[firstMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaIn = sdIn_alpha - SDL::deltaPhi(mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorY[firstMDIndex], tl_axis_x, tl_axis_y);
 
     float sdIn_alphaRHmin = __H2F(segmentsInGPU.dPhiChangeMins[innerSegmentIndex]);
     float sdIn_alphaRHmax = __H2F(segmentsInGPU.dPhiChangeMaxs[innerSegmentIndex]);
     float betaInRHmin = betaIn + sdIn_alphaRHmin - sdIn_alpha;
     float betaInRHmax = betaIn + sdIn_alphaRHmax - sdIn_alpha;
 
-    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], mdsInGPU.anchorZ[fourthMDIndex], tl_axis_x, tl_axis_y, tl_axis_z);
+    betaOut = -sdOut_alphaOut + SDL::deltaPhi(mdsInGPU.anchorX[fourthMDIndex], mdsInGPU.anchorY[fourthMDIndex], tl_axis_x, tl_axis_y);
 
     float betaOutRHmin = betaOut - sdOut_alphaOutRHmin + sdOut_alphaOut;
     float betaOutRHmax = betaOut - sdOut_alphaOutRHmax + sdOut_alphaOut;

--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -312,6 +312,7 @@ void run_sdl()
     std::vector<std::vector<float>> out_etaErr_vec;
     std::vector<std::vector<float>> out_phi_vec;
     std::vector<std::vector<int>> out_charge_vec;
+    std::vector<std::vector<unsigned int>> out_seedIdx_vec;
     std::vector<std::vector<int>> out_superbin_vec;
     std::vector<std::vector<int8_t>> out_pixelType_vec;
     std::vector<std::vector<short>> out_isQuad_vec;
@@ -321,7 +322,6 @@ void run_sdl()
     // Looping input file
     while (ana.looper.nextEvent())
     {
-
         // if (ana.looper.getCurrentEventIndex() ==49) {continue;}
         if (ana.verbose >= 1)
             std::cout << "PreLoading event number = " << ana.looper.getCurrentEventIndex() << std::endl;
@@ -347,6 +347,7 @@ void run_sdl()
                                               out_etaErr_vec,
                                               out_phi_vec,
                                               out_charge_vec,
+                                              out_seedIdx_vec,
                                               out_superbin_vec,
                                               out_pixelType_vec,
                                               out_isQuad_vec);
@@ -410,6 +411,7 @@ void run_sdl()
                                                            out_etaErr_vec.at(evt),
                                                            out_phi_vec.at(evt),
                                                            out_charge_vec.at(evt),
+                                                           out_seedIdx_vec.at(evt),
                                                            out_superbin_vec.at(evt),
                                                            out_pixelType_vec.at(evt),
                                                            out_isQuad_vec.at(evt));

--- a/code/core/AccessHelper.cc
+++ b/code/core/AccessHelper.cc
@@ -38,11 +38,8 @@ std::vector<unsigned int> getPixelHitIdxsFrompLS(SDL::Event* event, unsigned int
 //____________________________________________________________________________________________
 std::vector<unsigned int> getPixelHitTypesFrompLS(SDL::Event* event, unsigned int pLS)
 {
-    SDL::hits& hitsInGPU = *(event->getHits());
     std::vector<unsigned int> hits = getPixelHitsFrompLS(event, pLS);
-    std::vector<unsigned int> hittypes;
-    for (auto& hit : hits)
-        hittypes.push_back(0);
+    std::vector<unsigned int> hittypes(hits.size(), 0);
     return hittypes;
 }
 
@@ -138,7 +135,6 @@ std::vector<unsigned int> getLSsFromT5(SDL::Event* event, unsigned int T5)
 //____________________________________________________________________________________________
 std::vector<unsigned int> getMDsFromT5(SDL::Event* event, unsigned int T5)
 {
-    SDL::segments& segments_ = *(event->getSegments());
     std::vector<unsigned int> LSs = getLSsFromT5(event, T5);
     std::vector<unsigned int> MDs_0 = getMDsFromLS(event, LSs[0]);
     std::vector<unsigned int> MDs_1 = getMDsFromLS(event, LSs[1]);

--- a/code/core/trkCore.h
+++ b/code/core/trkCore.h
@@ -66,6 +66,7 @@ void addInputsToLineSegmentTrackingPreLoad(std::vector<std::vector<float>> &out_
                                            std::vector<std::vector<float>> &out_etaErr_vec,
                                            std::vector<std::vector<float>> &out_phi_vec,
                                            std::vector<std::vector<int>> &out_charge_vec,
+                                           std::vector<std::vector<unsigned int>> &out_seedIdx_vec,
                                            std::vector<std::vector<int>> &out_superbin_vec,
                                            std::vector<std::vector<int8_t>> &out_pixelType_vec,
                                            std::vector<std::vector<short>> &out_isQuad_vec);
@@ -91,6 +92,7 @@ float addInputsToEventPreLoad(SDL::Event *event,
                               std::vector<float> etaErr_vec,
                               std::vector<float> phi_vec,
                               std::vector<int> charge_vec,
+                              std::vector<unsigned int> seedIdx_vec,
                               std::vector<int> superbin_vec,
                               std::vector<int8_t> pixelType_vec,
                               std::vector<short> isQuad_vec);

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -313,7 +313,6 @@ std::tuple<float, float, float, vector<unsigned int>, vector<unsigned int>> pars
     SDL::trackCandidates& trackCandidatesInGPU = (*event->getTrackCandidates());
     SDL::triplets& tripletsInGPU = (*event->getTriplets());
     SDL::segments& segmentsInGPU = (*event->getSegments());
-    SDL::miniDoublets& miniDoubletsInGPU = (*event->getMiniDoublets());
     SDL::hits& hitsInGPU = (*event->getHits());
 
     //
@@ -452,7 +451,6 @@ std::tuple<float, float, float, vector<unsigned int>, vector<unsigned int>> pars
     SDL::trackCandidates& trackCandidatesInGPU = (*event->getTrackCandidates());
     SDL::triplets& tripletsInGPU = (*event->getTriplets());
     SDL::segments& segmentsInGPU = (*event->getSegments());
-    SDL::miniDoublets& miniDoubletsInGPU = (*event->getMiniDoublets());
     SDL::hits& hitsInGPU = (*event->getHits());
 
     //


### PR DESCRIPTION
Zeroth version of a class, called LST, which can be called by CMSSW producer and run the full algorithm.

The input expected by the class is all the info we are getting from the tracking NTuple but per event, i.e. no preloading. The output that it spits out are the TC pT, η, φ, length and hit indices, to be consumed by downstream producers in the CMSSW configuration and create CMSSW track candidates.

The methods in the LST class are simplified versions of the functions that we run in the standalone scripts. For the class to run within CMSSW, some of these functions needed to be copied and possibly rewrittten, since they need to be included in `libsdl`. Starting from the needs of this PR, there is an addition to the Hits.cuh functions and a simplification of some other functions there.

Right now, the LST geometry is set up in each event within CMSSW. This is suboptimal and is expected to be fixed in the near future. However, I envision this development to go in a next PR.

Related CMSSW PR: SegmentLinking/cmssw#2

Related slides: https://cernbox.cern.ch/index.php/s/t7M0BfsyiEVN7eu