### PR TITLE
Precompute custom layer variable

### DIFF
--- a/SDL/Module.cuh
+++ b/SDL/Module.cuh
@@ -108,6 +108,7 @@ namespace SDL
         bool* isAnchor;
         ModuleType* moduleType;
         ModuleLayerType* moduleLayerType;
+        int* sdlLayers;
        
         CUDA_HOSTDEV ModuleType parseModuleType(unsigned int index);
         CUDA_HOSTDEV ModuleType parseModuleType(short subdet, short layer, short ring);

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -566,11 +566,11 @@ __device__ bool SDL::runQuintupletDefaultAlgo(struct SDL::modules& modulesInGPU,
 __device__ bool SDL::passChiSquaredConstraint(struct SDL::modules& modulesInGPU, uint16_t& lowerModuleIndex1, uint16_t& lowerModuleIndex2, uint16_t& lowerModuleIndex3, uint16_t& lowerModuleIndex4, uint16_t& lowerModuleIndex5, float& chiSquared)
 {
     //following Philip's layer number prescription
-    const int layer1 = modulesInGPU.layers[lowerModuleIndex1] + 6 * (modulesInGPU.subdets[lowerModuleIndex1] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex1] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex1] == SDL::TwoS);
-    const int layer2 = modulesInGPU.layers[lowerModuleIndex2] + 6 * (modulesInGPU.subdets[lowerModuleIndex2] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex2] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex2] == SDL::TwoS);
-    const int layer3 = modulesInGPU.layers[lowerModuleIndex3] + 6 * (modulesInGPU.subdets[lowerModuleIndex3] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex3] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex3] == SDL::TwoS);
-    const int layer4 = modulesInGPU.layers[lowerModuleIndex4] + 6 * (modulesInGPU.subdets[lowerModuleIndex4] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex4] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex4] == SDL::TwoS);
-    const int layer5 = modulesInGPU.layers[lowerModuleIndex5] + 6 * (modulesInGPU.subdets[lowerModuleIndex5] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex5] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex5] == SDL::TwoS);
+    const int layer1 = modulesInGPU.sdlLayers[lowerModuleIndex1];
+    const int layer2 = modulesInGPU.sdlLayers[lowerModuleIndex2];
+    const int layer3 = modulesInGPU.sdlLayers[lowerModuleIndex3];
+    const int layer4 = modulesInGPU.sdlLayers[lowerModuleIndex4];
+    const int layer5 = modulesInGPU.sdlLayers[lowerModuleIndex5];
 
     if(layer1 == 7 and layer2 == 8 and layer3 == 9)
     {
@@ -709,11 +709,11 @@ __device__ bool SDL::passT5RZConstraint(struct SDL::modules& modulesInGPU, struc
     const float& z5 = mdsInGPU.anchorZ[fifthMDIndex]/100;
 
     //following Philip's layer number prescription
-    const int layer1 = modulesInGPU.layers[lowerModuleIndex1] + 6 * (modulesInGPU.subdets[lowerModuleIndex1] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex1] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex1] == SDL::TwoS);
-    const int layer2 = modulesInGPU.layers[lowerModuleIndex2] + 6 * (modulesInGPU.subdets[lowerModuleIndex2] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex2] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex2] == SDL::TwoS);
-    const int layer3 = modulesInGPU.layers[lowerModuleIndex3] + 6 * (modulesInGPU.subdets[lowerModuleIndex3] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex3] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex3] == SDL::TwoS);
-    const int layer4 = modulesInGPU.layers[lowerModuleIndex4] + 6 * (modulesInGPU.subdets[lowerModuleIndex4] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex4] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex4] == SDL::TwoS);
-    const int layer5 = modulesInGPU.layers[lowerModuleIndex5] + 6 * (modulesInGPU.subdets[lowerModuleIndex5] == SDL::Endcap) + 5 * (modulesInGPU.subdets[lowerModuleIndex5] == SDL::Endcap and modulesInGPU.moduleType[lowerModuleIndex5] == SDL::TwoS);
+    const int layer1 = modulesInGPU.layers[lowerModuleIndex1];
+    const int layer2 = modulesInGPU.layers[lowerModuleIndex2];
+    const int layer3 = modulesInGPU.layers[lowerModuleIndex3];
+    const int layer4 = modulesInGPU.layers[lowerModuleIndex4];
+    const int layer5 = modulesInGPU.layers[lowerModuleIndex5];
 
     //slope computed using the internal T3s
     const int moduleType1 = modulesInGPU.moduleType[lowerModuleIndex1]; //0 is ps, 1 is 2s

--- a/SDL/Triplet.cu
+++ b/SDL/Triplet.cu
@@ -335,9 +335,9 @@ __device__ bool SDL::passRZConstraint(struct SDL::modules& modulesInGPU, struct 
     const float& z3 = mdsInGPU.anchorZ[thirdMDIndex];
         
     //following Philip's layer number prescription
-    const int layer1 = modulesInGPU.layers[innerInnerLowerModuleIndex] + 6 * (modulesInGPU.subdets[innerInnerLowerModuleIndex] == SDL::Endcap) + 5 * (modulesInGPU.subdets[innerInnerLowerModuleIndex] == SDL::Endcap and modulesInGPU.moduleType[innerInnerLowerModuleIndex] == SDL::TwoS);
-    const int layer2 = modulesInGPU.layers[middleLowerModuleIndex] + 6 * (modulesInGPU.subdets[middleLowerModuleIndex] == SDL::Endcap) + 5 * (modulesInGPU.subdets[middleLowerModuleIndex] == SDL::Endcap and modulesInGPU.moduleType[middleLowerModuleIndex] == SDL::TwoS);
-    const int layer3 = modulesInGPU.layers[outerOuterLowerModuleIndex] + 6 * (modulesInGPU.subdets[outerOuterLowerModuleIndex] == SDL::Endcap) + 5 * (modulesInGPU.subdets[outerOuterLowerModuleIndex] == SDL::Endcap and modulesInGPU.moduleType[outerOuterLowerModuleIndex] == SDL::TwoS);
+    const int layer1 = modulesInGPU.sdlLayers[innerInnerLowerModuleIndex];
+    const int layer2 = modulesInGPU.sdlLayers[middleLowerModuleIndex];
+    const int layer3 = modulesInGPU.sdlLayers[outerOuterLowerModuleIndex];
 
     const float residual = z2 - ( (z3 - z1) / (r3 - r1) * (r2 - r1) + z1);
 
@@ -675,8 +675,7 @@ __global__ void SDL::createTripletsInGPUv2(struct SDL::modules& modulesInGPU, st
 
       unsigned int nOuterSegments = segmentsInGPU.nSegments[middleLowerModuleIndex];
       for(int outerSegmentArrayIndex = blockIdx.x * blockDim.x + threadIdx.x; outerSegmentArrayIndex< nOuterSegments; outerSegmentArrayIndex += blockxSize){
-        //if(outerSegmentArrayIndex >= nOuterSegments) continue;
-         unsigned int outerSegmentIndex = rangesInGPU.segmentRanges[2 * middleLowerModuleIndex] + outerSegmentArrayIndex;
+        unsigned int outerSegmentIndex = rangesInGPU.segmentRanges[2 * middleLowerModuleIndex] + outerSegmentArrayIndex;
     
         uint16_t outerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[outerSegmentIndex];
 


### PR DESCRIPTION
As per title, we identified some variables that were computed per kernel, even though they are properties of the modules and, hence, they can be computed up front. These variables are used in the Triplet and Quintuplet kernels.

**On cgpu-1 (A30)**
Before:
![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/67dfe81c-5c0c-4197-a268-981975d94ef7)

After:
![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/706b904e-aa96-4f7b-95c3-2e05ac3a64ec)

I guess the timing is within the usual variations.

**Stall reduction**
Before (T3):
![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/4a96b056-cd49-4d14-a68c-86cfd0ef0435)

After (T3):
![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/e85ba98d-8223-4375-b293-656c569b5314)

Before (T5):
![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/91b3ac46-38c0-43d9-8f11-195b93c7c740)

After (T5):
![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/2dc50bc4-1fb8-4eca-99a6-bb4fdef1fdfc)
