### PR TITLE
Fixing hackathon bugs (alpaka version)

### DIFF
--- a/SDL/Hit.h
+++ b/SDL/Hit.h
@@ -155,7 +155,7 @@ namespace SDL
     template<typename TAcc>
     ALPAKA_FN_HOST_ACC ALPAKA_FN_INLINE float phi(TAcc const & acc, float x, float y)
     {
-        return phi_mpi_pi(acc, float(M_PI) + alpaka::math::atan2(acc, y, x));
+        return phi_mpi_pi(acc, float(M_PI) + alpaka::math::atan2(acc, -y, -x));
     };
 
     template<typename TAcc>

--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -339,11 +339,11 @@ namespace SDL
         const float& z5 = mdsInGPU.anchorZ[fifthMDIndex]/100;
 
         //following Philip's layer number prescription
-        const int layer1 = modulesInGPU.layers[lowerModuleIndex1];
-        const int layer2 = modulesInGPU.layers[lowerModuleIndex2];
-        const int layer3 = modulesInGPU.layers[lowerModuleIndex3];
-        const int layer4 = modulesInGPU.layers[lowerModuleIndex4];
-        const int layer5 = modulesInGPU.layers[lowerModuleIndex5];
+        const int layer1 = modulesInGPU.sdlLayers[lowerModuleIndex1];
+        const int layer2 = modulesInGPU.sdlLayers[lowerModuleIndex2];
+        const int layer3 = modulesInGPU.sdlLayers[lowerModuleIndex3];
+        const int layer4 = modulesInGPU.sdlLayers[lowerModuleIndex4];
+        const int layer5 = modulesInGPU.sdlLayers[lowerModuleIndex5];
 
         //slope computed using the internal T3s
         const int moduleType1 = modulesInGPU.moduleType[lowerModuleIndex1]; //0 is ps, 1 is 2s


### PR DESCRIPTION
Same fixes as in the master, different results:

- Master branch with the fix (as things should be): https://uaf-10.t2.ucsd.edu/~evourlio/SDL/hackathonFixes/hackathonFixes_PU200_NEVT175_aed0d8-PU200/mtv/var/TC_fakerate_etazoom.pdf
- Alpaka branch with the fix (should agree with the above): https://uaf-10.t2.ucsd.edu/~evourlio/SDL/hackathonFixes/alpaka_hackathonFixes_PU200_NEVT175_d724f0-PU200/mtv/var/TC_fakerate_etazoom.pdf

Something is killing the T5s. Gavin and I are looking into it.