### PR TITLE
LS optimization: early stop, const arrays in moduleGapSize, simpler logic in isTighterTiltedModules (master version)

### DIFF
--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -733,10 +733,10 @@ __device__ float SDL::moduleGapSize_seg(short layer, short ring, short subdet, s
 
 __device__ float SDL::moduleGapSize_seg(struct modules& modulesInGPU, unsigned int moduleIndex)
 {
-    float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
-    float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
-    float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
-    float miniDeltaEndcap[5][15] = {
+    constexpr float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
+    constexpr float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
+    constexpr float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
+    constexpr float miniDeltaEndcap[5][15] = {
 	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
 	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
 	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.18f, 0.18f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -625,17 +625,9 @@ __device__ inline float SDL::isTighterTiltedModules_seg(struct modules& modulesI
     short side = modulesInGPU.sides[moduleIndex];
     short rod = modulesInGPU.rods[moduleIndex];
 
-    if (
-           (subdet == Barrel and side != Center and layer== 3)
-           or (subdet == Barrel and side == NegZ and layer == 2 and rod > 5)
-           or (subdet == Barrel and side == PosZ and layer == 2 and rod < 8)
-           or (subdet == Barrel and side == NegZ and layer == 1 and rod > 9)
-           or (subdet == Barrel and side == PosZ and layer == 1 and rod < 4)
-       )
-        return true;
-    else
-        return false;
-
+    return subdet == Barrel & ( ((side != Center) & (layer== 3))
+                | (side == NegZ & (((layer == 2) & (rod > 5)) | ((layer == 1) & (rod > 9))))
+                | (side == PosZ & (((layer == 2) & (rod < 8)) | ((layer == 1) & (rod < 4)))) );
 }
 
 __device__ inline float SDL::isTighterTiltedModules_seg(short subdet, short layer, short side, short rod)
@@ -643,17 +635,9 @@ __device__ inline float SDL::isTighterTiltedModules_seg(short subdet, short laye
     // The "tighter" tilted modules are the subset of tilted modules that have smaller spacing
     // This is the same as what was previously considered as"isNormalTiltedModules"
     // See Figure 9.1 of https://cds.cern.ch/record/2272264/files/CMS-TDR-014.pdf
-    if (
-           (subdet == Barrel and side != Center and layer== 3)
-           or (subdet == Barrel and side == NegZ and layer == 2 and rod > 5)
-           or (subdet == Barrel and side == PosZ and layer == 2 and rod < 8)
-           or (subdet == Barrel and side == NegZ and layer == 1 and rod > 9)
-           or (subdet == Barrel and side == PosZ and layer == 1 and rod < 4)
-       )
-        return true;
-    else
-        return false;
-
+    return subdet == Barrel & ( ((side != Center) & (layer== 3))
+		| (side == NegZ & (((layer == 2) & (rod > 5)) | ((layer == 1) & (rod > 9))))
+		| (side == PosZ & (((layer == 2) & (rod < 8)) | ((layer == 1) & (rod < 4)))) );
 }
 
 //__device__ float SDL::moduleGapSize_seg(struct modules& modulesInGPU, unsigned int moduleIndex)

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -659,50 +659,16 @@ __device__ inline float SDL::isTighterTiltedModules_seg(short subdet, short laye
 //__device__ float SDL::moduleGapSize_seg(struct modules& modulesInGPU, unsigned int moduleIndex)
 __device__ float SDL::moduleGapSize_seg(short layer, short ring, short subdet, short side, short rod)
 {
-    float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
-    float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
-    float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
-    float miniDeltaEndcap[5][15];
-
-    for (size_t i = 0; i < 5; i++)
-    {
-        for (size_t j = 0; j < 15; j++)
-        {
-            if (i == 0 || i == 1)
-            {
-                if (j < 10)
-                {
-                    miniDeltaEndcap[i][j] = 0.4f;
-                }
-                else
-                {
-                    miniDeltaEndcap[i][j] = 0.18f;
-                }
-            }
-            else if (i == 2 || i == 3)
-            {
-                if (j < 8)
-                {
-                    miniDeltaEndcap[i][j] = 0.4f;
-                }
-                else
-                {
-                    miniDeltaEndcap[i][j]  = 0.18f;
-                }
-            }
-            else
-            {
-                if (j < 9)
-                {
-                    miniDeltaEndcap[i][j] = 0.4f;
-                }
-                else
-                {
-                    miniDeltaEndcap[i][j] = 0.18f;
-                }
-            }
-        }
-    }
+    static constexpr float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
+    static constexpr float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
+    static constexpr float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
+    static constexpr float miniDeltaEndcap[5][15] = {
+            {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
+            {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
+            {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.18f, 0.18f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
+            {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.18f, 0.18f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
+            {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.18f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f}
+    };
 
 
     unsigned int iL = layer-1;
@@ -733,10 +699,10 @@ __device__ float SDL::moduleGapSize_seg(short layer, short ring, short subdet, s
 
 __device__ float SDL::moduleGapSize_seg(struct modules& modulesInGPU, unsigned int moduleIndex)
 {
-    constexpr float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
-    constexpr float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
-    constexpr float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
-    constexpr float miniDeltaEndcap[5][15] = {
+    static constexpr float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
+    static constexpr float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
+    static constexpr float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
+    static constexpr float miniDeltaEndcap[5][15] = {
 	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
 	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
 	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.18f, 0.18f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -736,48 +736,13 @@ __device__ float SDL::moduleGapSize_seg(struct modules& modulesInGPU, unsigned i
     float miniDeltaTilted[3] = {0.26f, 0.26f, 0.26f};
     float miniDeltaFlat[6] ={0.26f, 0.16f, 0.16f, 0.18f, 0.18f, 0.18f};
     float miniDeltaLooseTilted[3] = {0.4f,0.4f,0.4f};
-    float miniDeltaEndcap[5][15];
-
-    for (size_t i = 0; i < 5; i++)
-    {
-        for (size_t j = 0; j < 15; j++)
-        {
-            if (i == 0 || i == 1)
-            {
-                if (j < 10)
-                {
-                    miniDeltaEndcap[i][j] = 0.4f;
-                }
-                else
-                {
-                    miniDeltaEndcap[i][j] = 0.18f;
-                }
-            }
-            else if (i == 2 || i == 3)
-            {
-                if (j < 8)
-                {
-                    miniDeltaEndcap[i][j] = 0.4f;
-                }
-                else
-                {
-                    miniDeltaEndcap[i][j]  = 0.18f;
-                }
-            }
-            else
-            {
-                if (j < 9)
-                {
-                    miniDeltaEndcap[i][j] = 0.4f;
-                }
-                else
-                {
-                    miniDeltaEndcap[i][j] = 0.18f;
-                }
-            }
-        }
-    }
-
+    float miniDeltaEndcap[5][15] = {
+	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
+	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
+	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.18f, 0.18f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
+	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.18f, 0.18f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f},
+	    {0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.4f, 0.18f,/*10*/ 0.18f, 0.18f, 0.18f, 0.18f, 0.18f}
+    };
 
     unsigned int iL = modulesInGPU.layers[moduleIndex]-1;
     unsigned int iR = modulesInGPU.rings[moduleIndex] - 1;

--- a/SDL/Segment.cu
+++ b/SDL/Segment.cu
@@ -812,13 +812,15 @@ __global__ void SDL::createSegmentsInGPUv2(struct SDL::modules& modulesInGPU, st
     int blockzSize = blockDim.x;
     for(uint16_t innerLowerModuleIndex = blockIdx.x ; innerLowerModuleIndex< (*modulesInGPU.nLowerModules); innerLowerModuleIndex += blockxSize){
 
+    unsigned int nInnerMDs = mdsInGPU.nMDs[innerLowerModuleIndex];
+    if (nInnerMDs == 0) continue;
+
     unsigned int nConnectedModules = modulesInGPU.nConnectedModules[innerLowerModuleIndex];
 
     for(uint16_t outerLowerModuleArrayIdx = threadIdx.y; outerLowerModuleArrayIdx< nConnectedModules; outerLowerModuleArrayIdx += blockySize){
 
         uint16_t outerLowerModuleIndex = modulesInGPU.moduleMap[innerLowerModuleIndex * MAX_CONNECTED_MODULES + outerLowerModuleArrayIdx];
 
-        unsigned int nInnerMDs = mdsInGPU.nMDs[innerLowerModuleIndex];
         unsigned int nOuterMDs = mdsInGPU.nMDs[outerLowerModuleIndex];
 
         int limit = nInnerMDs*nOuterMDs;


### PR DESCRIPTION
Equivalent to PR #298 but to the master branch. This PR has been tested on the V100 of lnx7188.

**Timing**
This PR (a5de4d4):
```
Total Timing Summary
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Event      Short           Rate
   avg      4.5      3.1      1.0      3.1      3.4      1.2      1.8      1.4      3.4      23.0      17.2+/-  3.0      26.9   explicit_cache[s=1]
   avg      7.1      5.0      1.5      5.5      4.8      1.5      3.6      2.4      6.0      37.4      28.8+/-  5.9      22.4   explicit_cache[s=2]
   avg     14.1      8.2      3.2     11.2      9.2      2.1      7.9      4.7     12.1      72.6      56.4+/-  9.9      20.1   explicit_cache[s=4]
   avg     22.8     10.2      4.5     15.0     12.5      2.5     11.8      7.3     16.9     103.4      78.1+/- 13.4      19.2   explicit_cache[s=6]
   avg     32.8     12.5      5.5     19.1     17.4      3.1     16.0      9.8     22.2     138.5     102.5+/- 20.1      19.2   explicit_cache[s=8]
```

Master (b498de8):
```
Total Timing Summary
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Event      Short           Rate
   avg      4.4      3.0      3.5      3.1      3.4      1.2      1.7      1.3      3.4      25.1      19.5+/-  3.2      27.3   explicit_cache[s=1]
   avg      7.2      5.2      4.3      5.9      5.3      1.5      3.7      2.3      6.7      42.1      33.4+/-  6.2      25.0   explicit_cache[s=2]
   avg     15.3      8.7      6.4     11.9     10.0      2.2      8.1      4.8     13.0      80.4      62.9+/- 10.4      22.0   explicit_cache[s=4]
   avg     24.6     11.9      8.1     17.1     15.0      2.9     13.4      7.5     18.0     118.6      91.1+/- 15.7      21.5   explicit_cache[s=6]
   avg     36.0     15.0     10.8     24.2     21.3      3.5     18.2     10.5     24.3     163.8     124.3+/- 20.0      22.1   explicit_cache[s=8]
```

Timing (also confirmed by the profiler timing) is cut down by almost 2/3. Part of the large timing reduction should be coming from the fact that the registers are reduced, so that we can increase the theoretical occupancy by 20%, and the achieved occupancy also goes up by 12.75%.

**Profiler reports**
This PR (a5de4d4) - in blue- with master (b498de8) - in green - comparison in parenthesis:
![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/fb4686c6-8235-410e-b22a-0a334b06622d)

![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/9937dc64-ac6f-4562-808a-4db3459eb895)

![image](https://github.com/SegmentLinking/TrackLooper/assets/15358704/fee5558b-a854-480d-b43a-ada104469a8a)

[**Validation plots**](https://uaf-10.t2.ucsd.edu/~evourlio/SDL/LSOptimization_earlyStop_simplifyModuleGapSizeAndIsTighterTiltedModules_PU200_NEVT-1_a5de4dD-PU200/summary/TC_eff_base_0.html)