### PR TITLE
More timing info

### DIFF
--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -401,7 +401,7 @@ void run_sdl()
         ; //(streams[omp_get_thread_num()]);
         events.push_back(event);
     }
-    float timeForStreamCreation = full_timer.RealTime()*1000;
+    float timeForEventCreation = full_timer.RealTime()*1000;
 
     std::vector<std::vector<float>> timevec;
     full_timer.Reset();
@@ -521,7 +521,7 @@ void run_sdl()
 
     std::cout << "Time for map loading = " << timeForMapLoading << " ms\n";
     std::cout << "Time for input loading = " << timeForInputLoading << " ms\n";
-    std::cout << "Time for stream creation = " << timeForStreamCreation << " ms\n";
+    std::cout << "Time for event creation = " << timeForEventCreation << " ms\n";
     printTimingInformation(timevec, full_elapsed, avg_elapsed);
 
     SDL::cleanModules();

--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -979,6 +979,7 @@ void printTimingInformation(std::vector<std::vector<float>>& timing_information,
     std::cout << "   " << setw(6) << "pT5";
     std::cout << "   " << setw(6) << "pT3";
     std::cout << "   " << setw(6) << "TC";
+    std::cout << "   " << setw(6) << "Reset";
     std::cout << "   " << setw(7) << "Total";
     std::cout << "   " << setw(7) << "Total(short)";
     std::cout << std::endl;
@@ -1005,6 +1006,7 @@ void printTimingInformation(std::vector<std::vector<float>>& timing_information,
         timing_total_short += timing[6] * 1000; // pT5
         timing_total_short += timing[7] * 1000; // pT3
         timing_total_short += timing[8] * 1000; // TC
+        timing_total_short += timing[9] * 1000; // Reset
         std::cout << setw(6) << ievt;
         std::cout << "   " << setw(6) << timing[0] * 1000;   // Hits
         std::cout << "   " << setw(6) << timing[1] * 1000;   // MD
@@ -1015,6 +1017,7 @@ void printTimingInformation(std::vector<std::vector<float>>& timing_information,
         std::cout << "   " << setw(6) << timing[6] * 1000;   // pT5
         std::cout << "   " << setw(6) << timing[7] * 1000;   // pT3
         std::cout << "   " << setw(6) << timing[8] * 1000;   // TC
+        std::cout << "   " << setw(6) << timing[9] * 1000;   // Reset
         std::cout << "   " << setw(7) << timing_total;       // Total time
         std::cout << "   " << setw(7) << timing_total_short; // Total time
         std::cout << std::endl;
@@ -1027,6 +1030,7 @@ void printTimingInformation(std::vector<std::vector<float>>& timing_information,
         timing_sum_information[6] += timing[6] * 1000;  // pT5
         timing_sum_information[7] += timing[7] * 1000;  // pT3
         timing_sum_information[8] += timing[8] * 1000;  // TC
+        timing_sum_information[9] += timing[9] * 1000;  // Reset
         timing_shortlist.push_back(timing_total_short); // short total
         timing_list.push_back(timing_total);            // short total
     }
@@ -1039,6 +1043,7 @@ void printTimingInformation(std::vector<std::vector<float>>& timing_information,
     timing_sum_information[6] /= timing_information.size(); // pT5
     timing_sum_information[7] /= timing_information.size(); // pT3
     timing_sum_information[8] /= timing_information.size(); // TC
+    timing_sum_information[9] /= timing_information.size(); // Reset
 
     float timing_total_avg = 0.0;
     timing_total_avg += timing_sum_information[0]; // Hits
@@ -1050,6 +1055,7 @@ void printTimingInformation(std::vector<std::vector<float>>& timing_information,
     timing_total_avg += timing_sum_information[6]; // pT5
     timing_total_avg += timing_sum_information[7]; // pT3
     timing_total_avg += timing_sum_information[8]; // TC
+    timing_total_avg += timing_sum_information[9]; // Reset
     float timing_totalshort_avg = 0.0;
     timing_totalshort_avg += timing_sum_information[1]; // MD
     timing_totalshort_avg += timing_sum_information[2]; // LS
@@ -1058,6 +1064,7 @@ void printTimingInformation(std::vector<std::vector<float>>& timing_information,
     timing_totalshort_avg += timing_sum_information[6]; // pT5
     timing_totalshort_avg += timing_sum_information[7]; // pT3
     timing_totalshort_avg += timing_sum_information[8]; // TC
+    timing_totalshort_avg += timing_sum_information[9]; // Reset
 
     float standardDeviation = 0.0;
     for (auto shorttime : timing_shortlist)
@@ -1077,6 +1084,7 @@ void printTimingInformation(std::vector<std::vector<float>>& timing_information,
     std::cout << "   " << setw(6) << "pT5";
     std::cout << "   " << setw(6) << "pT3";
     std::cout << "   " << setw(6) << "TC";
+    std::cout << "   " << setw(6) << "Reset";
     std::cout << "   " << setw(7) << "Total";
     std::cout << "   " << setw(7) << "Total(short)";
     std::cout << std::endl;
@@ -1090,6 +1098,7 @@ void printTimingInformation(std::vector<std::vector<float>>& timing_information,
     std::cout << "   " << setw(6) << timing_sum_information[6]; // pT5
     std::cout << "   " << setw(6) << timing_sum_information[7]; // pT3
     std::cout << "   " << setw(6) << timing_sum_information[8]; // TC
+    std::cout << "   " << setw(6) << timing_sum_information[9]; // Reset
     std::cout << "   " << setw(7) << timing_total_avg;          // Average total time
     std::cout << "   " << setw(7) << timing_totalshort_avg;     // Average total time
     std::cout << "+/- " << setw(4) << stdDev;

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -116,6 +116,6 @@ fi
 echo "Total Timing Summary"
 grep -h "Time for map " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for map loading =",SUM/5,"ms" }' # 5 is the number of stream values run
 grep -h "Time for input " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for input loading =",SUM/5,"ms" }' # 5 is the number of stream values run
-grep -h "Time for stream " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for stream creation =",SUM/5,"ms"}' # 5 is the number of stream values run
+grep -h "Time for event " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for SDL::Event creation =",SUM/21,"ms"}' # 5 is the number of total streams run (1+2+4+6+8)
 echo "   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate"
 grep -hr "avg " timing_temp.txt # space is needed to not get certain bad lines 

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -114,6 +114,8 @@ if [ -z ${SPECIFICGPUVERSION} ] || [[ "${SPECIFICGPUVERSION}" == "explicit_cache
 fi
 
 echo "Total Timing Summary"
-echo "   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Event      Short           Rate"
-#echo "   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       TCE      Event      Short           Loop      Effective"
+grep -h "Time for map " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for map loading =",SUM/5,"ms" }' # 5 is the number of stream values run
+grep -h "Time for input " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for input loading =",SUM/5,"ms" }' # 5 is the number of stream values run
+grep -h "Time for stream " timing_temp.txt | cut -d " " -f 6 | awk '{ SUM += $1} END { print "Average time for stream creation =",SUM/5,"ms"}' # 5 is the number of stream values run
+echo "   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate"
 grep -hr "avg " timing_temp.txt # space is needed to not get certain bad lines 


### PR DESCRIPTION
Timing info added for
- map loading
- input loading
- event/stream creation
- event reset

The event reset time ("Reset") is included in both the "Event" and the "Short" time. 

**Timing for 100 events**

This PR (0b91428f653d32a2811b7a63bb4e28106552fc62):
```
Total Timing Summary
Average time for map loading = 3163.12 ms
Average time for input loading = 5536.64 ms
Average time for stream creation = 0.164747 ms
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate
   avg      4.6      3.2      1.1      3.4      4.0      1.2      1.9      1.5      4.0      0.1      24.9      19.1+/-  3.5      29.1   explicit_cache[s=1]
   avg      7.6      4.6      1.7      6.6      5.6      1.5      3.7      2.4      6.5      0.1      40.4      31.4+/-  6.0      22.4   explicit_cache[s=2]
   avg     14.7      7.4      3.0     13.0     10.1      2.0      8.0      5.1     12.6      0.2      76.1      59.4+/- 10.8      20.4   explicit_cache[s=4]
   avg     24.1     10.1      4.8     18.5     15.1      2.7     12.5      7.3     18.0      0.4     113.7      86.9+/- 13.3      20.3   explicit_cache[s=6]
   avg     34.1     12.5      6.5     22.8     20.9      3.1     16.5      9.5     23.3      0.5     149.7     112.5+/- 19.2      20.2   explicit_cache[s=8]

```

Master (6e6e2d0612a9c67223b72da25fb5bf5ff4b6c848):
```
Total Timing Summary
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Event      Short           Rate
   avg      4.6      3.1      1.0      3.3      3.8      1.2      1.8      1.5      3.6      23.9      18.1+/-  3.4      28.1   explicit_cache[s=1]
   avg      7.7      4.4      1.7      6.4      5.5      1.5      3.5      2.4      6.5      39.7      30.5+/-  5.5      22.1   explicit_cache[s=2]
   avg     14.5      7.9      3.1     13.5      9.8      2.0      8.3      5.0     12.8      76.8      60.3+/- 10.0      20.5   explicit_cache[s=4]
   avg     22.1     10.7      4.7     18.6     15.8      2.7     13.6      7.4     18.1     113.5      88.8+/- 12.9      20.4   explicit_cache[s=6]
   avg     32.1     13.0      6.6     23.8     20.9      3.1     16.8      9.2     23.1     148.5     113.4+/- 21.0      20.3   explicit_cache[s=8]

```