### PR TITLE
Addition of new cube samples

### DIFF
--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -81,7 +81,7 @@ int main(int argc, char** argv)
     TString TrackingNtupleDir = gSystem->Getenv("TRACKINGNTUPLEDIR");
     if (ana.input_raw_string.EqualTo("muonGun"))
         ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_pt_0p5_2.root", TrackingNtupleDir.Data());
-    else if (ana.input_raw_string.EqualTo("muonGun_highE"))
+    else if (ana.input_raw_string.EqualTo("muonGun_highPt"))
         ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_pt_0p5_50.root", TrackingNtupleDir.Data());
     else if (ana.input_raw_string.EqualTo("pionGun"))
         ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_6pion_1k_pt_0p5_50.root", TrackingNtupleDir.Data());
@@ -89,10 +89,14 @@ int main(int argc, char** argv)
         ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_ttbar_PU200.root", TrackingNtupleDir.Data());
     else if (ana.input_raw_string.EqualTo("PU200RelVal"))
         ana.input_file_list_tstring = TString::Format("%s/RelValTTbar_14TeV_CMSSW_12_5_0_pre3/", (TrackingNtupleDir.Replace(31,1,"5").Replace(38,1,"3")).Data()); // RelVal files under CMSSW_12_5_0_pre3 directory, not CMSSW_12_2_0_pre2 as is the case for the rest of the samples
-    else if (ana.input_raw_string.EqualTo("cube"))
-        ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_pt_0p5_50_5cm_cube.root", TrackingNtupleDir.Data());
-    else if (ana.input_raw_string.EqualTo("cube50cm"))
-        ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_pt_0p5_50_50cm_cube.root", TrackingNtupleDir.Data());
+    else if (ana.input_raw_string.EqualTo("cube5"))
+        ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_10k_pt_0p5_2_5cm_cube.root", TrackingNtupleDir.Data());
+    else if (ana.input_raw_string.EqualTo("cube5_highPt"))
+        ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_10k_pt_0p5_50_5cm_cube.root", TrackingNtupleDir.Data());
+    else if (ana.input_raw_string.EqualTo("cube50"))
+        ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_10k_pt_0p5_2_50cm_cube.root", TrackingNtupleDir.Data());
+    else if (ana.input_raw_string.EqualTo("cube50_highPt"))
+        ana.input_file_list_tstring = TString::Format("%s/trackingNtuple_10mu_10k_pt_0p5_50_50cm_cube.root", TrackingNtupleDir.Data());
     else
     {
         ana.input_file_list_tstring = ana.input_raw_string;


### PR DESCRIPTION
This PR includes the new cube samples (with the `AddAntiParticle` flag set to `false` but adding the antiparticles by hand, so that there are still 10 muons per event) with 10k events each. There is a slight change in the naming:
- `cube5`: Muons with 0.5 < pT < 2 GeV in a cube of 5 cm.
- `cube5_highPt`: Muons with 0.5 < pT < 50 GeV in a cube of 5 cm.
- `cube50`: Muons with 0.5 < pT < 2 GeV in a cube of 50 cm.
- `cube50_highPt`: Muons with 0.5 < pT < 50 GeV in a cube of 50 cm.

The `muonGun_highE` samples is renamed to `muonGun_highPt, since the sample is generated with a uniform muon pT distribution.

Validation plots can be found [here](https://uaf-10.t2.ucsd.edu/~evourlio/SDL/newCubeSamples/). The `cube5` samples look as expected, while the `cube50` samples do not seem very useful as is. I wanted to check the |η| < 2.5 plots but they seem to not be produced by default? This seems weird, as the "|η| < 2.5" category in the webpage is always produced. @sgnoohc any idea what I may be doing wrong?

The new samples are available both on phi3 and on lnx7188. Let me know if they are needed on more machines or feel free to copy them yourselves.