### PR TITLE
Alpaka Kernel Parameter Exploration

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1157,7 +1157,7 @@ void SDL::Event::createTriplets()
     cudaStreamSynchronize(stream);
 
     Vec const threadsPerBlockCreateTrip(static_cast<Idx>(1), static_cast<Idx>(16), static_cast<Idx>(16));
-    Vec const blocksPerGridCreateTrip(static_cast<Idx>(MAX_BLOCKS), static_cast<Idx>(1), static_cast<Idx>(1));
+    Vec const blocksPerGridCreateTrip(static_cast<Idx>(2048), static_cast<Idx>(1), static_cast<Idx>(1));
     WorkDiv const createTripletsInGPUv2_workDiv(blocksPerGridCreateTrip, threadsPerBlockCreateTrip, elementsPerThread);
 
     SDL::createTripletsInGPUv2 createTripletsInGPUv2_kernel;

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -1059,8 +1059,8 @@ void SDL::Event::createSegmentsWithModuleMap()
         createSegmentsInExplicitMemory(*segmentsInGPU, nTotalSegments, nLowerModules, N_MAX_PIXEL_SEGMENTS_PER_MODULE,stream);
     }
 
-    Vec const threadsPerBlockCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(64));
-    Vec const blocksPerGridCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(nLowerModules));
+    Vec const threadsPerBlockCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(32));
+    Vec const blocksPerGridCreateSeg(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(512));
     WorkDiv const createSegmentsInGPUv2_workDiv(blocksPerGridCreateSeg, threadsPerBlockCreateSeg, elementsPerThread);
 
     SDL::createSegmentsInGPUv2 createSegmentsInGPUv2_kernel;

--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -677,7 +677,7 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
     alpaka::wait(queue);
 
     Vec const threadsPerBlock2(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(256));
-    Vec const blocksPerGrid2(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(MAX_BLOCKS));
+    Vec const blocksPerGrid2(static_cast<Idx>(1), static_cast<Idx>(1), static_cast<Idx>(5));
     WorkDiv const module_ranges_workdiv(blocksPerGrid2, threadsPerBlock2, elementsPerThread);
 
     moduleRangesKernel module_ranges_kernel;


### PR DESCRIPTION
Making this draft PR to make some changes to the kernel launch parameters on the Alpaka branch. First change is createSegmentsInGPUv2, moving from (13200,1,1)x(64,1,1) to (512,1,1)x(32,1,1)

Current Timing
<img width="1039" alt="current" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/00ec5a01-fef4-4422-8dec-54f710b55739">

This PR Timing
<img width="1041" alt="alpaka_timing" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/d894934d-8c70-4b10-8228-048fd8a1b4a8">

You can see a significant reduction in the LS timing above for s=1 and 2. The total Event time decreases for all streams. If we look at the profiler we see a significant increase in the hit rate, as well as a large decrease in the long scoreboard stalls and LG Throttle stalls. (blue is new, green is current)

<img width="1195" alt="prof_timing" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/3eb181a4-62ce-481f-a472-ab7e853e58f2">

<img width="1195" alt="scoreboard" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/e32d7c49-849a-47b8-bcf5-be7d0b531491">

<img width="1187" alt="roofline" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/b47a4e27-55fa-48de-b54a-46c1b0d409eb">

<img width="1195" alt="stats" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/42247b2e-dd30-4bab-992a-67cf307b77b9">

<img width="1039" alt="Screenshot 2023-06-22 at 10 23 19 AM" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/384254e2-e4a3-4240-a972-d75d7bf85ede">