### PR TITLE
bug fix in T3

### DIFF
--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -532,7 +532,7 @@ __device__ bool SDL::passPointingConstraintBBE(struct SDL::modules& modulesInGPU
     if(not pass) return pass;
 
     float dLum = copysignf(SDL::deltaZLum, zIn);
-    bool isOutSgInnerMDPS = modulesInGPU.moduleType[outerOuterLowerModuleIndex] == SDL::PS;
+    bool isOutSgInnerMDPS = modulesInGPU.moduleType[middleLowerModuleIndex] == SDL::PS;
     float rtGeom1 = isOutSgInnerMDPS ? SDL::pixelPSZpitch : SDL::strip2SZpitch;
     float zGeom1 = copysignf(zGeom,zIn);
     float rtLo = rtIn * (1.f + (zOut - zIn - zGeom1) / (zIn + zGeom1 + dLum) / dzDrtScale) - rtGeom1; //slope correction only on the lower end
@@ -623,7 +623,7 @@ __device__ bool SDL::passPointingConstraintEEE(struct SDL::modules& modulesInGPU
     pass = pass and ((rtOut >= rtLo) & (rtOut <= rtHi));
     if(not pass) return pass;
     
-    bool isInSgOuterMDPS = modulesInGPU.moduleType[outerOuterLowerModuleIndex] == SDL::PS;
+    bool isInSgOuterMDPS = modulesInGPU.moduleType[middleLowerModuleIndex] == SDL::PS;
 
     float drOutIn = rtOut - rtIn;
     float drtSDIn = rtMid - rtIn;


### PR DESCRIPTION
a stale bug in the T3 code, with incorrect assignment of inner module index.
performance plots doesn't have obvious changes after fixing
master: http://uaf-10.t2.ucsd.edu/~yagu/SDL_GPU_plots/T3bug_fix/master_16dc15-PU200/
after fix: http://uaf-10.t2.ucsd.edu/~yagu/SDL_GPU_plots/T3bug_fix/fix_16dc15D-PU200/
comparison to master: http://uaf-10.t2.ucsd.edu/~yagu/SDL_GPU_plots/T3bug_fix/comparison_16dc15-PU200_16dc15D-PU200/