### PR TITLE
placed printf in warnings ifdef

### DIFF
--- a/SDL/MiniDoublet.cu
+++ b/SDL/MiniDoublet.cu
@@ -442,16 +442,11 @@ __device__ inline float SDL::dPhiThreshold(/*struct hits& hitsInGPU,*/float rt, 
     {
         if(modulesInGPU.moduleType[moduleIndex] == PS and modulesInGPU.moduleLayerType[moduleIndex] == Strip)
         {
-            // printf("moduleIndex: %d\n", moduleIndex);
             drdz = modulesInGPU.drdzs[moduleIndex];
-            // printf("drdz: %f\n", drdz);
         }
         else
         {
-            // printf("moduleIndex: %d\n", moduleIndex);
-            // printf("partnerModuleIndex: %d\n", modulesInGPU.partnerModuleIndex(moduleIndex));
             drdz = modulesInGPU.drdzs[modulesInGPU.partnerModuleIndices[moduleIndex]];
-            // printf("drdz: %f\n", drdz);
         }
     }
     else

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -1014,7 +1014,9 @@ __device__ float SDL::computeRadiusFromThreeAnchorHits(float x1, float y1, float
 
     if(((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3) == 0) || (g * g + f * f - c < 0))
     {
+#ifdef Warnings
         printf("three collinear points or FATAL! r^2 < 0!\n");
+#endif
 	radius = -1.f;
     }
     else
@@ -1118,7 +1120,9 @@ __device__ void SDL::computeSigmasForRegression(SDL::modules& modulesInGPU, cons
         }
         else
         {
+#ifdef Warnings
             printf("ERROR!!!!! I SHOULDN'T BE HERE!!!! subdet = %d, type = %d, side = %d\n", moduleSubdet, moduleType, moduleSide);
+#endif
         }
     }
 }
@@ -1197,7 +1201,9 @@ __device__ float SDL::computeRadiusUsingRegression(int nPoints, float* xs, float
     f = 0.5f*twoF;
     if(g * g + f * f - c < 0)
     {
+#ifdef Warnings
         printf("FATAL! r^2 < 0!\n");
+#endif
         return -1;
     }
     
@@ -1313,7 +1319,9 @@ __global__ void SDL::createQuintupletsInGPUv2(struct SDL::modules& modulesInGPU,
                     //this if statement should never get executed!
                     if(rangesInGPU.quintupletModuleIndices[lowerModule1] == -1)
                     {
+#ifdef Warnings
                         printf("Quintuplets : no memory for module at module index = %d\n", lowerModule1);
+#endif
                     }
                     else
                     {

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -258,7 +258,6 @@ __device__ void SDL::addSegmentToMemory(struct segments& segmentsInGPU, unsigned
     //idx will be computed in the kernel, which is the index into which the 
     //segment will be written
     //nSegments will be incremented in the kernel
-    //printf("seg: %u %u %u %u\n",lowerMDIndex, upperMDIndex,innerLowerModuleIndex,outerLowerModuleIndex);
     segmentsInGPU.mdIndices[idx * 2] = lowerMDIndex;
     segmentsInGPU.mdIndices[idx * 2 + 1] = upperMDIndex;
     segmentsInGPU.innerLowerModuleIndices[idx] = innerLowerModuleIndex;
@@ -814,7 +813,6 @@ __global__ void SDL::createSegmentsInGPUv2(struct SDL::modules& modulesInGPU, st
     for(uint16_t innerLowerModuleIndex = blockIdx.x ; innerLowerModuleIndex< (*modulesInGPU.nLowerModules); innerLowerModuleIndex += blockxSize){
 
     unsigned int nConnectedModules = modulesInGPU.nConnectedModules[innerLowerModuleIndex];
-//printf("HERE:  %d nConnectedModules = %d\n", innerLowerModuleIndex, nConnectedModules);
 
     for(uint16_t outerLowerModuleArrayIdx = threadIdx.y; outerLowerModuleArrayIdx< nConnectedModules; outerLowerModuleArrayIdx += blockySize){
 
@@ -824,7 +822,6 @@ __global__ void SDL::createSegmentsInGPUv2(struct SDL::modules& modulesInGPU, st
         unsigned int nOuterMDs = mdsInGPU.nMDs[outerLowerModuleIndex];
 
         int limit = nInnerMDs*nOuterMDs;
-//printf("HERE:  %d %d limit %d\n", innerLowerModuleIndex, outerLowerModuleArrayIdx, limit);
 
         if (limit == 0) continue;
         for(int hitIndex = threadIdx.x; hitIndex< limit; hitIndex += blockzSize)


### PR DESCRIPTION
By @VourMa's suggestion, placed all printf statements in quintuplets.cu around the warnings ifdef. This does seem to reduce the max registers in T5 creation from 255 to 167 (still the highest but better than before.). This doesn't seem to happen anywhere else.
![image](https://user-images.githubusercontent.com/6370024/235762117-19feba0a-279a-459f-9cfd-4644870aea8c.png)

No physics validation