### PR TITLE
Move New "Ranges" Kernels to Alpaka + Working Alpaka Multistreaming

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -768,11 +768,30 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
         mdsInGPU = (SDL::miniDoublets*)cms::cuda::allocate_host(sizeof(SDL::miniDoublets), stream);
         unsigned int nTotalMDs;
         cudaMemsetAsync(&rangesInGPU->miniDoubletModuleOccupancy[nLowerModules],N_MAX_PIXEL_MD_PER_MODULES, sizeof(unsigned int),stream);
-        createMDArrayRangesGPU<<<1,1024,0,stream>>>(*modulesInGPU, *rangesInGPU);
+
+        // Temporary fix for queue initialization.
+        QueueAcc queue(devAcc);
+
+        Vec const threadsPerBlockCreateMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
+        Vec const blocksPerGridCreateMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
+        WorkDiv const createMDArrayRangesGPU_workDiv(blocksPerGridCreateMD, threadsPerBlockCreateMD, elementsPerThread);
+
+        SDL::createMDArrayRangesGPU createMDArrayRangesGPU_kernel;
+        auto const createMDArrayRangesGPUTask(alpaka::createTaskKernel<Acc>(
+            createMDArrayRangesGPU_workDiv,
+            createMDArrayRangesGPU_kernel,
+            *modulesInGPU,
+            *rangesInGPU));
+
+        alpaka::enqueue(queue, createMDArrayRangesGPUTask);
+        alpaka::wait(queue);
+
         cudaMemcpyAsync(&nTotalMDs,rangesInGPU->device_nTotalMDs,sizeof(unsigned int),cudaMemcpyDeviceToHost,stream);
         cudaStreamSynchronize(stream);
         nTotalMDs+= N_MAX_PIXEL_MD_PER_MODULES;
+
         createMDsInExplicitMemory(*mdsInGPU, nTotalMDs, nLowerModules, N_MAX_PIXEL_MD_PER_MODULES,stream);
+
         cudaMemcpyAsync(mdsInGPU->nMemoryLocations, &nTotalMDs, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
         cudaStreamSynchronize(stream);
     }
@@ -781,7 +800,25 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
         segmentsInGPU = (SDL::segments*)cms::cuda::allocate_host(sizeof(SDL::segments), stream);
         // can be optimized here: because we didn't distinguish pixel segments and outer-tracker segments and call them both "segments", so they use the index continuously.
         // If we want to further study the memory footprint in detail, we can separate the two and allocate different memories to them
-        createSegmentArrayRanges<<<1,1024,0,stream>>>(*modulesInGPU, *rangesInGPU, *mdsInGPU);
+
+        // Temporary fix for queue initialization.
+        QueueAcc queue(devAcc);
+
+        Vec const threadsPerBlockCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
+        Vec const blocksPerGridCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
+        WorkDiv const createSegmentArrayRanges_workDiv(blocksPerGridCreateSeg, threadsPerBlockCreateSeg, elementsPerThread);
+
+        SDL::createSegmentArrayRanges createSegmentArrayRanges_kernel;
+        auto const createSegmentArrayRangesTask(alpaka::createTaskKernel<Acc>(
+            createSegmentArrayRanges_workDiv,
+            createSegmentArrayRanges_kernel,
+            *modulesInGPU,
+            *rangesInGPU,
+            *mdsInGPU));
+
+        alpaka::enqueue(queue, createSegmentArrayRangesTask);
+        alpaka::wait(queue);
+
         cudaMemcpyAsync(&nTotalSegments,rangesInGPU->device_nTotalSegs,sizeof(unsigned int),cudaMemcpyDeviceToHost,stream);
         cudaStreamSynchronize(stream);
         nTotalSegments += N_MAX_PIXEL_SEGMENTS_PER_MODULE;
@@ -936,7 +973,24 @@ void SDL::Event::createMiniDoublets()
     //hardcoded range numbers for this will come from studies!
     unsigned int nTotalMDs;
     cudaMemsetAsync(&rangesInGPU->miniDoubletModuleOccupancy[nLowerModules],N_MAX_PIXEL_MD_PER_MODULES, sizeof(unsigned int),stream);
-    createMDArrayRangesGPU<<<1,1024,0,stream>>>(*modulesInGPU, *rangesInGPU); 
+
+    // Temporary fix for queue initialization.
+    QueueAcc queue(devAcc);
+
+    Vec const threadsPerBlockCreateMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
+    Vec const blocksPerGridCreateMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
+    WorkDiv const createMDArrayRangesGPU_workDiv(blocksPerGridCreateMD, threadsPerBlockCreateMD, elementsPerThread);
+
+    SDL::createMDArrayRangesGPU createMDArrayRangesGPU_kernel;
+    auto const createMDArrayRangesGPUTask(alpaka::createTaskKernel<Acc>(
+        createMDArrayRangesGPU_workDiv,
+        createMDArrayRangesGPU_kernel,
+        *modulesInGPU,
+        *rangesInGPU));
+
+    alpaka::enqueue(queue, createMDArrayRangesGPUTask);
+    alpaka::wait(queue);
+
     cudaMemcpyAsync(&nTotalMDs,rangesInGPU->device_nTotalMDs,sizeof(unsigned int),cudaMemcpyDeviceToHost,stream);
     cudaStreamSynchronize(stream);
     nTotalMDs+=N_MAX_PIXEL_MD_PER_MODULES;
@@ -983,13 +1037,9 @@ void SDL::Event::createMiniDoublets()
     cms::cuda::free_host(module_isLower);
     cms::cuda::free_host(module_isInverted);
 
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
-
-    Vec const threadsPerBlock(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(32));
-    Vec const blocksPerGrid(static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1));
-
-    WorkDiv const createMiniDoubletsInGPUv2_workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
+    Vec const threadsPerBlockCreateMDInGPU(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(32));
+    Vec const blocksPerGridCreateMDInGPU(static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1));
+    WorkDiv const createMiniDoubletsInGPUv2_workDiv(blocksPerGridCreateMDInGPU, threadsPerBlockCreateMDInGPU, elementsPerThread);
 
     SDL::createMiniDoubletsInGPUv2 createMiniDoubletsInGPUv2_kernel;
     auto const createMiniDoubletsInGPUv2Task(alpaka::createTaskKernel<Acc>(
@@ -1001,13 +1051,26 @@ void SDL::Event::createMiniDoublets()
         *rangesInGPU));
 
     alpaka::enqueue(queue, createMiniDoubletsInGPUv2Task);
+
+    Vec const threadsPerBlockAddMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
+    Vec const blocksPerGridAddMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
+    WorkDiv const addMiniDoubletRangesToEventExplicit_workDiv(blocksPerGridAddMD, threadsPerBlockAddMD, elementsPerThread);
+
+    SDL::addMiniDoubletRangesToEventExplicit addMiniDoubletRangesToEventExplicit_kernel;
+    auto const addMiniDoubletRangesToEventExplicitTask(alpaka::createTaskKernel<Acc>(
+        addMiniDoubletRangesToEventExplicit_workDiv,
+        addMiniDoubletRangesToEventExplicit_kernel,
+        *modulesInGPU,
+        *mdsInGPU,
+        *rangesInGPU,
+        *hitsInGPU));
+
+    alpaka::enqueue(queue, addMiniDoubletRangesToEventExplicitTask);
     alpaka::wait(queue);
 
-    addMiniDoubletRangesToEventExplicit<<<1,1024,0,stream>>>(*modulesInGPU,*mdsInGPU, *rangesInGPU,*hitsInGPU);
-    cudaStreamSynchronize(stream);
-
-    if(addObjects){
-      addMiniDoubletsToEventExplicit();
+    if(addObjects)
+    {
+        addMiniDoubletsToEventExplicit();
     }
 
 }
@@ -1023,10 +1086,9 @@ void SDL::Event::createSegmentsWithModuleMap()
     // Temporary fix for queue initialization.
     QueueAcc queue(devAcc);
 
-    Vec const threadsPerBlock(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(64));
-    Vec const blocksPerGrid(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(nLowerModules));
-
-    WorkDiv const createSegmentsInGPUv2_workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
+    Vec const threadsPerBlockCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(64));
+    Vec const blocksPerGridCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(nLowerModules));
+    WorkDiv const createSegmentsInGPUv2_workDiv(blocksPerGridCreateSeg, threadsPerBlockCreateSeg, elementsPerThread);
 
     SDL::createSegmentsInGPUv2 createSegmentsInGPUv2_kernel;
     auto const createSegmentsInGPUv2Task(alpaka::createTaskKernel<Acc>(
@@ -1038,13 +1100,25 @@ void SDL::Event::createSegmentsWithModuleMap()
         *rangesInGPU));
 
     alpaka::enqueue(queue, createSegmentsInGPUv2Task);
+
+    Vec const threadsPerBlockAddSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
+    Vec const blocksPerGridAddSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
+    WorkDiv const addSegmentRangesToEventExplicit_workDiv(blocksPerGridAddSeg, threadsPerBlockAddSeg, elementsPerThread);
+
+    SDL::addSegmentRangesToEventExplicit addSegmentRangesToEventExplicit_kernel;
+    auto const addSegmentRangesToEventExplicitTask(alpaka::createTaskKernel<Acc>(
+        addSegmentRangesToEventExplicit_workDiv,
+        addSegmentRangesToEventExplicit_kernel,
+        *modulesInGPU,
+        *segmentsInGPU,
+        *rangesInGPU));
+
+    alpaka::enqueue(queue, addSegmentRangesToEventExplicitTask);
     alpaka::wait(queue);
 
-    addSegmentRangesToEventExplicit<<<1,1024,0,stream>>>(*modulesInGPU,*segmentsInGPU, *rangesInGPU);
-    cudaStreamSynchronize(stream);
-
-    if(addObjects){
-      addSegmentsToEventExplicit();
+    if(addObjects)
+    {
+        addSegmentsToEventExplicit();
     }
 }
 
@@ -1055,9 +1129,28 @@ void SDL::Event::createTriplets()
     {
         tripletsInGPU = (SDL::triplets*)cms::cuda::allocate_host(sizeof(SDL::triplets), stream);
         unsigned int maxTriplets;
-        createTripletArrayRanges<<<1,1024,0,stream>>>(*modulesInGPU, *rangesInGPU, *segmentsInGPU);
+
+        // Temporary fix for queue initialization.
+        QueueAcc queue(devAcc);
+
+        Vec const threadsPerBlockCreateTrip(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
+        Vec const blocksPerGridCreateTrip(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
+        WorkDiv const createTripletArrayRanges_workDiv(blocksPerGridCreateTrip, threadsPerBlockCreateTrip, elementsPerThread);
+
+        SDL::createTripletArrayRanges createTripletArrayRanges_kernel;
+        auto const createTripletArrayRangesTask(alpaka::createTaskKernel<Acc>(
+            createTripletArrayRanges_workDiv,
+            createTripletArrayRanges_kernel,
+            *modulesInGPU,
+            *rangesInGPU,
+            *segmentsInGPU));
+
+        alpaka::enqueue(queue, createTripletArrayRangesTask);
+        alpaka::wait(queue);
+
         cudaMemcpyAsync(&maxTriplets,rangesInGPU->device_nTotalTrips,sizeof(unsigned int),cudaMemcpyDeviceToHost,stream);
         cudaStreamSynchronize(stream);
+
         createTripletsInExplicitMemory(*tripletsInGPU, maxTriplets, nLowerModules,stream);
 
         cudaMemcpyAsync(tripletsInGPU->nMemoryLocations, &maxTriplets, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
@@ -1096,10 +1189,9 @@ void SDL::Event::createTriplets()
     // Temporary fix for queue initialization.
     QueueAcc queue(devAcc);
 
-    Vec const threadsPerBlock(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
-    Vec const blocksPerGrid(static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1), static_cast<Idx>(1));
-
-    WorkDiv const createTripletsInGPUv2_workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
+    Vec const threadsPerBlockCreateTrip(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
+    Vec const blocksPerGridCreateTrip(static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1), static_cast<Idx>(1));
+    WorkDiv const createTripletsInGPUv2_workDiv(blocksPerGridCreateTrip, threadsPerBlockCreateTrip, elementsPerThread);
 
     SDL::createTripletsInGPUv2 createTripletsInGPUv2_kernel;
     auto const createTripletsInGPUv2Task(alpaka::createTaskKernel<Acc>(
@@ -1114,17 +1206,29 @@ void SDL::Event::createTriplets()
         nonZeroModules));
 
     alpaka::enqueue(queue, createTripletsInGPUv2Task);
-    alpaka::wait(queue);
 
-    addTripletRangesToEventExplicit<<<1,1024,0,stream>>>(*modulesInGPU,*tripletsInGPU,*rangesInGPU);
-    cudaStreamSynchronize(stream);
+    Vec const threadsPerBlockAddTrip(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
+    Vec const blocksPerGridAddTrip(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
+    WorkDiv const addTripletRangesToEventExplicit_workDiv(blocksPerGridAddTrip, threadsPerBlockAddTrip, elementsPerThread);
+
+    SDL::addTripletRangesToEventExplicit addTripletRangesToEventExplicit_kernel;
+    auto const addTripletRangesToEventExplicitTask(alpaka::createTaskKernel<Acc>(
+        addTripletRangesToEventExplicit_workDiv,
+        addTripletRangesToEventExplicit_kernel,
+        *modulesInGPU,
+        *tripletsInGPU,
+        *rangesInGPU));
+
+    alpaka::enqueue(queue, addTripletRangesToEventExplicitTask);
+    alpaka::wait(queue);
 
     free(nSegments);
     free(index);
     cms::cuda::free_device(dev, index_gpu);
 
-    if(addObjects){
-      addTripletsToEventExplicit();
+    if(addObjects)
+    {
+        addTripletsToEventExplicit();
     }
 }
 
@@ -1143,7 +1247,6 @@ void SDL::Event::createTrackCandidates()
 
     Vec const threadsPerBlock_crossCleanpT3(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(64));
     Vec const blocksPerGrid_crossCleanpT3(static_cast<Idx>(1), static_cast<Idx>(4), static_cast<Idx>(20));
-
     WorkDiv const crossCleanpT3_workDiv(blocksPerGrid_crossCleanpT3, blocksPerGrid_crossCleanpT3, elementsPerThread);
 
     SDL::crossCleanpT3 crossCleanpT3_kernel;
@@ -1162,7 +1265,6 @@ void SDL::Event::createTrackCandidates()
     //adding objects
     Vec const threadsPerBlock_addpT3asTrackCandidatesInGPU(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(512));
     Vec const blocksPerGrid_addpT3asTrackCandidatesInGPU(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
-
     WorkDiv const addpT3asTrackCandidatesInGPU_workDiv(blocksPerGrid_addpT3asTrackCandidatesInGPU, threadsPerBlock_addpT3asTrackCandidatesInGPU, elementsPerThread);
 
     SDL::addpT3asTrackCandidatesInGPU addpT3asTrackCandidatesInGPU_kernel;
@@ -1177,7 +1279,6 @@ void SDL::Event::createTrackCandidates()
 
     Vec const threadsPerBlockRemoveDupQuints(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(32));
     Vec const blocksPerGridRemoveDupQuints(static_cast<Idx>(1), static_cast<Idx>(max(nEligibleModules/16,1)), static_cast<Idx>(max(nEligibleModules/32,1)));
-
     WorkDiv const removeDupQuintupletsInGPUBeforeTC_workDiv(blocksPerGridRemoveDupQuints, threadsPerBlockRemoveDupQuints, elementsPerThread);
 
     SDL::removeDupQuintupletsInGPUBeforeTC removeDupQuintupletsInGPUBeforeTC_kernel;
@@ -1192,7 +1293,6 @@ void SDL::Event::createTrackCandidates()
 
     Vec const threadsPerBlock_crossCleanT5(static_cast<Idx>(32), static_cast<Idx>(1), static_cast<Idx>(32));
     Vec const blocksPerGrid_crossCleanT5(static_cast<Idx>((13296/32) + 1), static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS));
-
     WorkDiv const crossCleanT5_workDiv(blocksPerGrid_crossCleanT5, threadsPerBlock_crossCleanT5, elementsPerThread);
 
     SDL::crossCleanT5 crossCleanT5_kernel;
@@ -1210,7 +1310,6 @@ void SDL::Event::createTrackCandidates()
 
     Vec const threadsPerBlock_addT5asTrackCandidateInGPU(static_cast<Idx>(1), static_cast<Idx>(8), static_cast<Idx>(128));
     Vec const blocksPerGrid_addT5asTrackCandidateInGPU(static_cast<Idx>(1), static_cast<Idx>(8), static_cast<Idx>(10));
-
     WorkDiv const addT5asTrackCandidateInGPU_workDiv(blocksPerGrid_addT5asTrackCandidateInGPU, threadsPerBlock_addT5asTrackCandidateInGPU, elementsPerThread);
 
     SDL::addT5asTrackCandidateInGPU addT5asTrackCandidateInGPU_kernel;
@@ -1227,7 +1326,6 @@ void SDL::Event::createTrackCandidates()
 
     Vec const threadsPerBlockCheckHitspLS(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
     Vec const blocksPerGridCheckHitspLS(static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS*4), static_cast<Idx>(MAX_BLOCKS/4));
-
     WorkDiv const checkHitspLS_workDiv(blocksPerGridCheckHitspLS, threadsPerBlockCheckHitspLS, elementsPerThread);
 
     SDL::checkHitspLS checkHitspLS_kernel;
@@ -1243,7 +1341,6 @@ void SDL::Event::createTrackCandidates()
 
     Vec const threadsPerBlock_crossCleanpLS(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(32));
     Vec const blocksPerGrid_crossCleanpLS(static_cast<Idx>(1), static_cast<Idx>(4), static_cast<Idx>(20));
-
     WorkDiv const crossCleanpLS_workDiv(blocksPerGrid_crossCleanpLS, threadsPerBlock_crossCleanpLS, elementsPerThread);
 
     SDL::crossCleanpLS crossCleanpLS_kernel;
@@ -1264,7 +1361,6 @@ void SDL::Event::createTrackCandidates()
 
     Vec const threadsPerBlock_addpLSasTrackCandidateInGPU(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(384));
     Vec const blocksPerGrid_addpLSasTrackCandidateInGPU(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS));
-
     WorkDiv const addpLSasTrackCandidateInGPU_workDiv(blocksPerGrid_addpLSasTrackCandidateInGPU, threadsPerBlock_addpLSasTrackCandidateInGPU, elementsPerThread);
 
     SDL::addpLSasTrackCandidateInGPU addpLSasTrackCandidateInGPU_kernel;
@@ -1365,7 +1461,6 @@ void SDL::Event::createPixelTriplets()
 
     Vec const threadsPerBlock(static_cast<Idx>(1), static_cast<Idx>(4), static_cast<Idx>(32));
     Vec const blocksPerGrid(static_cast<Idx>(16 /* above median of connected modules*/), static_cast<Idx>(4096), static_cast<Idx>(1));
-
     WorkDiv const createPixelTripletsInGPUFromMapv2_workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
 
     SDL::createPixelTripletsInGPUFromMapv2 createPixelTripletsInGPUFromMapv2_kernel;
@@ -1400,7 +1495,6 @@ void SDL::Event::createPixelTriplets()
     Vec const threadsPerBlockDupPixTrip(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
     //seems like more blocks lead to conflicting writes
     Vec const blocksPerGridDupPixTrip(static_cast<Idx>(1), static_cast<Idx>(40), static_cast<Idx>(1));
-
     WorkDiv const removeDupPixelTripletsInGPUFromMap_workDiv(blocksPerGridDupPixTrip, threadsPerBlockDupPixTrip, elementsPerThread);
 
     SDL::removeDupPixelTripletsInGPUFromMap removeDupPixelTripletsInGPUFromMap_kernel;
@@ -1432,7 +1526,6 @@ void SDL::Event::createQuintuplets()
 
     Vec const threadsPerBlockCreateQuints(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
     Vec const blocksPerGridCreateQuints(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
-
     WorkDiv const createEligibleModulesListForQuintupletsGPU_workDiv(blocksPerGridCreateQuints, threadsPerBlockCreateQuints, elementsPerThread);
 
     SDL::createEligibleModulesListForQuintupletsGPU createEligibleModulesListForQuintupletsGPU_kernel;
@@ -1460,7 +1553,6 @@ void SDL::Event::createQuintuplets()
 
     Vec const threadsPerBlockQuints(static_cast<Idx>(1), static_cast<Idx>(8), static_cast<Idx>(32));
     Vec const blocksPerGridQuints(static_cast<Idx>(max(nEligibleT5Modules,1)), static_cast<Idx>(1), static_cast<Idx>(1));
-
     WorkDiv const createQuintupletsInGPUv2_workDiv(blocksPerGridQuints, threadsPerBlockQuints, elementsPerThread);
 
     SDL::createQuintupletsInGPUv2 createQuintupletsInGPUv2_kernel;
@@ -1480,7 +1572,6 @@ void SDL::Event::createQuintuplets()
 
     Vec const threadsPerBlockDupQuint(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
     Vec const blocksPerGridDupQuint(static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1), static_cast<Idx>(1));
-
     WorkDiv const removeDupQuintupletsInGPUAfterBuild_workDiv(blocksPerGridDupQuint, threadsPerBlockDupQuint, elementsPerThread);
 
     SDL::removeDupQuintupletsInGPUAfterBuild removeDupQuintupletsInGPUAfterBuild_kernel;
@@ -1492,15 +1583,26 @@ void SDL::Event::createQuintuplets()
         *rangesInGPU));
 
     alpaka::enqueue(queue, removeDupQuintupletsInGPUAfterBuildTask);
+
+    Vec const threadsPerBlockAddQuint(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
+    Vec const blocksPerGridAddQuint(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
+    WorkDiv const addQuintupletRangesToEventExplicit_workDiv(blocksPerGridAddQuint, threadsPerBlockAddQuint, elementsPerThread);
+
+    SDL::addQuintupletRangesToEventExplicit addQuintupletRangesToEventExplicit_kernel;
+    auto const addQuintupletRangesToEventExplicitTask(alpaka::createTaskKernel<Acc>(
+        addQuintupletRangesToEventExplicit_workDiv,
+        addQuintupletRangesToEventExplicit_kernel,
+        *modulesInGPU,
+        *quintupletsInGPU,
+        *rangesInGPU));
+
+    alpaka::enqueue(queue, addQuintupletRangesToEventExplicitTask);
     alpaka::wait(queue);
 
-    addQuintupletRangesToEventExplicit<<<1,1024,0,stream>>>(*modulesInGPU, *quintupletsInGPU,*rangesInGPU);
-    cudaStreamSynchronize(stream);
-
-    if(addObjects){
-      addQuintupletsToEventExplicit();
+    if(addObjects)
+    {
+        addQuintupletsToEventExplicit();
     }
-
 }
 
 void SDL::Event::pixelLineSegmentCleaning()
@@ -1510,7 +1612,6 @@ void SDL::Event::pixelLineSegmentCleaning()
 
     Vec const threadsPerBlockCheckHitspLS(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
     Vec const blocksPerGridCheckHitspLS(static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS*4), static_cast<Idx>(MAX_BLOCKS/4));
-
     WorkDiv const checkHitspLS_workDiv(blocksPerGridCheckHitspLS, threadsPerBlockCheckHitspLS, elementsPerThread);
 
     SDL::checkHitspLS checkHitspLS_kernel;
@@ -1610,7 +1711,6 @@ void SDL::Event::createPixelQuintuplets()
 
     Vec const threadsPerBlockCreatePixQuints(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
     Vec const blocksPerGridCreatePixQuints(static_cast<Idx>(16), static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1));
-
     WorkDiv const createPixelQuintupletsInGPUFromMapv2_workDiv(blocksPerGridCreatePixQuints, threadsPerBlockCreatePixQuints, elementsPerThread);
 
     SDL::createPixelQuintupletsInGPUFromMapv2 createPixelQuintupletsInGPUFromMapv2_kernel;
@@ -1641,7 +1741,6 @@ void SDL::Event::createPixelQuintuplets()
 
     Vec const threadsPerBlockDupPix(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
     Vec const blocksPerGridDupPix(static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1));
-
     WorkDiv const removeDupPixelQuintupletsInGPUFromMap_workDiv(blocksPerGridDupPix, threadsPerBlockDupPix, elementsPerThread);
 
     SDL::removeDupPixelQuintupletsInGPUFromMap removeDupPixelQuintupletsInGPUFromMap_kernel;
@@ -1656,7 +1755,6 @@ void SDL::Event::createPixelQuintuplets()
 
     Vec const threadsPerBlockAddpT5asTrackCan(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(256));
     Vec const blocksPerGridAddpT5asTrackCan(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
-
     WorkDiv const addpT5asTrackCandidateInGPU_workDiv(blocksPerGridAddpT5asTrackCan, threadsPerBlockAddpT5asTrackCan, elementsPerThread);
 
     SDL::addpT5asTrackCandidateInGPU addpT5asTrackCandidateInGPU_kernel;
@@ -1676,7 +1774,6 @@ void SDL::Event::createPixelQuintuplets()
     std::cout<<"number of pixel quintuplets = "<<nPixelQuintuplets<<std::endl;
 #endif   
 }
-
 
 void SDL::Event::addQuintupletsToEventExplicit()
 {

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -6,17 +6,9 @@ uint16_t SDL::nModules;
 uint16_t SDL::nLowerModules;
 
 // Temporary alpaka statements
-using Dim = alpaka::DimInt<3u>;
-using Idx = std::size_t;
-using Vec = alpaka::Vec<Dim,Idx>;
-using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
-using Acc = alpaka::AccGpuCudaRt<Dim, Idx>;
-using QueueProperty = alpaka::NonBlocking;
-using QueueAcc = alpaka::Queue<Acc, QueueProperty>;
-auto devAcc = alpaka::getDevByIdx<Acc>(0u);
 Vec const elementsPerThread(Vec::all(static_cast<Idx>(1)));
 
-SDL::Event::Event(cudaStream_t estream,bool verbose)
+SDL::Event::Event(cudaStream_t estream, bool verbose): queue(alpaka::getDevByIdx<Acc>(0u))
 {
     int version;
     int driver;
@@ -265,7 +257,6 @@ SDL::Event::~Event()
         delete[] modulesInCPUFull->moduleLayerType;
         delete[] modulesInCPUFull;
     }
-    SDL::freeEndCapMapMemory();
 }
 
 void SDL::Event::resetEvent()
@@ -664,9 +655,6 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
     cudaMemcpyAsync(hitsInGPU->nHits, &nHits, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
     cudaStreamSynchronize(stream);
 
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
-
     Vec const threadsPerBlock1(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(256));
     Vec const blocksPerGrid1(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS));
     WorkDiv const hit_loop_workdiv(blocksPerGrid1, threadsPerBlock1, elementsPerThread);
@@ -769,9 +757,6 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
         unsigned int nTotalMDs;
         cudaMemsetAsync(&rangesInGPU->miniDoubletModuleOccupancy[nLowerModules],N_MAX_PIXEL_MD_PER_MODULES, sizeof(unsigned int),stream);
 
-        // Temporary fix for queue initialization.
-        QueueAcc queue(devAcc);
-
         Vec const threadsPerBlockCreateMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
         Vec const blocksPerGridCreateMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
         WorkDiv const createMDArrayRangesGPU_workDiv(blocksPerGridCreateMD, threadsPerBlockCreateMD, elementsPerThread);
@@ -800,9 +785,6 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
         segmentsInGPU = (SDL::segments*)cms::cuda::allocate_host(sizeof(SDL::segments), stream);
         // can be optimized here: because we didn't distinguish pixel segments and outer-tracker segments and call them both "segments", so they use the index continuously.
         // If we want to further study the memory footprint in detail, we can separate the two and allocate different memories to them
-
-        // Temporary fix for queue initialization.
-        QueueAcc queue(devAcc);
 
         Vec const threadsPerBlockCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
         Vec const blocksPerGridCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
@@ -859,9 +841,6 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
     cudaMemcpyAsync(&(mdsInGPU->nMDs)[pixelModuleIndex], &mdSize, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
     cudaMemcpyAsync(&(mdsInGPU->totOccupancyMDs)[pixelModuleIndex], &mdSize, sizeof(unsigned int), cudaMemcpyHostToDevice, stream);
     cudaStreamSynchronize(stream);
-
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
 
     Vec const threadsPerBlock(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(256));
     Vec const blocksPerGrid(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS));
@@ -974,9 +953,6 @@ void SDL::Event::createMiniDoublets()
     unsigned int nTotalMDs;
     cudaMemsetAsync(&rangesInGPU->miniDoubletModuleOccupancy[nLowerModules],N_MAX_PIXEL_MD_PER_MODULES, sizeof(unsigned int),stream);
 
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
-
     Vec const threadsPerBlockCreateMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
     Vec const blocksPerGridCreateMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
     WorkDiv const createMDArrayRangesGPU_workDiv(blocksPerGridCreateMD, threadsPerBlockCreateMD, elementsPerThread);
@@ -1083,9 +1059,6 @@ void SDL::Event::createSegmentsWithModuleMap()
         createSegmentsInExplicitMemory(*segmentsInGPU, nTotalSegments, nLowerModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE,stream);
     }
 
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
-
     Vec const threadsPerBlockCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(64));
     Vec const blocksPerGridCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(nLowerModules));
     WorkDiv const createSegmentsInGPUv2_workDiv(blocksPerGridCreateSeg, threadsPerBlockCreateSeg, elementsPerThread);
@@ -1129,9 +1102,6 @@ void SDL::Event::createTriplets()
     {
         tripletsInGPU = (SDL::triplets*)cms::cuda::allocate_host(sizeof(SDL::triplets), stream);
         unsigned int maxTriplets;
-
-        // Temporary fix for queue initialization.
-        QueueAcc queue(devAcc);
 
         Vec const threadsPerBlockCreateTrip(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
         Vec const blocksPerGridCreateTrip(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
@@ -1186,9 +1156,6 @@ void SDL::Event::createTriplets()
     cudaMemcpyAsync(index_gpu, index, nonZeroModules*sizeof(uint16_t), cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
 
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
-
     Vec const threadsPerBlockCreateTrip(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
     Vec const blocksPerGridCreateTrip(static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1), static_cast<Idx>(1));
     WorkDiv const createTripletsInGPUv2_workDiv(blocksPerGridCreateTrip, threadsPerBlockCreateTrip, elementsPerThread);
@@ -1241,9 +1208,6 @@ void SDL::Event::createTrackCandidates()
         trackCandidatesInGPU = (SDL::trackCandidates*)cms::cuda::allocate_host(sizeof(SDL::trackCandidates), stream);
         createTrackCandidatesInExplicitMemory(*trackCandidatesInGPU, N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES,stream);
     }
-
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
 
     Vec const threadsPerBlock_crossCleanpT3(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(64));
     Vec const blocksPerGrid_crossCleanpT3(static_cast<Idx>(1), static_cast<Idx>(4), static_cast<Idx>(20));
@@ -1456,9 +1420,6 @@ void SDL::Event::createPixelTriplets()
     cms::cuda::free_host(pixelTypes);
     cms::cuda::free_host(nTriplets);
 
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
-
     Vec const threadsPerBlock(static_cast<Idx>(1), static_cast<Idx>(4), static_cast<Idx>(32));
     Vec const blocksPerGrid(static_cast<Idx>(16 /* above median of connected modules*/), static_cast<Idx>(4096), static_cast<Idx>(1));
     WorkDiv const createPixelTripletsInGPUFromMapv2_workDiv(blocksPerGrid, threadsPerBlock, elementsPerThread);
@@ -1520,9 +1481,6 @@ void SDL::Event::createQuintuplets()
     cudaMemsetAsync(rangesInGPU->quintupletModuleIndices, -1, sizeof(int) * (nLowerModules),stream);
     cudaStreamSynchronize(stream);
     unsigned int nTotalQuintuplets;
-
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
 
     Vec const threadsPerBlockCreateQuints(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
     Vec const blocksPerGridCreateQuints(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1));
@@ -1607,9 +1565,6 @@ void SDL::Event::createQuintuplets()
 
 void SDL::Event::pixelLineSegmentCleaning()
 {
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
-
     Vec const threadsPerBlockCheckHitspLS(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
     Vec const blocksPerGridCheckHitspLS(static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS*4), static_cast<Idx>(MAX_BLOCKS/4));
     WorkDiv const checkHitspLS_workDiv(blocksPerGridCheckHitspLS, threadsPerBlockCheckHitspLS, elementsPerThread);
@@ -1705,9 +1660,6 @@ void SDL::Event::createPixelQuintuplets()
     cudaMemcpyAsync(connectedPixelSize_dev, connectedPixelSize_host, nInnerSegments*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
     cudaMemcpyAsync(connectedPixelIndex_dev, connectedPixelIndex_host, nInnerSegments*sizeof(unsigned int), cudaMemcpyHostToDevice,stream);
     cudaStreamSynchronize(stream);
-
-    // Temporary fix for queue initialization.
-    QueueAcc queue(devAcc);
 
     Vec const threadsPerBlockCreatePixQuints(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
     Vec const blocksPerGridCreatePixQuints(static_cast<Idx>(16), static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1));

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1050,6 +1050,7 @@ void SDL::Event::createMiniDoublets()
         *mdsInGPU,
         *rangesInGPU));
 
+    // No wait is needed here, runs concurrently with next kernel.
     alpaka::enqueue(queue, createMiniDoubletsInGPUv2Task);
 
     Vec const threadsPerBlockAddMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
@@ -1099,6 +1100,7 @@ void SDL::Event::createSegmentsWithModuleMap()
         *segmentsInGPU,
         *rangesInGPU));
 
+    // No wait is needed here, runs concurrently with next kernel.
     alpaka::enqueue(queue, createSegmentsInGPUv2Task);
 
     Vec const threadsPerBlockAddSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
@@ -1205,6 +1207,7 @@ void SDL::Event::createTriplets()
         index_gpu,
         nonZeroModules));
 
+    // No wait is needed here, runs concurrently with next kernel.
     alpaka::enqueue(queue, createTripletsInGPUv2Task);
 
     Vec const threadsPerBlockAddTrip(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
@@ -1582,6 +1585,7 @@ void SDL::Event::createQuintuplets()
         *quintupletsInGPU,
         *rangesInGPU));
 
+    // No wait is needed here, runs concurrently with next kernel.
     alpaka::enqueue(queue, removeDupQuintupletsInGPUAfterBuildTask);
 
     Vec const threadsPerBlockAddQuint(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1050,7 +1050,6 @@ void SDL::Event::createMiniDoublets()
         *mdsInGPU,
         *rangesInGPU));
 
-    // No wait is needed here, runs concurrently with next kernel.
     alpaka::enqueue(queue, createMiniDoubletsInGPUv2Task);
 
     Vec const threadsPerBlockAddMD(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
@@ -1100,7 +1099,6 @@ void SDL::Event::createSegmentsWithModuleMap()
         *segmentsInGPU,
         *rangesInGPU));
 
-    // No wait is needed here, runs concurrently with next kernel.
     alpaka::enqueue(queue, createSegmentsInGPUv2Task);
 
     Vec const threadsPerBlockAddSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
@@ -1207,7 +1205,6 @@ void SDL::Event::createTriplets()
         index_gpu,
         nonZeroModules));
 
-    // No wait is needed here, runs concurrently with next kernel.
     alpaka::enqueue(queue, createTripletsInGPUv2Task);
 
     Vec const threadsPerBlockAddTrip(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));
@@ -1585,7 +1582,6 @@ void SDL::Event::createQuintuplets()
         *quintupletsInGPU,
         *rangesInGPU));
 
-    // No wait is needed here, runs concurrently with next kernel.
     alpaka::enqueue(queue, removeDupQuintupletsInGPUAfterBuildTask);
 
     Vec const threadsPerBlockAddQuint(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(1024));

--- a/SDL/Event.cuh
+++ b/SDL/Event.cuh
@@ -14,6 +14,13 @@
 
 #include "allocate.h"
 
+// Temporary alpaka statements
+using Dim = alpaka::DimInt<3u>;
+using Idx = std::size_t;
+using Vec = alpaka::Vec<Dim,Idx>;
+using QueueProperty = alpaka::NonBlocking;
+using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
+
 namespace SDL
 {
     class Event
@@ -21,6 +28,13 @@ namespace SDL
     private:
         cudaStream_t stream;
         bool addObjects;
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+        using Acc = alpaka::AccGpuCudaRt<Dim, Idx>;
+        using QueueAcc = alpaka::Queue<Acc, QueueProperty>;
+        QueueAcc queue;
+#endif
+
         std::array<unsigned int, 6> n_hits_by_layer_barrel_;
         std::array<unsigned int, 5> n_hits_by_layer_endcap_;
         std::array<unsigned int, 6> n_minidoublets_by_layer_barrel_;

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -746,17 +746,22 @@ namespace SDL
             Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
             Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
+            // Initialize variables in shared memory and set to 0
             int& nTotalMDs = alpaka::declareSharedVar<int, __COUNTER__>(acc); nTotalMDs = 0;
             alpaka::syncBlockThreads(acc);
 
+            // Initialize variables outside of the for loop.
+            float module_eta;
+            unsigned int nTotMDs;
+            int occupancy, category_number, eta_number;
+            short module_subdets, module_layers, module_rings;
+
             for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2])
             {
-                short module_subdets = modulesInGPU.subdets[i];
-                short module_layers = modulesInGPU.layers[i];
-                short module_rings = modulesInGPU.rings[i];
-                float module_eta = modulesInGPU.eta[i];
-                float abs_eta = alpaka::math::abs(acc, module_eta);
-                int occupancy, category_number, eta_number;
+                module_rings = modulesInGPU.rings[i];
+                module_layers = modulesInGPU.layers[i];
+                module_subdets = modulesInGPU.subdets[i];
+                module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
 
                 if (module_layers<=3 && module_subdets==5) category_number = 0;
                 else if (module_layers>=4 && module_subdets==5) category_number = 1;
@@ -765,10 +770,10 @@ namespace SDL
                 else if (module_layers<=2 && module_subdets==4 && module_rings<=10) category_number = 3;
                 else if (module_layers>=3 && module_subdets==4 && module_rings<=7) category_number = 3;
 
-                if (abs_eta<0.75) eta_number=0;
-                else if (abs_eta>0.75 && abs_eta<1.5) eta_number=1;
-                else if (abs_eta>1.5  && abs_eta<2.25) eta_number=2;
-                else if (abs_eta>2.25 && abs_eta<3) eta_number=3;
+                if (module_eta<0.75) eta_number = 0;
+                else if (module_eta>0.75 && module_eta<1.5) eta_number = 1;
+                else if (module_eta>1.5  && module_eta<2.25) eta_number = 2;
+                else if (module_eta>2.25 && module_eta<3) eta_number = 3;
 
                 if (category_number == 0 && eta_number == 0) occupancy = 49;
                 else if (category_number == 0 && eta_number == 1) occupancy = 42;
@@ -781,7 +786,7 @@ namespace SDL
                 else if (category_number == 3 && eta_number == 2) occupancy = 20;
                 else if (category_number == 3 && eta_number == 3) occupancy = 25;
 
-                unsigned int nTotMDs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalMDs, occupancy);
+                nTotMDs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalMDs, occupancy);
 
                 rangesInGPU.miniDoubletModuleIndices[i] = nTotMDs; 
                 rangesInGPU.miniDoubletModuleOccupancy[i] = occupancy;

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -741,7 +741,8 @@ namespace SDL
             Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
             // Initialize variables in shared memory and set to 0
-            int& nTotalMDs = alpaka::declareSharedVar<int, __COUNTER__>(acc); nTotalMDs = 0;
+            int& nTotalMDs = alpaka::declareSharedVar<int, __COUNTER__>(acc);
+            nTotalMDs = 0;
             alpaka::syncBlockThreads(acc);
 
             // Initialize variables outside of the for loop.

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -746,17 +746,14 @@ namespace SDL
             alpaka::syncBlockThreads(acc);
 
             // Initialize variables outside of the for loop.
-            float module_eta;
-            unsigned int nTotMDs;
             int occupancy, category_number, eta_number;
-            short module_subdets, module_layers, module_rings;
 
             for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2])
             {
-                module_rings = modulesInGPU.rings[i];
-                module_layers = modulesInGPU.layers[i];
-                module_subdets = modulesInGPU.subdets[i];
-                module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
+                short module_rings = modulesInGPU.rings[i];
+                short module_layers = modulesInGPU.layers[i];
+                short module_subdets = modulesInGPU.subdets[i];
+                float module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
 
                 if (module_layers<=3 && module_subdets==5) category_number = 0;
                 else if (module_layers>=4 && module_subdets==5) category_number = 1;
@@ -781,7 +778,7 @@ namespace SDL
                 else if (category_number == 3 && eta_number == 2) occupancy = 20;
                 else if (category_number == 3 && eta_number == 3) occupancy = 25;
 
-                nTotMDs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalMDs, occupancy);
+                unsigned int nTotMDs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalMDs, occupancy);
 
                 rangesInGPU.miniDoubletModuleIndices[i] = nTotMDs; 
                 rangesInGPU.miniDoubletModuleOccupancy[i] = occupancy;

--- a/SDL/MiniDoublet.cuh
+++ b/SDL/MiniDoublet.cuh
@@ -75,7 +75,7 @@ namespace SDL
     {
         //the index into which this MD needs to be written will be computed in the kernel
         //nMDs variable will be incremented in the kernel, no need to worry about that here
-        
+
         mdsInGPU.moduleIndices[idx] = lowerModuleIdx;
         unsigned int anchorHitIndex, outerHitIndex;
         if(modulesInGPU.moduleType[lowerModuleIdx] == PS and modulesInGPU.moduleLayerType[lowerModuleIdx] == Strip)
@@ -267,7 +267,6 @@ namespace SDL
         // Compute luminous region requirement for endcap
         const float miniLum = alpaka::math::abs(acc, dPhi * deltaZLum/dz); // Balaji's new error
 
-
         // =================================================================
         // Return the threshold value
         // =================================================================
@@ -364,16 +363,16 @@ namespace SDL
         }
         else
         {
-                xo =xUpper;
-                yo =yUpper;
-                xp =xLower;
-                yp =yLower;
-                zp =zLower;
-                rtp =rtLower;
-                xp =xLower;
-                yp =yLower;
-                zp =zLower;
-                rtp =rtLower;
+            xo =xUpper;
+            yo =yUpper;
+            xp =xLower;
+            yp =yLower;
+            zp =zLower;
+            rtp =rtLower;
+            xp =xLower;
+            yp =yLower;
+            zp =zLower;
+            rtp =rtLower;
         }
 
         // If it is endcap some of the math gets simplified (and also computers don't like infinities)
@@ -476,7 +475,6 @@ namespace SDL
     template<typename TAcc>
     ALPAKA_FN_ACC bool runMiniDoubletDefaultAlgoBarrel(TAcc const & acc, struct modules& modulesInGPU, uint16_t& lowerModuleIndex, uint16_t& upperModuleIndex, unsigned int lowerHitIndex, unsigned int upperHitIndex, float& dz, float& dPhi, float& dPhiChange, float& shiftedX, float& shiftedY, float& shiftedZ, float& noshiftedDz, float& noShiftedDphi, float& noShiftedDphiChange, float xLower,float yLower, float zLower, float rtLower,float xUpper,float yUpper,float zUpper,float rtUpper)
     {
-
         bool pass = true; 
         dz = zLower - zUpper;     
         const float dzCut = modulesInGPU.moduleType[lowerModuleIndex] == SDL::PS ? 2.f : 10.f;
@@ -547,7 +545,6 @@ namespace SDL
                 // But I still placed this check for safety. (TODO: After cheking explicitly if not needed remove later?)
                 // setdeltaPhiChange(lowerHit.rt() < upperHitMod.rt() ? lowerHit.deltaPhiChange(upperHitMod) : upperHitMod.deltaPhiChange(lowerHit));
 
-
                 dPhiChange = (rtLower < shiftedRt) ? SDL::deltaPhiChange(acc, xLower, yLower, shiftedX, shiftedY) : SDL::deltaPhiChange(acc, shiftedX, shiftedY, xLower, yLower); 
                 noShiftedDphiChange = rtLower < rtUpper ? SDL::deltaPhiChange(acc, xLower,yLower, xUpper, yUpper) : SDL::deltaPhiChange(acc, xUpper, yUpper, xLower, yLower);
             }
@@ -577,11 +574,9 @@ namespace SDL
     template<typename TAcc>
     ALPAKA_FN_ACC bool runMiniDoubletDefaultAlgoEndcap(TAcc const & acc, struct modules& modulesInGPU, uint16_t& lowerModuleIndex, uint16_t& upperModuleIndex, unsigned int lowerHitIndex, unsigned int upperHitIndex, float& drt, float& dPhi, float& dPhiChange, float& shiftedX, float& shiftedY, float& shiftedZ, float& noshiftedDz, float& noShiftedDphi, float& noShiftedDphichange,float xLower, float yLower, float zLower, float rtLower,float xUpper,float yUpper,float zUpper,float rtUpper)
     {
-
         bool pass = true; 
 
         // There are series of cuts that applies to mini-doublet in a "endcap" region
-
         // Cut #1 : dz cut. The dz difference can't be larger than 1cm. (max separation is 4mm for modules in the endcap)
         // Ref to original code: https://github.com/slava77/cms-tkph2-ntuple/blob/184d2325147e6930030d3d1f780136bc2dd29ce6/doubletAnalysis.C#L3093
         // For PS module in case when it is tilted a different dz (after the strip hit shift) is calculated later.
@@ -708,7 +703,7 @@ namespace SDL
 
                     float dz, dphi, dphichange, shiftedX, shiftedY, shiftedZ, noShiftedDz, noShiftedDphi, noShiftedDphiChange;
                     bool success = runMiniDoubletDefaultAlgo(acc, modulesInGPU, lowerModuleIndex, upperModuleIndex, lowerHitArrayIndex, upperHitArrayIndex, dz, dphi, dphichange, shiftedX, shiftedY, shiftedZ, noShiftedDz, noShiftedDphi, noShiftedDphiChange, xLower,yLower,zLower,rtLower,xUpper,yUpper,zUpper,rtUpper);
-        if(success)
+                    if(success)
                     {
                         int totOccupancyMDs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &mdsInGPU.totOccupancyMDs[lowerModuleIndex], 1);
                         if(totOccupancyMDs >= (rangesInGPU.miniDoubletModuleOccupancy[lowerModuleIndex]))
@@ -724,7 +719,6 @@ namespace SDL
 
                             addMDToMemory(mdsInGPU,hitsInGPU, modulesInGPU, lowerHitArrayIndex, upperHitArrayIndex, lowerModuleIndex, dz, dphi, dphichange, shiftedX, shiftedY, shiftedZ, noShiftedDz, noShiftedDphi, noShiftedDphiChange, mdIndex);
                         }
-
                     }
                 }
             }

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -137,22 +137,3 @@ void SDL::createQuintupletsInExplicitMemory(struct SDL::quintuplets& quintuplets
     quintupletsInGPU.phi = quintupletsInGPU.pt + 2*nTotalQuintuplets;
     quintupletsInGPU.score_rphisum = quintupletsInGPU.pt + 3*nTotalQuintuplets;
 }
-
-__global__ void SDL::addQuintupletRangesToEventExplicit(struct modules& modulesInGPU, struct quintuplets& quintupletsInGPU, struct objectRanges& rangesInGPU)
-{
-    int gid = blockIdx.x * blockDim.x + threadIdx.x;
-    int np = gridDim.x * blockDim.x;
-    for(uint16_t i = gid; i < *modulesInGPU.nLowerModules; i+= np)
-    {
-        if(quintupletsInGPU.nQuintuplets[i] == 0 or rangesInGPU.quintupletModuleIndices[i] == -1)
-        {
-            rangesInGPU.quintupletRanges[i * 2] = -1;
-            rangesInGPU.quintupletRanges[i * 2 + 1] = -1;
-        }
-       else
-        {
-            rangesInGPU.quintupletRanges[i * 2] = rangesInGPU.quintupletModuleIndices[i];
-            rangesInGPU.quintupletRanges[i * 2 + 1] = rangesInGPU.quintupletModuleIndices[i] + quintupletsInGPU.nQuintuplets[i] - 1;
-        }
-    }
-}

--- a/SDL/Quintuplet.cuh
+++ b/SDL/Quintuplet.cuh
@@ -1918,25 +1918,22 @@ namespace SDL
             alpaka::syncBlockThreads(acc);
 
             // Initialize variables outside of the for loop.
-            float module_eta;
-            int nEligibleT5Modules, nTotQ;
             int occupancy, category_number, eta_number;
-            short module_subdets, module_layers, module_rings;
 
             for(int i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2])
             {
                 // Condition for a quintuple to exist for a module
                 // TCs don't exist for layers 5 and 6 barrel, and layers 2,3,4,5 endcap   
-                module_rings = modulesInGPU.rings[i];
-                module_layers = modulesInGPU.layers[i];
-                module_subdets = modulesInGPU.subdets[i];
-                module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
+                short module_rings = modulesInGPU.rings[i];
+                short module_layers = modulesInGPU.layers[i];
+                short module_subdets = modulesInGPU.subdets[i];
+                float module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
 
                 if (tripletsInGPU.nTriplets[i] == 0) continue;
                 if (module_subdets == SDL::Barrel and module_layers >= 3) continue;
                 if (module_subdets == SDL::Endcap and module_layers > 1) continue;
 
-                nEligibleT5Modules = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nEligibleT5Modulesx, 1);
+                int nEligibleT5Modules = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nEligibleT5Modulesx, 1);
 
                 if (module_layers<=3 && module_subdets==5) category_number = 0;
                 else if (module_layers>=4 && module_subdets==5) category_number = 1;
@@ -1958,7 +1955,7 @@ namespace SDL
                 else if (category_number == 3 && eta_number == 2) occupancy = 191;
                 else if (category_number == 3 && eta_number == 3) occupancy = 106;
 
-                nTotQ = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalQuintupletsx, occupancy);
+                int nTotQ = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalQuintupletsx, occupancy);
                 rangesInGPU.quintupletModuleIndices[i] = nTotQ;
                 rangesInGPU.indicesOfEligibleT5Modules[nEligibleT5Modules] = i;
             }

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -24,70 +24,6 @@ void SDL::segments::resetMemory(unsigned int nMemoryLocationsx, unsigned int nLo
     cudaMemsetAsync(pLSHitsIdxs, 0,maxPixelSegments * sizeof(uint4),stream);
 }
 
-
-__global__ void SDL::createSegmentArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct miniDoublets& mdsInGPU)
-{
-    short module_subdets;
-    short module_layers;
-    short module_rings;
-    float module_eta;
-
-    __shared__ unsigned int nTotalSegments;
-    nTotalSegments = 0; //start!
-    __syncthreads(); 
-    int gid = blockIdx.x * blockDim.x + threadIdx.x;
-    int np = gridDim.x * blockDim.x;
-    for(uint16_t i = gid; i < *modulesInGPU.nLowerModules; i+= np)
-    {
-        if(modulesInGPU.nConnectedModules[i] == 0)
-        {
-          rangesInGPU.segmentModuleIndices[i] = nTotalSegments;
-          rangesInGPU.segmentModuleOccupancy[i] = 0;
-          continue;
-        }
-        module_subdets = modulesInGPU.subdets[i];
-        module_layers = modulesInGPU.layers[i];
-        module_rings = modulesInGPU.rings[i];
-        module_eta = abs(modulesInGPU.eta[i]);
-        unsigned int occupancy;
-        unsigned int category_number, eta_number;
-        if (module_layers<=3 && module_subdets==5) category_number = 0;
-        else if (module_layers>=4 && module_subdets==5) category_number = 1;
-        else if (module_layers<=2 && module_subdets==4 && module_rings>=11) category_number = 2;
-        else if (module_layers>=3 && module_subdets==4 && module_rings>=8) category_number = 2;
-        else if (module_layers<=2 && module_subdets==4 && module_rings<=10) category_number = 3;
-        else if (module_layers>=3 && module_subdets==4 && module_rings<=7) category_number = 3;
-        if (module_eta<0.75) eta_number=0;
-        else if (module_eta>0.75 && module_eta<1.5) eta_number=1;
-        else if (module_eta>1.5  && module_eta<2.25) eta_number=2;
-        else if (module_eta>2.25 && module_eta<3) eta_number=3;
-
-        if (category_number == 0 && eta_number == 0) occupancy = 572;
-        else if (category_number == 0 && eta_number == 1) occupancy = 300;
-        else if (category_number == 0 && eta_number == 2) occupancy = 183;
-        else if (category_number == 0 && eta_number == 3) occupancy = 62;
-        else if (category_number == 1 && eta_number == 0) occupancy = 191;
-        else if (category_number == 1 && eta_number == 1) occupancy = 128;
-        else if (category_number == 2 && eta_number == 1) occupancy = 107;
-        else if (category_number == 2 && eta_number == 2) occupancy = 102;
-        else if (category_number == 3 && eta_number == 1) occupancy = 64;
-        else if (category_number == 3 && eta_number == 2) occupancy = 79;
-        else if (category_number == 3 && eta_number == 3) occupancy = 85;
-
-
-        unsigned int nTotSegs = atomicAdd(&nTotalSegments,occupancy);
-        rangesInGPU.segmentModuleIndices[i] = nTotSegs;
-        rangesInGPU.segmentModuleOccupancy[i] = occupancy;
-    }
-
-    __syncthreads();
-    if(threadIdx.x==0){
-      rangesInGPU.segmentModuleIndices[*modulesInGPU.nLowerModules] = nTotalSegments;
-      *rangesInGPU.device_nTotalSegs = nTotalSegments;
-    }
-}
-
-
 void SDL::createSegmentsInExplicitMemory(struct segments& segmentsInGPU, unsigned int nMemoryLocations, uint16_t nLowerModules, unsigned int maxPixelSegments, cudaStream_t stream)
 {
     //FIXME:Since the number of pixel segments is 10x the number of regular segments per module, we need to provide
@@ -261,24 +197,5 @@ void SDL::printSegment(struct SDL::segments& segmentsInGPU, struct SDL::miniDoub
     {
         IndentingOStreambuf indent(std::cout);
         printMD(mdsInGPU, hitsInGPU, modulesInGPU, outerMDIndex);
-    }
-}
-
-__global__ void SDL::addSegmentRangesToEventExplicit(struct modules& modulesInGPU, struct segments& segmentsInGPU, struct objectRanges& rangesInGPU)
-{
-    int gid = blockIdx.x * blockDim.x + threadIdx.x;
-    int np = gridDim.x * blockDim.x;
-    for(uint16_t i = gid; i < *modulesInGPU.nLowerModules; i+= np)
-    {
-        if(segmentsInGPU.nSegments[i] == 0)
-        {
-            rangesInGPU.segmentRanges[i * 2] = -1;
-            rangesInGPU.segmentRanges[i * 2 + 1] = -1;
-        }
-        else
-        {
-            rangesInGPU.segmentRanges[i * 2] = rangesInGPU.segmentModuleIndices[i];
-            rangesInGPU.segmentRanges[i * 2 + 1] = rangesInGPU.segmentModuleIndices[i] + segmentsInGPU.nSegments[i] - 1;
-        }
     }
 }

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -658,8 +658,15 @@ namespace SDL
             Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
             Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
+            // Initialize variables in shared memory and set to 0
             int& nTotalSegments = alpaka::declareSharedVar<int, __COUNTER__>(acc); nTotalSegments = 0;
             alpaka::syncBlockThreads(acc);
+
+            // Initialize variables outside of the for loop.
+            int nTotSegs;
+            float module_eta;
+            int occupancy, category_number, eta_number;
+            short module_subdets, module_layers, module_rings;
 
             for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i+= gridThreadExtent[2])
             {
@@ -670,13 +677,10 @@ namespace SDL
                     continue;
                 }
 
-                short module_subdets = modulesInGPU.subdets[i];
-                short module_layers = modulesInGPU.layers[i];
-                short module_rings = modulesInGPU.rings[i];
-                float module_eta = modulesInGPU.eta[i];
-                float abs_eta = alpaka::math::abs(acc, module_eta);
-                int occupancy;
-                int category_number, eta_number;
+                module_rings = modulesInGPU.rings[i];
+                module_layers = modulesInGPU.layers[i];
+                module_subdets = modulesInGPU.subdets[i];
+                module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
 
                 if (module_layers<=3 && module_subdets==5) category_number = 0;
                 else if (module_layers>=4 && module_subdets==5) category_number = 1;
@@ -685,10 +689,10 @@ namespace SDL
                 else if (module_layers<=2 && module_subdets==4 && module_rings<=10) category_number = 3;
                 else if (module_layers>=3 && module_subdets==4 && module_rings<=7) category_number = 3;
 
-                if (abs_eta<0.75) eta_number=0;
-                else if (abs_eta>0.75 && abs_eta<1.5) eta_number=1;
-                else if (abs_eta>1.5  && abs_eta<2.25) eta_number=2;
-                else if (abs_eta>2.25 && abs_eta<3) eta_number=3;
+                if (module_eta<0.75) eta_number = 0;
+                else if (module_eta>0.75 && module_eta<1.5) eta_number = 1;
+                else if (module_eta>1.5  && module_eta<2.25) eta_number = 2;
+                else if (module_eta>2.25 && module_eta<3) eta_number = 3;
 
                 if (category_number == 0 && eta_number == 0) occupancy = 572;
                 else if (category_number == 0 && eta_number == 1) occupancy = 300;
@@ -702,7 +706,7 @@ namespace SDL
                 else if (category_number == 3 && eta_number == 2) occupancy = 79;
                 else if (category_number == 3 && eta_number == 3) occupancy = 85;
 
-                int nTotSegs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalSegments,occupancy);
+                nTotSegs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalSegments,occupancy);
                 rangesInGPU.segmentModuleIndices[i] = nTotSegs;
                 rangesInGPU.segmentModuleOccupancy[i] = occupancy;
             }

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -61,10 +61,6 @@ namespace SDL
 
     void createSegmentsInExplicitMemory(struct segments& segmentsInGPU, unsigned int maxSegments, uint16_t nLowerModules, unsigned int maxPixelSegments,cudaStream_t stream);
 
-    __global__ void createSegmentArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct miniDoublets& mdsInGPU);
-
-    __global__ void addSegmentRangesToEventExplicit(struct modules& modulesInGPU, struct segments& segmentsInGPU, struct objectRanges& rangesInGPU);
-
     ALPAKA_FN_ACC ALPAKA_FN_INLINE float isTighterTiltedModules_seg(struct modules& modulesInGPU, unsigned int moduleIndex)
     {
         // The "tighter" tilted modules are the subset of tilted modules that have smaller spacing
@@ -641,6 +637,113 @@ namespace SDL
                             }
                         }
                     }
+                }
+            }
+        }
+    };
+
+    struct createSegmentArrayRanges
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct modules& modulesInGPU,
+                struct objectRanges& rangesInGPU,
+                struct miniDoublets& mdsInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            int& nTotalSegments = alpaka::declareSharedVar<int, __COUNTER__>(acc); nTotalSegments = 0;
+            alpaka::syncBlockThreads(acc);
+
+            for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i+= gridThreadExtent[2])
+            {
+                if(modulesInGPU.nConnectedModules[i] == 0)
+                {
+                    rangesInGPU.segmentModuleIndices[i] = nTotalSegments;
+                    rangesInGPU.segmentModuleOccupancy[i] = 0;
+                    continue;
+                }
+
+                short module_subdets = modulesInGPU.subdets[i];
+                short module_layers = modulesInGPU.layers[i];
+                short module_rings = modulesInGPU.rings[i];
+                float module_eta = modulesInGPU.eta[i];
+                float abs_eta = alpaka::math::abs(acc, module_eta);
+                int occupancy;
+                int category_number, eta_number;
+
+                if (module_layers<=3 && module_subdets==5) category_number = 0;
+                else if (module_layers>=4 && module_subdets==5) category_number = 1;
+                else if (module_layers<=2 && module_subdets==4 && module_rings>=11) category_number = 2;
+                else if (module_layers>=3 && module_subdets==4 && module_rings>=8) category_number = 2;
+                else if (module_layers<=2 && module_subdets==4 && module_rings<=10) category_number = 3;
+                else if (module_layers>=3 && module_subdets==4 && module_rings<=7) category_number = 3;
+
+                if (abs_eta<0.75) eta_number=0;
+                else if (abs_eta>0.75 && abs_eta<1.5) eta_number=1;
+                else if (abs_eta>1.5  && abs_eta<2.25) eta_number=2;
+                else if (abs_eta>2.25 && abs_eta<3) eta_number=3;
+
+                if (category_number == 0 && eta_number == 0) occupancy = 572;
+                else if (category_number == 0 && eta_number == 1) occupancy = 300;
+                else if (category_number == 0 && eta_number == 2) occupancy = 183;
+                else if (category_number == 0 && eta_number == 3) occupancy = 62;
+                else if (category_number == 1 && eta_number == 0) occupancy = 191;
+                else if (category_number == 1 && eta_number == 1) occupancy = 128;
+                else if (category_number == 2 && eta_number == 1) occupancy = 107;
+                else if (category_number == 2 && eta_number == 2) occupancy = 102;
+                else if (category_number == 3 && eta_number == 1) occupancy = 64;
+                else if (category_number == 3 && eta_number == 2) occupancy = 79;
+                else if (category_number == 3 && eta_number == 3) occupancy = 85;
+
+                int nTotSegs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalSegments,occupancy);
+                rangesInGPU.segmentModuleIndices[i] = nTotSegs;
+                rangesInGPU.segmentModuleOccupancy[i] = occupancy;
+            }
+
+            // Wait for all threads to finish before reporting final values
+            alpaka::syncBlockThreads(acc);
+            if(globalThreadIdx[2] == 0)
+            {
+                rangesInGPU.segmentModuleIndices[*modulesInGPU.nLowerModules] = nTotalSegments;
+                *rangesInGPU.device_nTotalSegs = nTotalSegments;
+            }
+        }
+    };
+
+    struct addSegmentRangesToEventExplicit
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct modules& modulesInGPU,
+                struct segments& segmentsInGPU,
+                struct objectRanges& rangesInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2])
+            {
+                if(segmentsInGPU.nSegments[i] == 0)
+                {
+                    rangesInGPU.segmentRanges[i * 2] = -1;
+                    rangesInGPU.segmentRanges[i * 2 + 1] = -1;
+                }
+                else
+                {
+                    rangesInGPU.segmentRanges[i * 2] = rangesInGPU.segmentModuleIndices[i];
+                    rangesInGPU.segmentRanges[i * 2 + 1] = rangesInGPU.segmentModuleIndices[i] + segmentsInGPU.nSegments[i] - 1;
                 }
             }
         }

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -664,10 +664,7 @@ namespace SDL
             alpaka::syncBlockThreads(acc);
 
             // Initialize variables outside of the for loop.
-            int nTotSegs;
-            float module_eta;
             int occupancy, category_number, eta_number;
-            short module_subdets, module_layers, module_rings;
 
             for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i+= gridThreadExtent[2])
             {
@@ -678,10 +675,10 @@ namespace SDL
                     continue;
                 }
 
-                module_rings = modulesInGPU.rings[i];
-                module_layers = modulesInGPU.layers[i];
-                module_subdets = modulesInGPU.subdets[i];
-                module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
+                short module_rings = modulesInGPU.rings[i];
+                short module_layers = modulesInGPU.layers[i];
+                short module_subdets = modulesInGPU.subdets[i];
+                float module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
 
                 if (module_layers<=3 && module_subdets==5) category_number = 0;
                 else if (module_layers>=4 && module_subdets==5) category_number = 1;
@@ -707,7 +704,7 @@ namespace SDL
                 else if (category_number == 3 && eta_number == 2) occupancy = 79;
                 else if (category_number == 3 && eta_number == 3) occupancy = 85;
 
-                nTotSegs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalSegments,occupancy);
+                int nTotSegs = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalSegments,occupancy);
                 rangesInGPU.segmentModuleIndices[i] = nTotSegs;
                 rangesInGPU.segmentModuleOccupancy[i] = occupancy;
             }

--- a/SDL/Segment.cuh
+++ b/SDL/Segment.cuh
@@ -659,7 +659,8 @@ namespace SDL
             Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
             // Initialize variables in shared memory and set to 0
-            int& nTotalSegments = alpaka::declareSharedVar<int, __COUNTER__>(acc); nTotalSegments = 0;
+            int& nTotalSegments = alpaka::declareSharedVar<int, __COUNTER__>(acc);
+            nTotalSegments = 0;
             alpaka::syncBlockThreads(acc);
 
             // Initialize variables outside of the for loop.

--- a/SDL/Triplet.cuh
+++ b/SDL/Triplet.cuh
@@ -49,18 +49,13 @@ namespace SDL
         float* rtLo;
         float* rtHi;
         float* kZ;
-
 #endif
-
         triplets();
         ~triplets();
         void freeMemory(cudaStream_t stream);
         void freeMemoryCache();
         void resetMemory(unsigned int maxTriplets, unsigned int nLowerModules,cudaStream_t stream);
     };
-
-    __global__ void createTripletArrayRanges(struct modules& modulesInGPU, struct objectRanges& rangesInGPU, struct segments& segmentsInGPU);
-    __global__ void addTripletRangesToEventExplicit(struct modules& modulesInGPU, struct triplets& tripletsInGPU, struct objectRanges& rangesInGPU);
 
     void createTripletsInExplicitMemory(struct triplets& tripletsInGPU, unsigned int maxTriplets, uint16_t nLowerModules,cudaStream_t stream);
 
@@ -1271,6 +1266,111 @@ namespace SDL
                             }
                         }
                     }
+                }
+            }
+        }
+    };
+
+    struct createTripletArrayRanges
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct modules& modulesInGPU,
+                struct objectRanges& rangesInGPU,
+                struct segments& segmentsInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            int& nTotalTriplets = alpaka::declareSharedVar<int, __COUNTER__>(acc); nTotalTriplets = 0;
+            alpaka::syncBlockThreads(acc);
+
+            for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i+= gridThreadExtent[2])
+            {
+                if(segmentsInGPU.nSegments[i] == 0)
+                {
+                    rangesInGPU.tripletModuleIndices[i] = nTotalTriplets;
+                    rangesInGPU.tripletModuleOccupancy[i] = 0;
+                    continue;
+                }
+
+                short module_subdets = modulesInGPU.subdets[i];
+                short module_layers = modulesInGPU.layers[i];
+                short module_rings = modulesInGPU.rings[i];
+                float module_eta = modulesInGPU.eta[i];
+                float abs_eta = alpaka::math::abs(acc, module_eta);
+                int occupancy, category_number, eta_number;
+
+                if (module_layers<=3 && module_subdets==5) category_number = 0;
+                else if (module_layers>=4 && module_subdets==5) category_number = 1;
+                else if (module_layers<=2 && module_subdets==4 && module_rings>=11) category_number = 2;
+                else if (module_layers>=3 && module_subdets==4 && module_rings>=8) category_number = 2;
+                else if (module_layers<=2 && module_subdets==4 && module_rings<=10) category_number = 3;
+                else if (module_layers>=3 && module_subdets==4 && module_rings<=7) category_number = 3;
+
+                if (abs_eta<0.75) eta_number=0;
+                else if (abs_eta>0.75 && abs_eta<1.5) eta_number=1;
+                else if (abs_eta>1.5 && abs_eta<2.25) eta_number=2;
+                else if (abs_eta>2.25 && abs_eta<3) eta_number=3;
+
+                if (category_number == 0 && eta_number == 0) occupancy = 543;
+                else if (category_number == 0 && eta_number == 1) occupancy = 235;
+                else if (category_number == 0 && eta_number == 2) occupancy = 88;
+                else if (category_number == 0 && eta_number == 3) occupancy = 46;
+                else if (category_number == 1 && eta_number == 0) occupancy = 755;
+                else if (category_number == 1 && eta_number == 1) occupancy = 347;
+                else if (category_number == 2 && eta_number == 1) occupancy = 0;
+                else if (category_number == 2 && eta_number == 2) occupancy = 0;
+                else if (category_number == 3 && eta_number == 1) occupancy = 38;
+                else if (category_number == 3 && eta_number == 2) occupancy = 46;
+                else if (category_number == 3 && eta_number == 3) occupancy = 39;
+
+                rangesInGPU.tripletModuleOccupancy[i] = occupancy;
+                unsigned int nTotT = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalTriplets, occupancy);
+                rangesInGPU.tripletModuleIndices[i] = nTotT;
+            }
+
+            // Wait for all threads to finish before reporting final values
+            alpaka::syncBlockThreads(acc);
+            if(globalThreadIdx[2] == 0)
+            {
+                *rangesInGPU.device_nTotalTrips = nTotalTriplets;
+            }
+        }
+    };
+
+    struct addTripletRangesToEventExplicit
+    {
+        template<typename TAcc>
+        ALPAKA_FN_ACC void operator()(
+                TAcc const & acc,
+                struct modules& modulesInGPU,
+                struct triplets& tripletsInGPU,
+                struct objectRanges& rangesInGPU) const
+        {
+            using Dim = alpaka::Dim<TAcc>;
+            using Idx = alpaka::Idx<TAcc>;
+            using Vec = alpaka::Vec<Dim, Idx>;
+
+            Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+            Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+
+            for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2])
+            {
+                if(tripletsInGPU.nTriplets[i] == 0)
+                {
+                    rangesInGPU.tripletRanges[i * 2] = -1;
+                    rangesInGPU.tripletRanges[i * 2 + 1] = -1;
+                }
+                else
+                {
+                    rangesInGPU.tripletRanges[i * 2] = rangesInGPU.tripletModuleIndices[i];
+                    rangesInGPU.tripletRanges[i * 2 + 1] = rangesInGPU.tripletModuleIndices[i] +  tripletsInGPU.nTriplets[i] - 1;
                 }
             }
         }

--- a/SDL/Triplet.cuh
+++ b/SDL/Triplet.cuh
@@ -1287,8 +1287,15 @@ namespace SDL
             Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
             Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
+            // Initialize variables in shared memory and set to 0
             int& nTotalTriplets = alpaka::declareSharedVar<int, __COUNTER__>(acc); nTotalTriplets = 0;
             alpaka::syncBlockThreads(acc);
+
+            // Initialize variables outside of the for loop.
+            float module_eta;
+            unsigned int nTotT;
+            int occupancy, category_number, eta_number;
+            short module_subdets, module_layers, module_rings;
 
             for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i+= gridThreadExtent[2])
             {
@@ -1299,12 +1306,10 @@ namespace SDL
                     continue;
                 }
 
-                short module_subdets = modulesInGPU.subdets[i];
-                short module_layers = modulesInGPU.layers[i];
-                short module_rings = modulesInGPU.rings[i];
-                float module_eta = modulesInGPU.eta[i];
-                float abs_eta = alpaka::math::abs(acc, module_eta);
-                int occupancy, category_number, eta_number;
+                module_rings = modulesInGPU.rings[i];
+                module_layers = modulesInGPU.layers[i];
+                module_subdets = modulesInGPU.subdets[i];
+                module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
 
                 if (module_layers<=3 && module_subdets==5) category_number = 0;
                 else if (module_layers>=4 && module_subdets==5) category_number = 1;
@@ -1313,10 +1318,10 @@ namespace SDL
                 else if (module_layers<=2 && module_subdets==4 && module_rings<=10) category_number = 3;
                 else if (module_layers>=3 && module_subdets==4 && module_rings<=7) category_number = 3;
 
-                if (abs_eta<0.75) eta_number=0;
-                else if (abs_eta>0.75 && abs_eta<1.5) eta_number=1;
-                else if (abs_eta>1.5 && abs_eta<2.25) eta_number=2;
-                else if (abs_eta>2.25 && abs_eta<3) eta_number=3;
+                if (module_eta<0.75) eta_number = 0;
+                else if (module_eta>0.75 && module_eta<1.5) eta_number = 1;
+                else if (module_eta>1.5 && module_eta<2.25) eta_number = 2;
+                else if (module_eta>2.25 && module_eta<3) eta_number = 3;
 
                 if (category_number == 0 && eta_number == 0) occupancy = 543;
                 else if (category_number == 0 && eta_number == 1) occupancy = 235;
@@ -1331,7 +1336,7 @@ namespace SDL
                 else if (category_number == 3 && eta_number == 3) occupancy = 39;
 
                 rangesInGPU.tripletModuleOccupancy[i] = occupancy;
-                unsigned int nTotT = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalTriplets, occupancy);
+                nTotT = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalTriplets, occupancy);
                 rangesInGPU.tripletModuleIndices[i] = nTotT;
             }
 

--- a/SDL/Triplet.cuh
+++ b/SDL/Triplet.cuh
@@ -1293,10 +1293,7 @@ namespace SDL
             alpaka::syncBlockThreads(acc);
 
             // Initialize variables outside of the for loop.
-            float module_eta;
-            unsigned int nTotT;
             int occupancy, category_number, eta_number;
-            short module_subdets, module_layers, module_rings;
 
             for(uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i+= gridThreadExtent[2])
             {
@@ -1307,10 +1304,10 @@ namespace SDL
                     continue;
                 }
 
-                module_rings = modulesInGPU.rings[i];
-                module_layers = modulesInGPU.layers[i];
-                module_subdets = modulesInGPU.subdets[i];
-                module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
+                short module_rings = modulesInGPU.rings[i];
+                short module_layers = modulesInGPU.layers[i];
+                short module_subdets = modulesInGPU.subdets[i];
+                float module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
 
                 if (module_layers<=3 && module_subdets==5) category_number = 0;
                 else if (module_layers>=4 && module_subdets==5) category_number = 1;
@@ -1337,7 +1334,7 @@ namespace SDL
                 else if (category_number == 3 && eta_number == 3) occupancy = 39;
 
                 rangesInGPU.tripletModuleOccupancy[i] = occupancy;
-                nTotT = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalTriplets, occupancy);
+                unsigned int nTotT = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalTriplets, occupancy);
                 rangesInGPU.tripletModuleIndices[i] = nTotT;
             }
 

--- a/SDL/Triplet.cuh
+++ b/SDL/Triplet.cuh
@@ -1288,7 +1288,8 @@ namespace SDL
             Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
             // Initialize variables in shared memory and set to 0
-            int& nTotalTriplets = alpaka::declareSharedVar<int, __COUNTER__>(acc); nTotalTriplets = 0;
+            int& nTotalTriplets = alpaka::declareSharedVar<int, __COUNTER__>(acc);
+            nTotalTriplets = 0;
             alpaka::syncBlockThreads(acc);
 
             // Initialize variables outside of the for loop.

--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -509,6 +509,7 @@ void run_sdl()
     printTimingInformation(timevec, full_elapsed, avg_elapsed);
 
     SDL::cleanModules();
+    SDL::freeEndCapMapMemory();
 
     if (ana.do_write_ntuple)
     {


### PR DESCRIPTION
This PR moves the recent kernels created by @tresreid over to Alpaka. These are the last kernels in the SDL directory that need to be moved over on the current master branch.

This PR Timing
<img width="1036" alt="Screenshot 2023-05-02 at 11 21 27 PM" src="https://user-images.githubusercontent.com/25272611/235827097-9d373607-b0ad-4fc4-bf26-573c1f6440c1.png">

This PR also introduces multistreaming with Alpaka. PR #286 resolved the issues I was having a while ago.

Timeline view with multistreaming (s=8). Notice that there are 8 streams which handle the kernel execution now through Alpaka, and the original 8 CUDA streams which only deal with memory allocation and transfers. Also an extra stream at the very bottom, but that's also present on the master branch. I think that's just the default stream or a stream used to set up the modules. In later PR's, after the alpaka caching allocator is used, I will remove the remaining CUDA streams so that it's equivalent to the master branch.
<img width="1081" alt="Screenshot 2023-05-11 at 0 36 17 PM" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/a94c4ecc-c0d1-4422-aeee-13bf8a8897c0">
