### PR TITLE
Fixing hackathon bugs

### DIFF
--- a/SDL/Hit.cuh
+++ b/SDL/Hit.cuh
@@ -85,7 +85,7 @@ namespace SDL
       return x - n * float(2.f * float(M_PI));
     }
     CUDA_HOSTDEV inline float phi(float x, float y) {
-      return phi_mpi_pi(float(M_PI) + atan2f(y,x));
+      return phi_mpi_pi(float(M_PI) + atan2f(-y,-x));
     }
     CUDA_HOSTDEV inline float deltaPhi(float x1, float y1, float x2, float y2) {
       float phi1 = phi(x1,y1);

--- a/SDL/Quintuplet.cu
+++ b/SDL/Quintuplet.cu
@@ -622,11 +622,11 @@ __device__ bool SDL::passT5RZConstraint(struct SDL::modules& modulesInGPU, struc
     const float& z5 = mdsInGPU.anchorZ[fifthMDIndex]/100;
 
     //following Philip's layer number prescription
-    const int layer1 = modulesInGPU.layers[lowerModuleIndex1];
-    const int layer2 = modulesInGPU.layers[lowerModuleIndex2];
-    const int layer3 = modulesInGPU.layers[lowerModuleIndex3];
-    const int layer4 = modulesInGPU.layers[lowerModuleIndex4];
-    const int layer5 = modulesInGPU.layers[lowerModuleIndex5];
+    const int layer1 = modulesInGPU.sdlLayers[lowerModuleIndex1];
+    const int layer2 = modulesInGPU.sdlLayers[lowerModuleIndex2];
+    const int layer3 = modulesInGPU.sdlLayers[lowerModuleIndex3];
+    const int layer4 = modulesInGPU.sdlLayers[lowerModuleIndex4];
+    const int layer5 = modulesInGPU.sdlLayers[lowerModuleIndex5];
 
     //slope computed using the internal T3s
     const int moduleType1 = modulesInGPU.moduleType[lowerModuleIndex1]; //0 is ps, 1 is 2s


### PR DESCRIPTION
Validation that this worked (everything on non-DNN version):

- Current master (buggy): https://uaf-10.t2.ucsd.edu/~evourlio/SDL/hackathonFixes/beforeFixes_PU200_NEVT175_a8c352-PU200/mtv/var/TC_fakerate_etazoom.pdf
- Before bugs were introduced (as it should be) - took as reference commit 1b12ee5b8be13f9ebf6c9530873c3635eaf039f3, which has no DNN and no other performance changes in between: https://uaf-10.t2.ucsd.edu/~evourlio/SDL/hackathonFixes/beforeHackathonPRsAndDNN_PU200_NEVT175_1b12ee-PU200/mtv/var/TC_fakerate_etazoom.pdf
- After fixes (should agree with the one just above): https://uaf-10.t2.ucsd.edu/~evourlio/SDL/hackathonFixes/hackathonFixes_PU200_NEVT175_aed0d8-PU200/mtv/var/TC_fakerate_etazoom.pdf
- Comparison of the last two: https://uaf-10.t2.ucsd.edu/~evourlio/SDL/hackathonFixes/compare_beforeHackathonPRsAndDNN_VS_hackathonFixes_1b12ee-PU200_aed0d8-PU200/mtv/var/TC_base_0_0_eff_etazoom.pdf
- Folder with all validation plots: https://uaf-10.t2.ucsd.edu/~evourlio/SDL/hackathonFixes/

Tl;dr: After fixes, things agree with the non-buggy version.