### PR TITLE
Move Track Candidate Kernels to Alpaka

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1770,11 +1770,8 @@ void SDL::Event::createPixelQuintuplets()
     auto const addpT5asTrackCandidateInGPUTask(alpaka::createTaskKernel<Acc>(
         addpT5asTrackCandidateInGPU_workDiv,
         addpT5asTrackCandidateInGPU_kernel,
-        *modulesInGPU,
         *pixelQuintupletsInGPU,
         *trackCandidatesInGPU,
-        *segmentsInGPU,
-        *tripletsInGPU,
         *quintupletsInGPU));
 
     alpaka::enqueue(queue, addpT5asTrackCandidateInGPUTask);

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -111,12 +111,12 @@ namespace SDL
         unsigned int getNumberOfTripletsByLayerBarrel(unsigned int layer);
         unsigned int getNumberOfTripletsByLayerEndcap(unsigned int layer);
 
-        unsigned int getNumberOfTrackCandidates();
-        unsigned int getNumberOfPixelTrackCandidates();
-        unsigned int getNumberOfPT5TrackCandidates();
-        unsigned int getNumberOfPT3TrackCandidates();
-        unsigned int getNumberOfT5TrackCandidates();
-        unsigned int getNumberOfPLSTrackCandidates();
+        int getNumberOfTrackCandidates();
+        int getNumberOfPixelTrackCandidates();
+        int getNumberOfPT5TrackCandidates();
+        int getNumberOfPT3TrackCandidates();
+        int getNumberOfT5TrackCandidates();
+        int getNumberOfPLSTrackCandidates();
 
         unsigned int getNumberOfQuintuplets();
         unsigned int getNumberOfQuintupletsByLayer(unsigned int layer);

--- a/SDL/Hit.cuh
+++ b/SDL/Hit.cuh
@@ -145,6 +145,21 @@ namespace SDL
         int sign_b = (b < 0) ? -1 : 1;
         return sign_a * sign_b * a;
     };
+
+    template<typename TAcc>
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE float calculate_dPhi(const TAcc& acc, float phi1, float phi2)
+    {
+        // Calculate dPhi
+        float dPhi = alpaka::math::abs(acc, phi1 - phi2);
+
+        // Adjust dPhi if it is greater than pi
+        if (dPhi > float(M_PI))
+        {
+            dPhi = dPhi - 2 * float(M_PI);
+        }
+
+        return dPhi;
+    };
 }
 #endif
 

--- a/SDL/Hit.cuh
+++ b/SDL/Hit.cuh
@@ -146,20 +146,22 @@ namespace SDL
         return sign_a * sign_b * a;
     };
 
-    template<typename TAcc>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE float calculate_dPhi(const TAcc& acc, float phi1, float phi2)
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE float calculate_dPhi(float phi1, float phi2)
     {
         // Calculate dPhi
-        float dPhi = alpaka::math::abs(acc, phi1 - phi2);
+        float dPhi = phi1 - phi2;
 
-        // Adjust dPhi if it is greater than pi
+        // Normalize dPhi to be between -pi and pi
         if (dPhi > float(M_PI))
         {
-            dPhi = dPhi - 2 * float(M_PI);
+            dPhi -= 2 * float(M_PI);
+        }
+        else if (dPhi < -float(M_PI))
+        {
+            dPhi += 2 * float(M_PI);
         }
 
         return dPhi;
     };
 }
 #endif
-

--- a/SDL/Kernels.cuh
+++ b/SDL/Kernels.cuh
@@ -200,28 +200,6 @@ namespace SDL
         matched[1] = nMatched;
     };
 
-    template<typename TAcc, typename TObject>
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE float calculate_dPhi(const TAcc& acc,
-                                                        const TObject& obj, // LST Object that must have a phi field
-                                                        unsigned int idx1, // First index of LST Obj for dPhi calc
-                                                        unsigned int idx2) // Second index of LST Obj for dPhi calc
-    {
-        // Extract the phi values for the given indices
-        float phi1 = __H2F(obj.phi[idx1]);
-        float phi2 = __H2F(obj.phi[idx2]);
-
-        // Calculate dPhi
-        float dPhi = alpaka::math::abs(acc, phi1 - phi2);
-
-        // Adjust dPhi if it is greater than pi
-        if (dPhi > float(M_PI))
-        {
-            dPhi = dPhi - 2 * float(M_PI);
-        }
-
-        return dPhi;
-    }
-
     struct removeDupQuintupletsInGPUAfterBuild
     {
         template<typename TAcc>
@@ -247,6 +225,7 @@ namespace SDL
                 {
                     unsigned int ix = quintupletModuleIndices_lowmod1 + ix1;
                     float eta1 = __H2F(quintupletsInGPU.eta[ix]);
+                    float phi1 = __H2F(quintupletsInGPU.phi[ix]);
                     float score_rphisum1 = __H2F(quintupletsInGPU.score_rphisum[ix]);
                     int nQuintuplets_lowmod = quintupletsInGPU.nQuintuplets[lowmod1];
                     int quintupletModuleIndices_lowmod = rangesInGPU.quintupletModuleIndices[lowmod1];
@@ -258,8 +237,9 @@ namespace SDL
                             continue;
 
                         float eta2 = __H2F(quintupletsInGPU.eta[jx]);
+                        float phi2 = __H2F(quintupletsInGPU.phi[jx]);
                         float dEta = alpaka::math::abs(acc, eta1 - eta2);
-                        float dPhi = calculate_dPhi(acc, quintupletsInGPU, ix, jx);
+                        float dPhi = SDL::calculate_dPhi(acc, phi1, phi2);
                         float score_rphisum2 = __H2F(quintupletsInGPU.score_rphisum[jx]);
 
                         if (dEta > 0.1f)
@@ -339,13 +319,15 @@ namespace SDL
                                 continue;
 
                             float eta1 = __H2F(quintupletsInGPU.eta[ix]);
+                            float phi1 = __H2F(quintupletsInGPU.phi[ix]);
                             float score_rphisum1 = __H2F(quintupletsInGPU.score_rphisum[ix]);
 
                             float eta2 = __H2F(quintupletsInGPU.eta[jx]);
+                            float phi2 = __H2F(quintupletsInGPU.phi[jx]);
                             float score_rphisum2 = __H2F(quintupletsInGPU.score_rphisum[jx]);
 
                             float dEta = alpaka::math::abs(acc, eta1-eta2);
-                            float dPhi = calculate_dPhi(acc, quintupletsInGPU, ix, jx);
+                            float dPhi = SDL::calculate_dPhi(acc, phi1, phi2);
 
                             if (dEta > 0.1f)
                                 continue;
@@ -497,6 +479,7 @@ namespace SDL
                 phits1[2] = segmentsInGPU.pLSHitsIdxs[ix].z;
                 phits1[3] = segmentsInGPU.pLSHitsIdxs[ix].w;
                 float eta_pix1 = segmentsInGPU.eta[ix];
+                float phi_pix1 = segmentsInGPU.phi[ix];
 
                 for(int jx = globalThreadIdx[2]; jx < nPixelSegments; jx += gridThreadExtent[2])
                 {
@@ -522,6 +505,8 @@ namespace SDL
                     phits2[1] = segmentsInGPU.pLSHitsIdxs[jx].y;
                     phits2[2] = segmentsInGPU.pLSHitsIdxs[jx].z;
                     phits2[3] = segmentsInGPU.pLSHitsIdxs[jx].w;
+
+                    float phi_pix2 = segmentsInGPU.phi[jx];
 
                     int npMatched = 0;
                     for (int i = 0; i < 4; i++)
@@ -554,7 +539,7 @@ namespace SDL
                     if(secondpass)
                     {
                         float dEta = alpaka::math::abs(acc, eta_pix1 - eta_pix2);
-                        float dPhi = calculate_dPhi(acc, segmentsInGPU, ix, jx);
+                        float dPhi = SDL::calculate_dPhi(acc, phi_pix1, phi_pix2);
 
                         float dR2 = dEta*dEta + dPhi*dPhi;
                         if(npMatched >= 1 or dR2 < 0.00075f and (ix < jx))

--- a/SDL/Kernels.cuh
+++ b/SDL/Kernels.cuh
@@ -239,7 +239,7 @@ namespace SDL
                         float eta2 = __H2F(quintupletsInGPU.eta[jx]);
                         float phi2 = __H2F(quintupletsInGPU.phi[jx]);
                         float dEta = alpaka::math::abs(acc, eta1 - eta2);
-                        float dPhi = SDL::calculate_dPhi(acc, phi1, phi2);
+                        float dPhi = SDL::calculate_dPhi(phi1, phi2);
                         float score_rphisum2 = __H2F(quintupletsInGPU.score_rphisum[jx]);
 
                         if (dEta > 0.1f)
@@ -327,7 +327,7 @@ namespace SDL
                             float score_rphisum2 = __H2F(quintupletsInGPU.score_rphisum[jx]);
 
                             float dEta = alpaka::math::abs(acc, eta1-eta2);
-                            float dPhi = SDL::calculate_dPhi(acc, phi1, phi2);
+                            float dPhi = SDL::calculate_dPhi(phi1, phi2);
 
                             if (dEta > 0.1f)
                                 continue;
@@ -484,6 +484,8 @@ namespace SDL
                 for(int jx = globalThreadIdx[2]; jx < nPixelSegments; jx += gridThreadExtent[2])
                 {
                     float eta_pix2 = segmentsInGPU.eta[jx];
+                    float phi_pix2 = segmentsInGPU.phi[jx];
+
                     if (ix == jx)
                         continue;
 
@@ -505,8 +507,6 @@ namespace SDL
                     phits2[1] = segmentsInGPU.pLSHitsIdxs[jx].y;
                     phits2[2] = segmentsInGPU.pLSHitsIdxs[jx].z;
                     phits2[3] = segmentsInGPU.pLSHitsIdxs[jx].w;
-
-                    float phi_pix2 = segmentsInGPU.phi[jx];
 
                     int npMatched = 0;
                     for (int i = 0; i < 4; i++)
@@ -539,7 +539,7 @@ namespace SDL
                     if(secondpass)
                     {
                         float dEta = alpaka::math::abs(acc, eta_pix1 - eta_pix2);
-                        float dPhi = SDL::calculate_dPhi(acc, phi_pix1, phi_pix2);
+                        float dPhi = SDL::calculate_dPhi(phi_pix1, phi_pix2);
 
                         float dR2 = dEta*dEta + dPhi*dPhi;
                         if(npMatched >= 1 or dR2 < 0.00075f and (ix < jx))

--- a/SDL/TrackCandidate.cu
+++ b/SDL/TrackCandidate.cu
@@ -1,18 +1,15 @@
 #include "TrackCandidate.cuh"
 
-#include "allocate.h"
-
-
 void SDL::trackCandidates::resetMemory(unsigned int maxTrackCandidates,cudaStream_t stream)
 {
     cudaMemsetAsync(trackCandidateType,0, maxTrackCandidates * sizeof(short),stream);
     cudaMemsetAsync(directObjectIndices, 0, maxTrackCandidates * sizeof(unsigned int),stream);
     cudaMemsetAsync(objectIndices, 0,2 * maxTrackCandidates * sizeof(unsigned int),stream);
-    cudaMemsetAsync(nTrackCandidates, 0,sizeof(unsigned int),stream);
-    cudaMemsetAsync(nTrackCandidatespT3, 0,sizeof(unsigned int),stream);
-    cudaMemsetAsync(nTrackCandidatesT5, 0,sizeof(unsigned int),stream);
-    cudaMemsetAsync(nTrackCandidatespT5,0, sizeof(unsigned int),stream);
-    cudaMemsetAsync(nTrackCandidatespLS, 0,sizeof(unsigned int),stream);
+    cudaMemsetAsync(nTrackCandidates, 0,sizeof(int),stream);
+    cudaMemsetAsync(nTrackCandidatespT3, 0,sizeof(int),stream);
+    cudaMemsetAsync(nTrackCandidatesT5, 0,sizeof(int),stream);
+    cudaMemsetAsync(nTrackCandidatespT5,0, sizeof(int),stream);
+    cudaMemsetAsync(nTrackCandidatespLS, 0,sizeof(int),stream);
 
     cudaMemsetAsync(logicalLayers, 0, 7 * maxTrackCandidates * sizeof(uint8_t), stream);
     cudaMemsetAsync(lowerModuleIndices, 0, 7 * maxTrackCandidates * sizeof(uint16_t), stream);
@@ -30,11 +27,11 @@ void SDL::createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCan
     trackCandidatesInGPU.trackCandidateType = (short*)cms::cuda::allocate_device(dev,maxTrackCandidates * sizeof(short),stream);
     trackCandidatesInGPU.directObjectIndices = (unsigned int*)cms::cuda::allocate_device(dev,maxTrackCandidates * sizeof(unsigned int),stream);
     trackCandidatesInGPU.objectIndices = (unsigned int*)cms::cuda::allocate_device(dev,maxTrackCandidates * 2*sizeof(unsigned int),stream);
-    trackCandidatesInGPU.nTrackCandidates= (unsigned int*)cms::cuda::allocate_device(dev, sizeof(unsigned int),stream);
-    trackCandidatesInGPU.nTrackCandidatespT3= (unsigned int*)cms::cuda::allocate_device(dev, sizeof(unsigned int),stream);
-    trackCandidatesInGPU.nTrackCandidatesT5= (unsigned int*)cms::cuda::allocate_device(dev, sizeof(unsigned int),stream);
-    trackCandidatesInGPU.nTrackCandidatespT5= (unsigned int*)cms::cuda::allocate_device(dev, sizeof(unsigned int),stream);
-    trackCandidatesInGPU.nTrackCandidatespLS= (unsigned int*)cms::cuda::allocate_device(dev, sizeof(unsigned int),stream);
+    trackCandidatesInGPU.nTrackCandidates= (int*)cms::cuda::allocate_device(dev, sizeof(int),stream);
+    trackCandidatesInGPU.nTrackCandidatespT3= (int*)cms::cuda::allocate_device(dev, sizeof(int),stream);
+    trackCandidatesInGPU.nTrackCandidatesT5= (int*)cms::cuda::allocate_device(dev, sizeof(int),stream);
+    trackCandidatesInGPU.nTrackCandidatespT5= (int*)cms::cuda::allocate_device(dev, sizeof(int),stream);
+    trackCandidatesInGPU.nTrackCandidatespLS= (int*)cms::cuda::allocate_device(dev, sizeof(int),stream);
 
     trackCandidatesInGPU.logicalLayers = (uint8_t*)cms::cuda::allocate_device(dev, 7 * maxTrackCandidates * sizeof(uint8_t), stream);
     trackCandidatesInGPU.lowerModuleIndices = (uint16_t*)cms::cuda::allocate_device(dev, 7 * maxTrackCandidates * sizeof(uint16_t), stream);
@@ -47,11 +44,11 @@ void SDL::createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCan
     cudaMalloc(&trackCandidatesInGPU.trackCandidateType, maxTrackCandidates * sizeof(short));
     cudaMalloc(&trackCandidatesInGPU.directObjectIndices, maxTrackCandidates * sizeof(unsigned int));
     cudaMalloc(&trackCandidatesInGPU.objectIndices, 2 * maxTrackCandidates * sizeof(unsigned int));
-    cudaMalloc(&trackCandidatesInGPU.nTrackCandidates, sizeof(unsigned int));
-    cudaMalloc(&trackCandidatesInGPU.nTrackCandidatespT3, sizeof(unsigned int));
-    cudaMalloc(&trackCandidatesInGPU.nTrackCandidatesT5, sizeof(unsigned int));
-    cudaMalloc(&trackCandidatesInGPU.nTrackCandidatespT5, sizeof(unsigned int));
-    cudaMalloc(&trackCandidatesInGPU.nTrackCandidatespLS, sizeof(unsigned int));
+    cudaMalloc(&trackCandidatesInGPU.nTrackCandidates, sizeof(int));
+    cudaMalloc(&trackCandidatesInGPU.nTrackCandidatespT3, sizeof(int));
+    cudaMalloc(&trackCandidatesInGPU.nTrackCandidatesT5, sizeof(int));
+    cudaMalloc(&trackCandidatesInGPU.nTrackCandidatespT5, sizeof(int));
+    cudaMalloc(&trackCandidatesInGPU.nTrackCandidatespLS, sizeof(int));
 
     cudaMalloc(&trackCandidatesInGPU.logicalLayers, 7 * maxTrackCandidates * sizeof(uint8_t));
     cudaMalloc(&trackCandidatesInGPU.lowerModuleIndices, 7 * maxTrackCandidates * sizeof(uint16_t));
@@ -60,11 +57,11 @@ void SDL::createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCan
     cudaMalloc(&trackCandidatesInGPU.centerY, maxTrackCandidates * sizeof(FPX));
     cudaMalloc(&trackCandidatesInGPU.radius , maxTrackCandidates * sizeof(FPX));
 #endif
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidates,0, sizeof(unsigned int), stream);
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatesT5,0, sizeof(unsigned int), stream);
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT3,0, sizeof(unsigned int), stream);
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT5,0, sizeof(unsigned int), stream);
-    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespLS,0, sizeof(unsigned int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidates,0, sizeof(int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatesT5,0, sizeof(int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT3,0, sizeof(int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespT5,0, sizeof(int), stream);
+    cudaMemsetAsync(trackCandidatesInGPU.nTrackCandidatespLS,0, sizeof(int), stream);
     cudaMemsetAsync(trackCandidatesInGPU.logicalLayers, 0, 7 * maxTrackCandidates * sizeof(uint8_t), stream);
     cudaMemsetAsync(trackCandidatesInGPU.lowerModuleIndices, 0, 7 * maxTrackCandidates * sizeof(uint16_t), stream);
     cudaMemsetAsync(trackCandidatesInGPU.hitIndices, 0, 14 * maxTrackCandidates * sizeof(unsigned int), stream);
@@ -167,250 +164,4 @@ void SDL::trackCandidates::freeMemory(cudaStream_t stream)
     cudaFree(radius);
     
     cudaStreamSynchronize(stream);
-}
-
-__global__ void SDL::addpT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU, struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,struct SDL::quintuplets& quintupletsInGPU)
-{
-    unsigned int nPixelQuintuplets = *pixelQuintupletsInGPU.nPixelQuintuplets;
-    for(int pixelQuintupletIndex = blockIdx.x * blockDim.x + threadIdx.x; pixelQuintupletIndex < nPixelQuintuplets; pixelQuintupletIndex += blockDim.x*gridDim.x)
-    {
-        if(pixelQuintupletsInGPU.isDup[pixelQuintupletIndex])
-        {
-            continue;
-        }
-        unsigned int trackCandidateIdx = atomicAdd(trackCandidatesInGPU.nTrackCandidates,1);
-        atomicAdd(trackCandidatesInGPU.nTrackCandidatespT5,1);
-
-
-        float radius = 0.5f*(__H2F(pixelQuintupletsInGPU.pixelRadius[pixelQuintupletIndex]) + __H2F(pixelQuintupletsInGPU.quintupletRadius[pixelQuintupletIndex]));
-        addTrackCandidateToMemory(trackCandidatesInGPU, 7/*track candidate type pT5=7*/, pixelQuintupletsInGPU.pixelIndices[pixelQuintupletIndex], pixelQuintupletsInGPU.T5Indices[pixelQuintupletIndex], &pixelQuintupletsInGPU.logicalLayers[7 * pixelQuintupletIndex], &pixelQuintupletsInGPU.lowerModuleIndices[7 * pixelQuintupletIndex], &pixelQuintupletsInGPU.hitIndices[14 * pixelQuintupletIndex], __H2F(pixelQuintupletsInGPU.centerX[pixelQuintupletIndex]),
-                            __H2F(pixelQuintupletsInGPU.centerY[pixelQuintupletIndex]),radius , trackCandidateIdx, pixelQuintupletIndex);
-    }
-}
-
-__global__ void SDL::crossCleanpT3(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU)
-{
-    unsigned int nPixelTriplets = *pixelTripletsInGPU.nPixelTriplets;
-    for(int pixelTripletIndex = blockIdx.x * blockDim.x + threadIdx.x; pixelTripletIndex < nPixelTriplets; pixelTripletIndex += blockDim.x*gridDim.x)
-    {
-        if(pixelTripletsInGPU.isDup[pixelTripletIndex]) continue;
-        //cross cleaning step
-        float eta1 = __H2F(pixelTripletsInGPU.eta_pix[pixelTripletIndex]);
-        float phi1 = __H2F(pixelTripletsInGPU.phi_pix[pixelTripletIndex]);
-
-        int pixelModuleIndex = *modulesInGPU.nLowerModules;
-        unsigned int prefix = rangesInGPU.segmentModuleIndices[pixelModuleIndex];
-
-        unsigned int nPixelQuintuplets = *pixelQuintupletsInGPU.nPixelQuintuplets;
-        for(int pixelQuintupletIndex = blockIdx.y * blockDim.y + threadIdx.y; pixelQuintupletIndex < nPixelQuintuplets; pixelQuintupletIndex += blockDim.y*gridDim.y)
-        {
-            unsigned int pLS_jx = pixelQuintupletsInGPU.pixelIndices[pixelQuintupletIndex];
-            float eta2 = segmentsInGPU.eta[pLS_jx - prefix];
-            float phi2 = segmentsInGPU.phi[pLS_jx - prefix];
-            float dEta = abs(eta1-eta2);
-            float dPhi = abs(phi1-phi2);
-            if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
-            float dR2 = dEta*dEta + dPhi*dPhi;
-            if(dR2 < 1e-5f) pixelTripletsInGPU.isDup[pixelTripletIndex] = true;
-        }
-    }
-}
-
-__global__ void SDL::crossCleanT5(struct SDL::modules& modulesInGPU, struct SDL::quintuplets& quintupletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU,struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::objectRanges& rangesInGPU)
-{
-    int stepx = blockDim.x*gridDim.x;
-    int stepy = blockDim.y*gridDim.y;
-    int stepz = blockDim.z*gridDim.z;
-    for(int innerInnerInnerLowerModuleArrayIndex = blockIdx.z * blockDim.z + threadIdx.z; innerInnerInnerLowerModuleArrayIndex < *(modulesInGPU.nLowerModules); innerInnerInnerLowerModuleArrayIndex+=stepz)
-    {
-        if(rangesInGPU.quintupletModuleIndices[innerInnerInnerLowerModuleArrayIndex] == -1) continue;
-        unsigned int nQuints = quintupletsInGPU.nQuintuplets[innerInnerInnerLowerModuleArrayIndex];
-        for(int innerObjectArrayIndex = blockIdx.y * blockDim.y + threadIdx.y;innerObjectArrayIndex < nQuints;innerObjectArrayIndex+=stepy)
-        {
-            int quintupletIndex = rangesInGPU.quintupletModuleIndices[innerInnerInnerLowerModuleArrayIndex] + innerObjectArrayIndex;
-
-            //don't add duplicate T5s or T5s that are accounted in pT5s
-            if(quintupletsInGPU.isDup[quintupletIndex] or quintupletsInGPU.partOfPT5[quintupletIndex])
-            {
-                continue;//return;
-            }
-#ifdef Crossclean_T5
-            int loop_bound = *pixelQuintupletsInGPU.nPixelQuintuplets + *pixelTripletsInGPU.nPixelTriplets; 
-            //cross cleaning step
-            float eta1 = __H2F(quintupletsInGPU.eta[quintupletIndex]);
-            float phi1 = __H2F(quintupletsInGPU.phi[quintupletIndex]);
-
-            for (unsigned int jx=blockIdx.x * blockDim.x + threadIdx.x; jx<loop_bound; jx+=stepx)
-            {
-                float eta2, phi2;
-                if(jx < *pixelQuintupletsInGPU.nPixelQuintuplets)
-                {
-                    eta2 = __H2F(pixelQuintupletsInGPU.eta[jx]);
-                    phi2 = __H2F(pixelQuintupletsInGPU.phi[jx]);
-                }
-                else
-                {
-                    eta2 = __H2F(pixelTripletsInGPU.eta[jx]);
-                    phi2 = __H2F(pixelTripletsInGPU.phi[jx]);
-                }
-
-                float dEta = abs(eta1-eta2);
-                float dPhi = abs(phi1-phi2);
-                if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
-                float dR2 = dEta*dEta + dPhi*dPhi;
-                if(dR2 < 1e-3f) {quintupletsInGPU.isDup[quintupletIndex] = true;}//return;
-
-            }
-#endif
-        }
-    }
-}
-
-//Using Matt's block for the outer loop and thread for inner loop trick here!
-//This will eliminate the need for another kernel just for adding the pLS, because we can __syncthreads()
-__global__ void SDL::crossCleanpLS(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU,struct SDL::segments& segmentsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::hits& hitsInGPU, struct SDL::quintuplets& quintupletsInGPU)
-{
-    int pixelModuleIndex = *modulesInGPU.nLowerModules;
-    unsigned int nPixels = segmentsInGPU.nSegments[pixelModuleIndex];
-    for(int pixelArrayIndex = blockIdx.x * blockDim.x + threadIdx.x; pixelArrayIndex < nPixels; pixelArrayIndex+=blockDim.x*gridDim.x)
-    {
-        if((!segmentsInGPU.isQuad[pixelArrayIndex]) || (segmentsInGPU.isDup[pixelArrayIndex])) {continue;}
-
-        float eta1 = segmentsInGPU.eta[pixelArrayIndex];
-        float phi1 = segmentsInGPU.phi[pixelArrayIndex];
-        unsigned int prefix = rangesInGPU.segmentModuleIndices[pixelModuleIndex];
-
-        unsigned int nTrackCandidates = *(trackCandidatesInGPU.nTrackCandidates);
-        for(int trackCandidateIndex = blockIdx.y * blockDim.y + threadIdx.y; trackCandidateIndex < nTrackCandidates; trackCandidateIndex+=blockDim.y*gridDim.y)
-        {
-            short type = trackCandidatesInGPU.trackCandidateType[trackCandidateIndex];
-            unsigned int innerTrackletIdx = trackCandidatesInGPU.objectIndices[2 * trackCandidateIndex];
-            if(type == 4) //T5
-            {
-                unsigned int quintupletIndex = innerTrackletIdx;//trackCandidatesInGPU.objectIndices[2*jx];//T5 index
-                float eta2 = __H2F(quintupletsInGPU.eta[quintupletIndex]);
-                float phi2 = __H2F(quintupletsInGPU.phi[quintupletIndex]);
-                float dEta = abs(eta1-eta2);
-                float dPhi = abs(phi1-phi2);
-                if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
-                float dR2 = dEta*dEta + dPhi*dPhi;
-                if(dR2 < 1e-3f) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
-            }
-            if(type == 5)  //pT3
-            {
-                int pLSIndex = pixelTripletsInGPU.pixelSegmentIndices[innerTrackletIdx];
-                int npMatched = checkPixelHits(prefix+pixelArrayIndex,pLSIndex,mdsInGPU,segmentsInGPU,hitsInGPU);
-                if(npMatched >0) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
-
-                int pT3Index = innerTrackletIdx;
-                float eta2 = __H2F(pixelTripletsInGPU.eta_pix[pT3Index]);
-                float phi2 = __H2F(pixelTripletsInGPU.phi_pix[pT3Index]);
-                float dEta = abs(eta1-eta2);
-                float dPhi = abs(phi1-phi2);
-                if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
-                float dR2 = dEta*dEta + dPhi*dPhi;
-                if(dR2 < 0.000001f) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
-            }
-            if(type == 7) //pT5
-            {
-                unsigned int pLSIndex = innerTrackletIdx;
-                int npMatched = checkPixelHits(prefix+pixelArrayIndex,pLSIndex,mdsInGPU,segmentsInGPU,hitsInGPU);
-                if(npMatched >0) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
-
-                float eta2 = segmentsInGPU.eta[pLSIndex - prefix];
-                float phi2 = segmentsInGPU.phi[pLSIndex - prefix];
-                float dEta = abs(eta1-eta2);
-                float dPhi = abs(phi1-phi2);
-                if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
-                float dR2 = dEta*dEta + dPhi*dPhi;
-                if(dR2 < 0.000001f) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
-            }
-        }
-    }
-}
-
-__global__ void SDL::addpT3asTrackCandidatesInGPU(struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU)
-{
-    unsigned int nPixelTriplets = *pixelTripletsInGPU.nPixelTriplets;
-
-    for(int pixelTripletIndex = blockIdx.x * blockDim.x + threadIdx.x; pixelTripletIndex < nPixelTriplets; pixelTripletIndex += blockDim.x*gridDim.x)
-    {
-        if((pixelTripletsInGPU.isDup[pixelTripletIndex])) continue;//return;
-        unsigned int trackCandidateIdx = atomicAdd(trackCandidatesInGPU.nTrackCandidates,1);
-        atomicAdd(trackCandidatesInGPU.nTrackCandidatespT3,1);
-    
-        float radius = 0.5f * (__H2F(pixelTripletsInGPU.pixelRadius[pixelTripletIndex]) + __H2F(pixelTripletsInGPU.tripletRadius[pixelTripletIndex]));
-        addTrackCandidateToMemory(trackCandidatesInGPU, 5/*track candidate type pT3=5*/, pixelTripletIndex, pixelTripletIndex, &pixelTripletsInGPU.logicalLayers[5 * pixelTripletIndex], &pixelTripletsInGPU.lowerModuleIndices[5 * pixelTripletIndex], &pixelTripletsInGPU.hitIndices[10 * pixelTripletIndex], __H2F(pixelTripletsInGPU.centerX[pixelTripletIndex]), __H2F(pixelTripletsInGPU.centerY[pixelTripletIndex]),radius,trackCandidateIdx, pixelTripletIndex);
-    }    
-
-}
-
-__global__ void SDL::addT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::quintuplets& quintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU)
-{
-    for(uint16_t idx = blockIdx.y * blockDim.y + threadIdx.y; idx < *(modulesInGPU.nLowerModules); idx+= gridDim.y * blockDim.y)
-    {
-        if(rangesInGPU.quintupletModuleIndices[idx] == -1) continue;
-        unsigned int nQuints = quintupletsInGPU.nQuintuplets[idx];
-        for(unsigned int jdx = blockIdx.x * blockDim.x + threadIdx.x; jdx < nQuints; jdx += blockDim.x * gridDim.x)
-        {
-            int quintupletIndex = rangesInGPU.quintupletModuleIndices[idx] + jdx;
-
-            if(quintupletsInGPU.isDup[quintupletIndex] or quintupletsInGPU.partOfPT5[quintupletIndex]) continue;
-
-            unsigned int trackCandidateIdx = atomicAdd(trackCandidatesInGPU.nTrackCandidates,1);
-            atomicAdd(trackCandidatesInGPU.nTrackCandidatesT5,1);
-    
-            addTrackCandidateToMemory(trackCandidatesInGPU, 4/*track candidate type T5=4*/, quintupletIndex, quintupletIndex, &quintupletsInGPU.logicalLayers[5 * quintupletIndex], &quintupletsInGPU.lowerModuleIndices[5 * quintupletIndex], &quintupletsInGPU.hitIndices[10 * quintupletIndex], quintupletsInGPU.regressionG[quintupletIndex], quintupletsInGPU.regressionF[quintupletIndex], quintupletsInGPU.regressionRadius[quintupletIndex], trackCandidateIdx, quintupletIndex);
-        } 
-    }
-}
-
-__global__ void SDL::addpLSasTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::trackCandidates& trackCandidatesInGPU, struct SDL::segments& segmentsInGPU)
-{
-    //int pixelArrayIndex = blockIdx.x * blockDim.x + threadIdx.x;
-    int step = blockDim.x*gridDim.x;
-    int pixelModuleIndex = *modulesInGPU.nLowerModules;
-    unsigned int nPixels = segmentsInGPU.nSegments[pixelModuleIndex];
-    for(int pixelArrayIndex = blockIdx.x * blockDim.x + threadIdx.x;pixelArrayIndex < nPixels;  pixelArrayIndex +=step)
-    {
-        if((!segmentsInGPU.isQuad[pixelArrayIndex]) || (segmentsInGPU.isDup[pixelArrayIndex]))
-        {
-            continue;//return;
-        }
-
-        unsigned int trackCandidateIdx = atomicAdd(trackCandidatesInGPU.nTrackCandidates,1);
-        atomicAdd(trackCandidatesInGPU.nTrackCandidatespLS,1);
-        addTrackCandidateToMemory(trackCandidatesInGPU, 8/*track candidate type pLS=8*/, pixelArrayIndex, pixelArrayIndex, trackCandidateIdx, pixelArrayIndex);
-    }
-}
-
-
-ALPAKA_FN_ACC int SDL::checkPixelHits(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::hits& hitsInGPU)
-{
-    int phits1[4] = {-1,-1,-1,-1};
-    int phits2[4] = {-1,-1,-1,-1};
-    phits1[0] = hitsInGPU.idxs[mdsInGPU.anchorHitIndices[segmentsInGPU.mdIndices[2*ix]]];
-    phits1[1] = hitsInGPU.idxs[mdsInGPU.anchorHitIndices[segmentsInGPU.mdIndices[2*ix+1]]];
-    phits1[2] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[segmentsInGPU.mdIndices[2*ix]]];
-    phits1[3] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[segmentsInGPU.mdIndices[2*ix+1]]];
-
-    phits2[0] = hitsInGPU.idxs[mdsInGPU.anchorHitIndices[segmentsInGPU.mdIndices[2*jx]]];
-    phits2[1] = hitsInGPU.idxs[mdsInGPU.anchorHitIndices[segmentsInGPU.mdIndices[2*jx+1]]];
-    phits2[2] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[segmentsInGPU.mdIndices[2*jx]]];
-    phits2[3] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[segmentsInGPU.mdIndices[2*jx+1]]];
-
-    int npMatched = 0;
-
-    for (int i =0; i<4;i++)
-    {
-        bool pmatched = false;
-        if(phits1[i] == -1){continue;}
-        for (int j =0; j<4; j++)
-        {
-            if(phits2[j] == -1){continue;}
-            if(phits1[i] == phits2[j]){pmatched = true; break;}
-        }
-        if(pmatched){npMatched++;}
-    }
-    return npMatched;
 }

--- a/SDL/TrackCandidate.cu
+++ b/SDL/TrackCandidate.cu
@@ -68,38 +68,6 @@ void SDL::createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCan
     cudaStreamSynchronize(stream);
 }
 
-ALPAKA_FN_ACC void SDL::addTrackCandidateToMemory(struct trackCandidates& trackCandidatesInGPU, short trackCandidateType, unsigned int innerTrackletIndex, unsigned int outerTrackletIndex, unsigned int trackCandidateIndex, unsigned int directObjectIndex)
-{
-    trackCandidatesInGPU.trackCandidateType[trackCandidateIndex] = trackCandidateType;
-    trackCandidatesInGPU.directObjectIndices[trackCandidateIndex] = directObjectIndex;
-    trackCandidatesInGPU.objectIndices[2 * trackCandidateIndex] = innerTrackletIndex;
-    trackCandidatesInGPU.objectIndices[2 * trackCandidateIndex + 1] = outerTrackletIndex;
-}
-
-ALPAKA_FN_ACC void SDL::addTrackCandidateToMemory(struct trackCandidates& trackCandidatesInGPU, short trackCandidateType, unsigned int innerTrackletIndex, unsigned int outerTrackletIndex, uint8_t* logicalLayerIndices, uint16_t* lowerModuleIndices, unsigned int* hitIndices, float centerX, float centerY, float radius, unsigned int trackCandidateIndex, unsigned int directObjectIndex)
-{
-    trackCandidatesInGPU.trackCandidateType[trackCandidateIndex] = trackCandidateType;
-    trackCandidatesInGPU.directObjectIndices[trackCandidateIndex] = directObjectIndex;
-    trackCandidatesInGPU.objectIndices[2 * trackCandidateIndex] = innerTrackletIndex;
-    trackCandidatesInGPU.objectIndices[2 * trackCandidateIndex + 1] = outerTrackletIndex;
-    
-    size_t limits = trackCandidateType == 7 ? 7 : 5;
-
-    //send the starting pointer to the logicalLayer and hitIndices
-    for(size_t i = 0; i < limits; i++)
-    {
-        trackCandidatesInGPU.logicalLayers[7 * trackCandidateIndex + i] = logicalLayerIndices[i];
-        trackCandidatesInGPU.lowerModuleIndices[7 * trackCandidateIndex + i] = lowerModuleIndices[i];
-    }
-    for(size_t i = 0; i < 2 * limits; i++)
-    {
-        trackCandidatesInGPU.hitIndices[14 * trackCandidateIndex + i] = hitIndices[i];
-    }
-    trackCandidatesInGPU.centerX[trackCandidateIndex] = __F2H(centerX);
-    trackCandidatesInGPU.centerY[trackCandidateIndex] = __F2H(centerY);
-    trackCandidatesInGPU.radius[trackCandidateIndex]  = __F2H(radius);
-}
-
 SDL::trackCandidates::trackCandidates()
 {
     trackCandidateType = nullptr;
@@ -145,6 +113,7 @@ void SDL::trackCandidates::freeMemoryCache()
     cms::cuda::free_device(dev, centerY);
     cms::cuda::free_device(dev, radius);
 }
+
 void SDL::trackCandidates::freeMemory(cudaStream_t stream)
 {
     cudaFree(trackCandidateType);

--- a/SDL/TrackCandidate.cuh
+++ b/SDL/TrackCandidate.cuh
@@ -2,8 +2,6 @@
 #define TrackCandidate_cuh
 
 #include "Constants.cuh"
-#include "EndcapGeometry.cuh"
-#include "TiltedGeometry.h"
 #include "Triplet.cuh"
 #include "Segment.cuh"
 #include "MiniDoublet.cuh"
@@ -19,11 +17,11 @@ namespace SDL
         short* trackCandidateType; //4-T5 5-pT3 7-pT5 8-pLS
         unsigned int* directObjectIndices; // will hold direct indices to each type containers
         unsigned int* objectIndices; //will hold tracklet and  triplet indices  - check the type!!
-        unsigned int* nTrackCandidates;
-        unsigned int* nTrackCandidatespT3;
-        unsigned int* nTrackCandidatespT5;
-        unsigned int* nTrackCandidatespLS;
-        unsigned int* nTrackCandidatesT5;
+        int* nTrackCandidates;
+        int* nTrackCandidatespT3;
+        int* nTrackCandidatespT5;
+        int* nTrackCandidatespLS;
+        int* nTrackCandidatesT5;
 
         uint8_t* logicalLayers;
         unsigned int* hitIndices;
@@ -46,21 +44,355 @@ namespace SDL
 
     ALPAKA_FN_ACC void addTrackCandidateToMemory(struct trackCandidates& trackCandidatesInGPU, short trackCandidateType, unsigned int innerTrackletIndex, unsigned int outerTrackletIndex, uint8_t* logicalLayerIndices, uint16_t* lowerModuleIndices, unsigned int* hitIndices, float centerX, float centerY, float radius, unsigned int trackCandidateIndex, unsigned int directObjectIndex);
 
-__global__ void crossCleanpT3(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU);
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE int checkPixelHits(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::hits& hitsInGPU)
+    {
+        int phits1[4] = {-1,-1,-1,-1};
+        int phits2[4] = {-1,-1,-1,-1};
+        phits1[0] = hitsInGPU.idxs[mdsInGPU.anchorHitIndices[segmentsInGPU.mdIndices[2*ix]]];
+        phits1[1] = hitsInGPU.idxs[mdsInGPU.anchorHitIndices[segmentsInGPU.mdIndices[2*ix+1]]];
+        phits1[2] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[segmentsInGPU.mdIndices[2*ix]]];
+        phits1[3] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[segmentsInGPU.mdIndices[2*ix+1]]];
 
-__global__ void crossCleanT5(struct SDL::modules& modulesInGPU, struct SDL::quintuplets& quintupletsInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU,struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::objectRanges& rangesInGPU);
+        phits2[0] = hitsInGPU.idxs[mdsInGPU.anchorHitIndices[segmentsInGPU.mdIndices[2*jx]]];
+        phits2[1] = hitsInGPU.idxs[mdsInGPU.anchorHitIndices[segmentsInGPU.mdIndices[2*jx+1]]];
+        phits2[2] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[segmentsInGPU.mdIndices[2*jx]]];
+        phits2[3] = hitsInGPU.idxs[mdsInGPU.outerHitIndices[segmentsInGPU.mdIndices[2*jx+1]]];
 
-__global__ void crossCleanpLS(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU,struct SDL::segments& segmentsInGPU, struct SDL::miniDoublets& mdsInGPU, struct SDL::hits& hitsInGPU, struct SDL::quintuplets& quintupletsInGPU);
+        int npMatched = 0;
 
-__global__ void addpT3asTrackCandidatesInGPU(struct SDL::pixelTriplets& pixelTripletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU);
+        for (int i =0; i<4;i++)
+        {
+            bool pmatched = false;
+            if(phits1[i] == -1){continue;}
+            for (int j =0; j<4; j++)
+            {
+                if(phits2[j] == -1){continue;}
+                if(phits1[i] == phits2[j]){pmatched = true; break;}
+            }
+            if(pmatched){npMatched++;}
+        }
+        return npMatched;
+    };
 
-__global__ void addT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::objectRanges& rangesInGPU, struct SDL::quintuplets& quintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU);
+    struct crossCleanpT3
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct SDL::modules& modulesInGPU,
+                struct SDL::objectRanges& rangesInGPU,
+                struct SDL::pixelTriplets& pixelTripletsInGPU,
+                struct SDL::segments& segmentsInGPU,
+                struct SDL::pixelQuintuplets& pixelQuintupletsInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
 
-__global__ void addpLSasTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::trackCandidates& trackCandidatesInGPU, struct SDL::segments& segmentsInGPU);
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
-__global__ void addpT5asTrackCandidateInGPU(struct SDL::modules& modulesInGPU, struct SDL::pixelQuintuplets& pixelQuintupletsInGPU, struct SDL::trackCandidates& trackCandidatesInGPU,struct SDL::segments& segmentsInGPU, struct SDL::triplets& tripletsInGPU,struct SDL::quintuplets& quintupletsInGPU);
+            unsigned int nPixelTriplets = *pixelTripletsInGPU.nPixelTriplets;
+            for(int pixelTripletIndex = globalThreadIdx[2]; pixelTripletIndex < nPixelTriplets; pixelTripletIndex += gridThreadExtent[2])
+            {
+                if(pixelTripletsInGPU.isDup[pixelTripletIndex]) continue;
+                //cross cleaning step
+                float eta1 = __H2F(pixelTripletsInGPU.eta_pix[pixelTripletIndex]);
+                float phi1 = __H2F(pixelTripletsInGPU.phi_pix[pixelTripletIndex]);
 
-  ALPAKA_FN_ACC int checkPixelHits(unsigned int ix, unsigned int jx,struct SDL::miniDoublets& mdsInGPU, struct SDL::segments& segmentsInGPU, struct SDL::hits& hitsInGPU);
+                int pixelModuleIndex = *modulesInGPU.nLowerModules;
+                unsigned int prefix = rangesInGPU.segmentModuleIndices[pixelModuleIndex];
+
+                unsigned int nPixelQuintuplets = *pixelQuintupletsInGPU.nPixelQuintuplets;
+                for(int pixelQuintupletIndex = globalThreadIdx[1]; pixelQuintupletIndex < nPixelQuintuplets; pixelQuintupletIndex += gridThreadExtent[1])
+                {
+                    unsigned int pLS_jx = pixelQuintupletsInGPU.pixelIndices[pixelQuintupletIndex];
+                    float eta2 = segmentsInGPU.eta[pLS_jx - prefix];
+                    float phi2 = segmentsInGPU.phi[pLS_jx - prefix];
+                    float dEta = alpaka::math::abs(acc, (eta1-eta2));
+                    float dPhi = alpaka::math::abs(acc, (phi1-phi2));
+                    if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
+                    float dR2 = dEta*dEta + dPhi*dPhi;
+                    if(dR2 < 1e-5f) pixelTripletsInGPU.isDup[pixelTripletIndex] = true;
+                }
+            }
+        }
+    };
+
+    struct crossCleanT5
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct SDL::modules& modulesInGPU,
+                struct SDL::quintuplets& quintupletsInGPU,
+                struct SDL::pixelQuintuplets& pixelQuintupletsInGPU,
+                struct SDL::pixelTriplets& pixelTripletsInGPU,
+                struct SDL::objectRanges& rangesInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            for(int innerInnerInnerLowerModuleArrayIndex = globalThreadIdx[0]; innerInnerInnerLowerModuleArrayIndex < *(modulesInGPU.nLowerModules); innerInnerInnerLowerModuleArrayIndex += gridThreadExtent[0])
+            {
+                if(rangesInGPU.quintupletModuleIndices[innerInnerInnerLowerModuleArrayIndex] == -1) continue;
+                unsigned int nQuints = quintupletsInGPU.nQuintuplets[innerInnerInnerLowerModuleArrayIndex];
+                for(int innerObjectArrayIndex = globalThreadIdx[1]; innerObjectArrayIndex < nQuints; innerObjectArrayIndex += gridThreadExtent[1])
+                {
+                    int quintupletIndex = rangesInGPU.quintupletModuleIndices[innerInnerInnerLowerModuleArrayIndex] + innerObjectArrayIndex;
+
+                    //don't add duplicate T5s or T5s that are accounted in pT5s
+                    if(quintupletsInGPU.isDup[quintupletIndex] or quintupletsInGPU.partOfPT5[quintupletIndex])
+                    {
+                        continue;//return;
+                    }
+#ifdef Crossclean_T5
+                    int loop_bound = *pixelQuintupletsInGPU.nPixelQuintuplets + *pixelTripletsInGPU.nPixelTriplets; 
+                    //cross cleaning step
+                    float eta1 = __H2F(quintupletsInGPU.eta[quintupletIndex]);
+                    float phi1 = __H2F(quintupletsInGPU.phi[quintupletIndex]);
+
+                    for(unsigned int jx = globalThreadIdx[2]; jx < loop_bound; jx += gridThreadExtent[2])
+                    {
+                        float eta2, phi2;
+                        if(jx < *pixelQuintupletsInGPU.nPixelQuintuplets)
+                        {
+                            eta2 = __H2F(pixelQuintupletsInGPU.eta[jx]);
+                            phi2 = __H2F(pixelQuintupletsInGPU.phi[jx]);
+                        }
+                        else
+                        {
+                            eta2 = __H2F(pixelTripletsInGPU.eta[jx]);
+                            phi2 = __H2F(pixelTripletsInGPU.phi[jx]);
+                        }
+
+                        float dEta = alpaka::math::abs(acc, (eta1-eta2));
+                        float dPhi = alpaka::math::abs(acc, (phi1-phi2));
+                        if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
+                        float dR2 = dEta*dEta + dPhi*dPhi;
+                        if(dR2 < 1e-3f) {quintupletsInGPU.isDup[quintupletIndex] = true;}//return;
+                    }
+#endif
+                }
+            }
+        }
+    };
+
+    //Using Matt's block for the outer loop and thread for inner loop trick here!
+    //This will eliminate the need for another kernel just for adding the pLS, because we can __syncthreads()
+    struct crossCleanpLS
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct SDL::modules& modulesInGPU,
+                struct SDL::objectRanges& rangesInGPU,
+                struct SDL::pixelTriplets& pixelTripletsInGPU,
+                struct SDL::trackCandidates& trackCandidatesInGPU,
+                struct SDL::segments& segmentsInGPU,
+                struct SDL::miniDoublets& mdsInGPU,
+                struct SDL::hits& hitsInGPU,
+                struct SDL::quintuplets& quintupletsInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            int pixelModuleIndex = *modulesInGPU.nLowerModules;
+            unsigned int nPixels = segmentsInGPU.nSegments[pixelModuleIndex];
+            for(int pixelArrayIndex = globalThreadIdx[2]; pixelArrayIndex < nPixels; pixelArrayIndex += gridThreadExtent[2])
+            {
+                if((!segmentsInGPU.isQuad[pixelArrayIndex]) || (segmentsInGPU.isDup[pixelArrayIndex])) {continue;}
+
+                float eta1 = segmentsInGPU.eta[pixelArrayIndex];
+                float phi1 = segmentsInGPU.phi[pixelArrayIndex];
+                unsigned int prefix = rangesInGPU.segmentModuleIndices[pixelModuleIndex];
+
+                int nTrackCandidates = *(trackCandidatesInGPU.nTrackCandidates);
+                for(int trackCandidateIndex = globalThreadIdx[1]; trackCandidateIndex < nTrackCandidates; trackCandidateIndex += gridThreadExtent[1])
+                {
+                    short type = trackCandidatesInGPU.trackCandidateType[trackCandidateIndex];
+                    unsigned int innerTrackletIdx = trackCandidatesInGPU.objectIndices[2 * trackCandidateIndex];
+                    if(type == 4) //T5
+                    {
+                        unsigned int quintupletIndex = innerTrackletIdx;//trackCandidatesInGPU.objectIndices[2*jx];//T5 index
+                        float eta2 = __H2F(quintupletsInGPU.eta[quintupletIndex]);
+                        float phi2 = __H2F(quintupletsInGPU.phi[quintupletIndex]);
+                        float dEta = alpaka::math::abs(acc, (eta1-eta2));
+                        float dPhi = alpaka::math::abs(acc, (phi1-phi2));
+                        if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
+                        float dR2 = dEta*dEta + dPhi*dPhi;
+                        if(dR2 < 1e-3f) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
+                    }
+                    if(type == 5) //pT3
+                    {
+                        int pLSIndex = pixelTripletsInGPU.pixelSegmentIndices[innerTrackletIdx];
+                        int npMatched = checkPixelHits(prefix+pixelArrayIndex,pLSIndex,mdsInGPU,segmentsInGPU,hitsInGPU);
+                        if(npMatched >0) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
+
+                        int pT3Index = innerTrackletIdx;
+                        float eta2 = __H2F(pixelTripletsInGPU.eta_pix[pT3Index]);
+                        float phi2 = __H2F(pixelTripletsInGPU.phi_pix[pT3Index]);
+                        float dEta = alpaka::math::abs(acc, (eta1-eta2));
+                        float dPhi = alpaka::math::abs(acc, (phi1-phi2));
+                        if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
+                        float dR2 = dEta*dEta + dPhi*dPhi;
+                        if(dR2 < 0.000001f) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
+                    }
+                    if(type == 7) //pT5
+                    {
+                        unsigned int pLSIndex = innerTrackletIdx;
+                        int npMatched = checkPixelHits(prefix+pixelArrayIndex,pLSIndex,mdsInGPU,segmentsInGPU,hitsInGPU);
+                        if(npMatched >0) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
+
+                        float eta2 = segmentsInGPU.eta[pLSIndex - prefix];
+                        float phi2 = segmentsInGPU.phi[pLSIndex - prefix];
+                        float dEta = alpaka::math::abs(acc, (eta1-eta2));
+                        float dPhi = alpaka::math::abs(acc, (phi1-phi2));
+                        if(dPhi > float(M_PI)){dPhi = dPhi - 2*float(M_PI);}
+                        float dR2 = dEta*dEta + dPhi*dPhi;
+                        if(dR2 < 0.000001f) {segmentsInGPU.isDup[pixelArrayIndex] = true;}
+                    }
+                }
+            }
+        }
+    };
+
+    struct addpT3asTrackCandidatesInGPU
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct SDL::pixelTriplets& pixelTripletsInGPU,
+                struct SDL::trackCandidates& trackCandidatesInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            unsigned int nPixelTriplets = *pixelTripletsInGPU.nPixelTriplets;
+            for(int pixelTripletIndex = globalThreadIdx[2]; pixelTripletIndex < nPixelTriplets; pixelTripletIndex += gridThreadExtent[2])
+            {
+                if((pixelTripletsInGPU.isDup[pixelTripletIndex])) continue;
+                unsigned int trackCandidateIdx = alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidates, 1);
+                alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidatespT3, 1);
+
+                float radius = 0.5f * (__H2F(pixelTripletsInGPU.pixelRadius[pixelTripletIndex]) + __H2F(pixelTripletsInGPU.tripletRadius[pixelTripletIndex]));
+                addTrackCandidateToMemory(trackCandidatesInGPU, 5/*track candidate type pT3=5*/, pixelTripletIndex, pixelTripletIndex, &pixelTripletsInGPU.logicalLayers[5 * pixelTripletIndex], &pixelTripletsInGPU.lowerModuleIndices[5 * pixelTripletIndex], &pixelTripletsInGPU.hitIndices[10 * pixelTripletIndex], __H2F(pixelTripletsInGPU.centerX[pixelTripletIndex]), __H2F(pixelTripletsInGPU.centerY[pixelTripletIndex]),radius,trackCandidateIdx, pixelTripletIndex);
+            }
+        }
+    };
+
+    struct addT5asTrackCandidateInGPU
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct SDL::modules& modulesInGPU,
+                struct SDL::objectRanges& rangesInGPU,
+                struct SDL::quintuplets& quintupletsInGPU,
+                struct SDL::trackCandidates& trackCandidatesInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            for(int idx = globalThreadIdx[1]; idx < *(modulesInGPU.nLowerModules); idx += gridThreadExtent[1])
+            {
+                if(rangesInGPU.quintupletModuleIndices[idx] == -1) continue;
+                unsigned int nQuints = quintupletsInGPU.nQuintuplets[idx];
+                for(int jdx = globalThreadIdx[2]; jdx < nQuints; jdx += gridThreadExtent[2])
+                {
+                    int quintupletIndex = rangesInGPU.quintupletModuleIndices[idx] + jdx;
+                    if(quintupletsInGPU.isDup[quintupletIndex] or quintupletsInGPU.partOfPT5[quintupletIndex]) continue;
+
+                    unsigned int trackCandidateIdx = alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidates,1);
+                    alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidatesT5,1);
+                    addTrackCandidateToMemory(trackCandidatesInGPU, 4/*track candidate type T5=4*/, quintupletIndex, quintupletIndex, &quintupletsInGPU.logicalLayers[5 * quintupletIndex], &quintupletsInGPU.lowerModuleIndices[5 * quintupletIndex], &quintupletsInGPU.hitIndices[10 * quintupletIndex], quintupletsInGPU.regressionG[quintupletIndex], quintupletsInGPU.regressionF[quintupletIndex], quintupletsInGPU.regressionRadius[quintupletIndex], trackCandidateIdx, quintupletIndex);
+                }
+            }
+        }
+    };
+
+    struct addpLSasTrackCandidateInGPU
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct SDL::modules& modulesInGPU,
+                struct SDL::trackCandidates& trackCandidatesInGPU,
+                struct SDL::segments& segmentsInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            int pixelModuleIndex = *modulesInGPU.nLowerModules;
+            unsigned int nPixels = segmentsInGPU.nSegments[pixelModuleIndex];
+            for(int pixelArrayIndex = globalThreadIdx[2]; pixelArrayIndex < nPixels; pixelArrayIndex += gridThreadExtent[2])
+            {
+                if((!segmentsInGPU.isQuad[pixelArrayIndex]) || (segmentsInGPU.isDup[pixelArrayIndex]))
+                {
+                    continue;
+                }
+
+                unsigned int trackCandidateIdx = alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidates, 1);
+                alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidatespLS, 1);
+                addTrackCandidateToMemory(trackCandidatesInGPU, 8/*track candidate type pLS=8*/, pixelArrayIndex, pixelArrayIndex, trackCandidateIdx, pixelArrayIndex);
+            }
+        }
+    };
+
+    struct addpT5asTrackCandidateInGPU
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct SDL::modules& modulesInGPU,
+                struct SDL::pixelQuintuplets& pixelQuintupletsInGPU,
+                struct SDL::trackCandidates& trackCandidatesInGPU,
+                struct SDL::segments& segmentsInGPU,
+                struct SDL::triplets& tripletsInGPU,
+                struct SDL::quintuplets& quintupletsInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            int nPixelQuintuplets = *pixelQuintupletsInGPU.nPixelQuintuplets;
+            for(int pixelQuintupletIndex = globalThreadIdx[2]; pixelQuintupletIndex < nPixelQuintuplets; pixelQuintupletIndex += gridThreadExtent[2])
+            {
+                if(pixelQuintupletsInGPU.isDup[pixelQuintupletIndex])
+                {
+                    continue;
+                }
+                int trackCandidateIdx = alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidates, 1);
+                alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidatespT5,1);
+
+                float radius = 0.5f*(__H2F(pixelQuintupletsInGPU.pixelRadius[pixelQuintupletIndex]) + __H2F(pixelQuintupletsInGPU.quintupletRadius[pixelQuintupletIndex]));
+                addTrackCandidateToMemory(trackCandidatesInGPU, 7/*track candidate type pT5=7*/, pixelQuintupletsInGPU.pixelIndices[pixelQuintupletIndex], pixelQuintupletsInGPU.T5Indices[pixelQuintupletIndex], &pixelQuintupletsInGPU.logicalLayers[7 * pixelQuintupletIndex], &pixelQuintupletsInGPU.lowerModuleIndices[7 * pixelQuintupletIndex], &pixelQuintupletsInGPU.hitIndices[14 * pixelQuintupletIndex], __H2F(pixelQuintupletsInGPU.centerX[pixelQuintupletIndex]), __H2F(pixelQuintupletsInGPU.centerY[pixelQuintupletIndex]),radius , trackCandidateIdx, pixelQuintupletIndex);
+            }
+        }
+    };
 }
 
 #endif

--- a/SDL/TrackCandidate.cuh
+++ b/SDL/TrackCandidate.cuh
@@ -40,7 +40,7 @@ namespace SDL
 
     void createTrackCandidatesInExplicitMemory(struct trackCandidates& trackCandidatesInGPU, unsigned int maxTrackCandidates,cudaStream_t stream);
     
-    ALPAKA_FN_ACC ALPAKA_FN_INLINE void addTrackCandidateToMemory(struct trackCandidates& trackCandidatesInGPU, short trackCandidateType, unsigned int innerTrackletIndex, unsigned int outerTrackletIndex, unsigned int trackCandidateIndex, unsigned int directObjectIndex)
+    ALPAKA_FN_ACC ALPAKA_FN_INLINE void addTrackCandidateToMemorypLS(struct trackCandidates& trackCandidatesInGPU, short trackCandidateType, unsigned int innerTrackletIndex, unsigned int outerTrackletIndex, unsigned int trackCandidateIndex, unsigned int directObjectIndex)
     {
         trackCandidatesInGPU.trackCandidateType[trackCandidateIndex] = trackCandidateType;
         trackCandidatesInGPU.directObjectIndices[trackCandidateIndex] = directObjectIndex;
@@ -148,7 +148,7 @@ namespace SDL
                     float eta2 = segmentsInGPU.eta[pLS_jx - prefix];
                     float phi2 = segmentsInGPU.phi[pLS_jx - prefix];
                     float dEta = alpaka::math::abs(acc, (eta1 - eta2));
-                    float dPhi = SDL::calculate_dPhi(acc, phi1, phi2);
+                    float dPhi = SDL::calculate_dPhi(phi1, phi2);
 
                     float dR2 = dEta*dEta + dPhi*dPhi;
                     if(dR2 < 1e-5f)
@@ -210,7 +210,7 @@ namespace SDL
                         }
 
                         float dEta = alpaka::math::abs(acc, eta1 - eta2);
-                        float dPhi = SDL::calculate_dPhi(acc, phi1, phi2);
+                        float dPhi = SDL::calculate_dPhi(phi1, phi2);
 
                         float dR2 = dEta*dEta + dPhi*dPhi;
                         if(dR2 < 1e-3f)
@@ -267,7 +267,7 @@ namespace SDL
                         float eta2 = __H2F(quintupletsInGPU.eta[quintupletIndex]);
                         float phi2 = __H2F(quintupletsInGPU.phi[quintupletIndex]);
                         float dEta = alpaka::math::abs(acc, eta1 - eta2);
-                        float dPhi = SDL::calculate_dPhi(acc, phi1, phi2);
+                        float dPhi = SDL::calculate_dPhi(phi1, phi2);
 
                         float dR2 = dEta*dEta + dPhi*dPhi;
                         if(dR2 < 1e-3f)
@@ -284,7 +284,7 @@ namespace SDL
                         float eta2 = __H2F(pixelTripletsInGPU.eta_pix[pT3Index]);
                         float phi2 = __H2F(pixelTripletsInGPU.phi_pix[pT3Index]);
                         float dEta = alpaka::math::abs(acc, eta1 - eta2);
-                        float dPhi = SDL::calculate_dPhi(acc, phi1, phi2);
+                        float dPhi = SDL::calculate_dPhi(phi1, phi2);
 
                         float dR2 = dEta*dEta + dPhi*dPhi;
                         if(dR2 < 0.000001f)
@@ -299,7 +299,7 @@ namespace SDL
                         float eta2 = segmentsInGPU.eta[pLSIndex - prefix];
                         float phi2 = segmentsInGPU.phi[pLSIndex - prefix];
                         float dEta = alpaka::math::abs(acc, eta1 - eta2);
-                        float dPhi = SDL::calculate_dPhi(acc, phi1, phi2);
+                        float dPhi = SDL::calculate_dPhi(phi1, phi2);
 
                         float dR2 = dEta*dEta + dPhi*dPhi;
                         if(dR2 < 0.000001f)
@@ -402,7 +402,7 @@ namespace SDL
 
                 unsigned int trackCandidateIdx = alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidates, 1);
                 alpaka::atomicOp<alpaka::AtomicAdd>(acc, trackCandidatesInGPU.nTrackCandidatespLS, 1);
-                addTrackCandidateToMemory(trackCandidatesInGPU, 8/*track candidate type pLS=8*/, pixelArrayIndex, pixelArrayIndex, trackCandidateIdx, pixelArrayIndex);
+                addTrackCandidateToMemorypLS(trackCandidatesInGPU, 8/*track candidate type pLS=8*/, pixelArrayIndex, pixelArrayIndex, trackCandidateIdx, pixelArrayIndex);
             }
         }
     };


### PR DESCRIPTION
New timing results. There seems to have been a speedup from the switch to Alpaka?
<img width="1038" alt="Screenshot 2023-03-21 at 12 30 56 AM" src="https://user-images.githubusercontent.com/25272611/226517758-744bdac4-45d8-4e2d-ad06-5c217452fdf0.png">

Validation Plots: [Here](https://www.classe.cornell.edu/~gsn27/www/www/PR257/mywork_e96d9e-PU200_6399e7-PU200/summary/)