### PR TITLE
MD kernel parallelization and shared memory cleanup

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -946,7 +946,7 @@ void SDL::Event::createMiniDoublets()
     //dim3 nThreads(64,16,1);
     dim3 nBlocks(1,MAX_BLOCKS,1);
 
-    SDL::createMiniDoubletsInGPUv2<<<nBlocks,nThreads,64*4*16*sizeof(float),stream>>>(*modulesInGPU,*hitsInGPU,*mdsInGPU,*rangesInGPU);
+    SDL::createMiniDoubletsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU,*hitsInGPU,*mdsInGPU,*rangesInGPU);
     addMiniDoubletRangesToEventExplicit<<<1,1024,0,stream>>>(*modulesInGPU,*mdsInGPU, *rangesInGPU,*hitsInGPU);
 
     cudaError_t cudaerr = cudaGetLastError(); 

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -944,7 +944,7 @@ void SDL::Event::createMiniDoublets()
 
     dim3 nThreads(32,16,1);
     //dim3 nThreads(64,16,1);
-    dim3 nBlocks(1,MAX_BLOCKS,1);
+    dim3 nBlocks(1,nLowerModules/nThreads.y,1); // max parallelization
 
     SDL::createMiniDoubletsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU,*hitsInGPU,*mdsInGPU,*rangesInGPU);
     addMiniDoubletRangesToEventExplicit<<<1,1024,0,stream>>>(*modulesInGPU,*mdsInGPU, *rangesInGPU,*hitsInGPU);


### PR DESCRIPTION
This is a result of my "day 1" so far.

- `createMiniDoubletsInGPUv2` launch had a 16 kB shared memory allocation requested but not used. Apparently declaring shared mem and not using it comes at a cost. After removing the first event MD time goes down by about 19% using the profiler and 10% using a minimum over 10 runs.
<img width="927" alt="image" src="https://github.com/SegmentLinking/TrackLooper/assets/4676718/7d724459-c0db-454d-be17-be348805ff6d">

- we were suggested to be more aggressive and schedule more blocks; I've increased the number of blocks (from 80 to `825=nLowerModules/16`) to have the outermost stride-loop become a no-op (one iteration). The MD time goes down a bit: by 8% in profiler and 5% using a minimum over 10 runs. However, this comes with a significant cost in memory transfers, especially the L2-to-device.
<img width="897" alt="image" src="https://github.com/SegmentLinking/TrackLooper/assets/4676718/65241589-60a8-466c-9f34-4a3bb2b7a505">
The last part better be tested on some less performing GPU to confirm that the update is not a loss.

~I'm leaving this as a draft for now; perhaps a better strategy is to just split off the first commit as that one is non-controversial.~

