### PR TITLE
Thread-safe event setup for CMSSW

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ For convenience, the workflow has been run for 100 events and the output is stor
 For enabling the LST reconstruction in the CMSSW tracking workflow, a modified step3 needs to be run.
 This is based on the step3 command of the 21034.1 workflow with the following changes:
    - Use dummy PU input files by changing the argument of the `--pileup_input` flag to `file:file.root` (this will be fixed manually in the configuration file)
+   - The number of threads and streams for the job can be optionally controlled by the `--nThreads` and `--nStreams` command line options respectively (`1` ends up being the actual default value for both, and more info can be found by running `cmsDriver.py --help`).
    - Add at the end of the command: `--procModifiers gpu,trackingLST,trackingIters01 --no_exec`
 
 Run the command and modify the output configuration file with the following:

--- a/SDL/LST.cc
+++ b/SDL/LST.cc
@@ -5,8 +5,10 @@ SDL::LST::LST() {
 }
 
 void SDL::LST::eventSetup() {
+    static std::once_flag mapsLoaded;
     std::call_once(mapsLoaded, &SDL::LST::loadMaps, this);
     TString path = get_absolute_path_after_check_file_exists(TString::Format("%s/data/centroid_CMSSW_12_2_0_pre2.txt",TrackLooperDir_.Data()).Data());
+    static std::once_flag modulesInited;
     std::call_once(modulesInited, SDL::initModules, path);
 }
 

--- a/SDL/LST.cc
+++ b/SDL/LST.cc
@@ -5,9 +5,9 @@ SDL::LST::LST() {
 }
 
 void SDL::LST::eventSetup() {
-    loadMaps();
+    std::call_once(mapsLoaded, &SDL::LST::loadMaps, this);
     TString path = get_absolute_path_after_check_file_exists(TString::Format("%s/data/centroid_CMSSW_12_2_0_pre2.txt",TrackLooperDir_.Data()).Data());
-    SDL::initModules(path);
+    std::call_once(modulesInited, SDL::initModules, path);
 }
 
 void SDL::LST::loadMaps() {

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -1,8 +1,10 @@
+#ifndef LST_H
+#define LST_H
+
 #include <filesystem>
 #include <cstdlib>
 #include <numeric>
 #include <mutex>
-std::once_flag mapsLoaded, modulesInited;
 
 #include "code/cppitertools/enumerate.hpp"
 
@@ -238,3 +240,5 @@ namespace SDL {
     };
 
 } //namespace
+
+#endif

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -1,6 +1,8 @@
 #include <filesystem>
 #include <cstdlib>
 #include <numeric>
+#include <mutex>
+std::once_flag mapsLoaded, modulesInited;
 
 #include "code/cppitertools/enumerate.hpp"
 


### PR DESCRIPTION
As per title.

**Performance with 32 threads/24 streams over 1000 events** can be found [here](https://uaf-10.t2.ucsd.edu/~evourlio/SDL/multithreadingValidation/).

**Circle timing plots for Iters01LST workflow:**
- [Before this PR](https://uaf-10.t2.ucsd.edu/~evourlio/circles/web/piechart.php?local=false&dataset=Iters01LST_noValidation_HLTonGPU_230610&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0)
- [After this PR (1 thread/1 stream)](https://uaf-10.t2.ucsd.edu/~evourlio/circles/web/piechart.php?local=false&dataset=resources_Iters01LST_noValidation_1threads1streams&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0): Timing of lstProducer greatly reduced, due to loading the maps only once per run, not once per event, as it was the case before. Timing gain expected: ~900ms * (NumberOfEvents - 1)
- [After this PR (2 thread/2 stream)](https://uaf-10.t2.ucsd.edu/~evourlio/circles/web/piechart.php?local=false&dataset=resources_Iters01LST_noValidation_2threads2streams&resource=time_real&colours=default&groups=reco_PhaseII&threshold=0): A multithreaded configuration was not possible previous to this PR. The blank area in the timing chart is greatly reduced, as the now explicitly initialized second thread actually does work.

**Throughput measurement for 100 events:**
- Before this PR: 0.17 ev/s
- After this PR (1 thread/1 stream): 0.21 ev/s
- After this PR (2 thread/2 stream): 0.42 ev/s
- After this PR (4 thread/4 stream): 0.80 ev/s

**CPU profiling:**
- [Before this PR](https://evourlio.web.cern.ch/evourlio/cgi-bin/igprof-navigator/ig_LSTinCMSSW_6e6e2d0_phi3_100Events): See entry [28](https://evourlio.web.cern.ch/evourlio/cgi-bin/igprof-navigator/ig_LSTinCMSSW_6e6e2d0_phi3_100Events/28).
- [After this PR](https://evourlio.web.cern.ch/evourlio/cgi-bin/igprof-navigator/ig_Iters01LST_noValidation_1threads1streams): See entries [437](https://evourlio.web.cern.ch/evourlio/cgi-bin/igprof-navigator/ig_Iters01LST_noValidation_1threads1streams/437) and [434](https://evourlio.web.cern.ch/evourlio/cgi-bin/igprof-navigator/ig_Iters01LST_noValidation_1threads1streams/434).