### PR TITLE
include <limits> to cover usage of std::numeric_limits

### DIFF
--- a/code/rooutil/cxxopts.h
+++ b/code/rooutil/cxxopts.h
@@ -37,6 +37,7 @@ THE SOFTWARE.
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <limits>
 
 #ifdef __cpp_lib_optional
 #include <optional>


### PR DESCRIPTION
without this the compilation failed on cgpu1 (el8) on top of CMSSW_13_0_0_pre4
