### PR TITLE
MD kernel parallelization and shared memory cleanup (master version)

### DIFF
--- a/SDL/Event.cu
+++ b/SDL/Event.cu
@@ -944,9 +944,9 @@ void SDL::Event::createMiniDoublets()
 
     dim3 nThreads(32,16,1);
     //dim3 nThreads(64,16,1);
-    dim3 nBlocks(1,MAX_BLOCKS,1);
+    dim3 nBlocks(1,nLowerModules/nThreads.y,1); // max parallelization
 
-    SDL::createMiniDoubletsInGPUv2<<<nBlocks,nThreads,64*4*16*sizeof(float),stream>>>(*modulesInGPU,*hitsInGPU,*mdsInGPU,*rangesInGPU);
+    SDL::createMiniDoubletsInGPUv2<<<nBlocks,nThreads,0,stream>>>(*modulesInGPU,*hitsInGPU,*mdsInGPU,*rangesInGPU);
     addMiniDoubletRangesToEventExplicit<<<1,1024,0,stream>>>(*modulesInGPU,*mdsInGPU, *rangesInGPU,*hitsInGPU);
 
     cudaError_t cudaerr = cudaGetLastError(); 


### PR DESCRIPTION
Equivalent to PR #294 but to the master branch. This PR has been tested on the V100 of lnx7188.

**Timing**
This PR (37e8ca4):
```
Total Timing Summary
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Event      Short           Rate
   avg      4.3      2.8      3.3      3.2      3.5      1.2      1.8      1.3      3.5      25.0      19.4+/-  3.2      28.9   explicit_cache[s=1]
   avg      7.4      4.7      4.5      6.3      5.2      1.5      3.8      2.4      6.7      42.6      33.8+/-  5.8      24.3   explicit_cache[s=2]
   avg     15.5      7.3      6.1     12.7      9.5      2.2      8.3      5.0     12.7      79.3      61.7+/- 12.1      22.4   explicit_cache[s=4]
   avg     25.9     10.6      8.3     18.8     15.3      2.8     13.2      7.6     18.4     120.8      92.1+/- 14.9      21.8   explicit_cache[s=6]
   avg     35.6     12.5      8.5     21.3     19.5      3.4     17.7     10.1     24.2     152.9     113.9+/- 20.2      21.2   explicit_cache[s=8]
```

Master (b498de8):
```
Total Timing Summary
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Event      Short           Rate
   avg      4.4      3.0      3.5      3.1      3.4      1.2      1.7      1.3      3.4      25.1      19.5+/-  3.2      27.3   explicit_cache[s=1]
   avg      7.2      5.2      4.3      5.9      5.3      1.5      3.7      2.3      6.7      42.1      33.4+/-  6.2      25.0   explicit_cache[s=2]
   avg     15.3      8.7      6.4     11.9     10.0      2.2      8.1      4.8     13.0      80.4      62.9+/- 10.4      22.0   explicit_cache[s=4]
   avg     24.6     11.9      8.1     17.1     15.0      2.9     13.4      7.5     18.0     118.6      91.1+/- 15.7      21.5   explicit_cache[s=6]
   avg     36.0     15.0     10.8     24.2     21.3      3.5     18.2     10.5     24.3     163.8     124.3+/- 20.0      22.1   explicit_cache[s=8]
```

Even though the decrease seems within uncertainty, I ran a few times and I was consistently getting lower numbers, while for other kernels there were ups and downs. Any gain is diminished when multistreaming.

**Profiler reports**
This PR (37e8ca4) with master (b498de8) comparison in parenthesis:
![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/29e0cd87-ca61-4beb-862f-0dd1bcd8e9a8)

![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/4d01b7a1-169d-45c0-800c-9e568c7c79ee)

I think that things move towards a good direction in general. If there are no comments on this, I am happy to merge it and close PR #294.