### PR TITLE
Fix Extra CudaFrees Bug

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -256,7 +256,6 @@ SDL::Event::~Event()
         delete[] modulesInCPUFull->moduleLayerType;
         delete[] modulesInCPUFull;
     }
-    SDL::freeEndCapMapMemory();
 }
 
 void SDL::Event::resetEvent()

--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -509,6 +509,7 @@ void run_sdl()
     printTimingInformation(timevec, full_elapsed, avg_elapsed);
 
     SDL::cleanModules();
+    SDL::freeEndCapMapMemory();
 
     if (ana.do_write_ntuple)
     {


### PR DESCRIPTION
See Issue https://github.com/SegmentLinking/TrackLooper/issues/285 for more explanation. There is a bug on the current master branch where extra cudaFrees are being created when there are multiple streams present. This PR fixes that by moving the function that frees the endcap map from the Event class' destructor to sdl.cc where the modules are also freed. This bug was introduced in PR #181, the hit loading speedup PR.

This PR Running: `nvprof ./bin/sdl -n 1 -v 1 -w 0 -s 8 -i PU200`
<img width="565" alt="Screenshot 2023-05-10 at 8 01 45 PM" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/7b6659dc-226d-465b-af24-a0a4fa464e06">

Current Master:
<img width="565" alt="Screenshot 2023-05-10 at 8 03 09 PM" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/0c50d05f-2c44-48ef-bee7-283d2fc2c043">

This PR Timing:
<img width="1031" alt="Screenshot 2023-05-10 at 8 06 16 PM" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/ec155bad-7799-4848-867a-9cc7f0c6a8cd">

Validation Plots: [Here](https://www.classe.cornell.edu/~gsn27/www/www/PR286/mywork_dfb750-PU200/summary/)
Comparison to Master: [Here](https://www.classe.cornell.edu/~gsn27/www/www/PR286/mywork_ef224c-PU200_dfb750-PU200/summary/)