### PR TITLE
Fixes in construction of T5s

### DIFF
--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -2204,6 +2204,20 @@ namespace SDL
             for (int iter = globalThreadIdx[0]; iter < nEligibleT5Modules; iter += gridThreadExtent[0])
             {
                 uint16_t lowerModule1 = rangesInGPU.indicesOfEligibleT5Modules[iter];
+                short layer2_adjustment;
+                int layer = modulesInGPU.layers[lowerModule1];
+                if(layer == 1)
+                {
+                    layer2_adjustment = 1;
+                } // get upper segment to be in second layer
+                else if(layer == 2)
+                {
+                    layer2_adjustment = 0;
+                } // get lower segment to be in second layer
+                else
+                {
+                    continue;
+                }
                 unsigned int nInnerTriplets = tripletsInGPU.nTriplets[lowerModule1];
                 for( unsigned int innerTripletArrayIndex = globalThreadIdx[1]; innerTripletArrayIndex < nInnerTriplets; innerTripletArrayIndex += gridThreadExtent[1])
                 {
@@ -2224,20 +2238,6 @@ namespace SDL
 
                         if(success)
                         {
-                            short layer2_adjustment;
-                            int layer = modulesInGPU.layers[lowerModule1];
-                            if(layer == 1)
-                            {
-                                layer2_adjustment = 1;
-                            } // get upper segment to be in second layer
-                            else if(layer == 2)
-                            {
-                                layer2_adjustment = 0;
-                            } // get lower segment to be in second layer
-                            else
-                            {
-                                return;
-                            } // ignore anything else TODO: move this to start, before object is made (faster)
                             int totOccupancyQuintuplets = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1);
                             if(totOccupancyQuintuplets >= rangesInGPU.quintupletModuleOccupancy[lowerModule1])
                             {

--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -2239,7 +2239,7 @@ namespace SDL
                                 return;
                             } // ignore anything else TODO: move this to start, before object is made (faster)
                             int totOccupancyQuintuplets = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1);
-                            if(totOccupancyQuintuplets >= (rangesInGPU.quintupletModuleIndices[lowerModule1 + 1] - rangesInGPU.quintupletModuleIndices[lowerModule1]))
+                            if(totOccupancyQuintuplets >= rangesInGPU.quintupletModuleOccupancy[lowerModule1])
                             {
 #ifdef Warnings
                                 printf("Quintuplet excess alert! Module index = %d\n", lowerModule1);
@@ -2338,6 +2338,7 @@ namespace SDL
                 int nTotQ = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalQuintupletsx, occupancy);
                 rangesInGPU.quintupletModuleIndices[i] = nTotQ;
                 rangesInGPU.indicesOfEligibleT5Modules[nEligibleT5Modules] = i;
+                rangesInGPU.quintupletModuleOccupancy[i] = occupancy;
             }
 
             // Wait for all threads to finish before reporting final values


### PR DESCRIPTION
I fixed a couple of issues with the construction of T5s.

1. When saving quintuplets, it was checking for the maximum occupancy using differences in values from `quintupletModuleIndices`. There are two issues with this. First, the indices in this array are in general not sorted since this array is created in parallel. Secondly, the maximum occupancy obtained with this difference would have actually corresponded to the one of the following module, and the computation for the last module was accessing garbage data. To fix this, we save the maximum occupancy for each module in `quintupletModuleOccupancy` and adjust the `createQuintupletsInGPUv2` kernel to check the maximum occupancy values from there.
2. There was a check for the layer of the first module that was done after the quintuplet algorithm. This was moved to the beginning of the loop for a potential speedup. The issue with this check was that there was a `return` statement. But again, since the modules were not guaranteed to be in a particular order this can cause some modules to be skipped. Therefore, this was changed to a `continue` statement.

Here are timing comparisons before and after this PR. Seems like there are mixed changes for the T5s.

Timing of master on GPU (https://github.com/SegmentLinking/TrackLooper/commit/6d818d4b77fccef161d798c9e6a228ea6936d417):
```
Total Timing Summary
Average time for map loading = 7819.46 ms
Average time for input loading = 19114.9 ms
Average time for SDL::Event creation = 0.0870681 ms
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate
   avg      8.9      2.2      0.4      2.8      3.3      1.0      1.4      1.2      1.2      6.7      29.0      19.1+/-  2.1      32.9   explicit[s=1]
   avg     17.3      2.5      0.5      5.2      5.6      1.0      3.3      3.0      1.6     11.5      51.5      33.2+/-  7.2      29.9   explicit[s=2]
   avg     37.7      2.7      0.5      9.3     11.7      1.1      8.8      7.1      2.0     27.1     108.0      69.2+/- 27.7      29.2   explicit[s=4]
   avg     65.1      2.7      0.5     13.6     17.0      1.2     15.8     13.1      1.9     47.2     178.1     111.9+/- 36.1      31.9   explicit[s=6]
   avg     95.4      2.7      0.6     17.7     23.7      1.1     22.8     17.3      1.9     73.1     256.2     159.7+/- 55.1      34.1   explicit[s=8]
   avg      4.9      2.2      0.4      1.9      1.9      1.0      1.3      1.1      1.2      0.5      16.3      10.5+/-  2.1      19.7   explicit_cache[s=1]
   avg      6.8      2.5      0.4      2.5      2.5      1.0      1.9      1.6      1.7      0.9      22.0      14.1+/-  3.6      15.5   explicit_cache[s=2]
   avg     11.7      3.1      0.7      4.2      3.9      1.1      3.2      2.4      2.8      1.5      34.6      21.8+/-  7.6      11.5   explicit_cache[s=4]
   avg     17.4      3.7      1.1      6.0      5.5      1.2      4.6      3.4      4.0      1.8      48.5      29.9+/- 10.2       9.9   explicit_cache[s=6]
   avg     23.9      4.6      1.5      8.1      7.5      1.5      6.1      4.2      4.8      3.0      65.1      39.8+/- 14.2       9.6   explicit_cache[s=8]
```

Timing of this PR on GPU (https://github.com/SegmentLinking/TrackLooper/commit/f907dea33f3d2acf0a89dd9f16a723fab2ffbb39):
```
Total Timing Summary
Average time for map loading = 8246.01 ms
Average time for input loading = 19167.2 ms
Average time for SDL::Event creation = 0.0990231 ms
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate
   avg      9.6      2.2      0.4      2.8      3.3      1.0      1.5      1.2      1.3      7.1      30.2      19.7+/-  2.1      32.9   explicit[s=1]
   avg     17.8      2.5      0.5      4.7      5.4      1.0      3.7      3.0      1.7     12.5      52.7      33.9+/-  6.0      30.4   explicit[s=2]
   avg     35.0      2.7      0.5      8.4      9.9      1.1      8.5      6.7      2.0     31.4     106.2      70.1+/- 27.0      30.1   explicit[s=4]
   avg     68.0      2.7      0.5     14.1     18.5      1.1     15.3     12.4      1.9     48.1     182.4     113.3+/- 39.8      32.7   explicit[s=6]
   avg     92.2      2.7      0.6     18.1     23.9      1.1     21.6     15.6      1.9     71.3     249.0     155.7+/- 50.5      33.5   explicit[s=8]
   avg      5.2      2.2      0.4      1.9      1.9      1.0      1.4      1.1      1.3      0.5      16.9      10.7+/-  2.2      19.5   explicit_cache[s=1]
   avg      6.7      2.5      0.5      2.6      2.5      1.0      2.1      1.5      1.6      0.8      21.9      14.1+/-  3.7      16.1   explicit_cache[s=2]
   avg     11.9      3.3      0.9      4.5      4.2      1.1      3.5      2.5      2.9      1.6      36.4      23.4+/-  5.7      10.4   explicit_cache[s=4]
   avg     18.0      4.1      1.4      6.2      6.5      1.3      5.1      3.5      4.5      2.2      52.9      33.5+/-  8.8       9.5   explicit_cache[s=6]
   avg     24.4      5.0      1.9      8.4      8.4      1.6      6.8      4.3      5.5      3.0      69.1      43.2+/- 13.1       9.6   explicit_cache[s=8]

```

Here are the performance plots for all the different configurations.
GPU master: [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR322/gpu_master_PU200_NEVT-1_6d818d-PU200/summary/)
GPU this PR: [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR322/gpu_t5_fixes_PU200_NEVT-1_f907de-PU200/summary/)
CPU alpaka_cpu: [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR322/cpu_alpaka_cpu_PU200_NEVT-1_2dca52-PU200/summary/)
CPU this PR: [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR322/cpu_alpaka_cpu_t5_fixes_PU200_NEVT-1_2dca52D-PU200/summary/)

And here are the comparison plots.
GPU master vs this PR: [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR322/gpu_comparison_6d818d-PU200_f907de-PU200/summary/)
CPU alpaka_cpu vs this PR: [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR322/cpu_comparison_2dca52-PU200_2dca52D-PU200/summary/)
GPU vs CPU with this PR: [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR322/gpu-vs-cpu_comparison_f907de-PU200_2dca52D-PU200/summary/)

Overall, it seems like the TC efficiency improved a tiny bit:
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/61b3f848-5ef1-4a06-8a33-6cc76d6103cb)
Fake rate and duplicate rate slightly decreased at high pt, but slightly increased at low pt:
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/801c5394-d60e-42db-8937-e533b73962a9)
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/f3862ae0-833b-42a9-94d2-999c80e569e4)

There are still small differences between CPU and GPU, but it seems like it's manly in duplicate rate, so we'll have to take a look at those kernels.