### PR TITLE
checkHitspLS fixes

### DIFF
--- a/SDL/Kernels.h
+++ b/SDL/Kernels.h
@@ -540,7 +540,7 @@ namespace SDL
                         float dPhi = SDL::calculate_dPhi(phi_pix1, phi_pix2);
 
                         float dR2 = dEta*dEta + dPhi*dPhi;
-                        if(npMatched >= 1 or dR2 < 0.00075f and (ix < jx))
+                        if(( (npMatched >= 1) || (dR2 < 0.00075f) ) && (ix < jx))
                         {
                             rmPixelSegmentFromMemory(segmentsInGPU, ix); 
                         }


### PR DESCRIPTION
There were two issues that I found in the checkHitspLS kernel:

1. When running it with `secondpass = true`, it checks whether the segments are duplicates during the loop. When it is checked for index `ix` it's fine because this is the only index that could be marked as a duplicate, so it can be skipped if it's already known that it is a duplicate. However, for the one at index `jx` it is a bit ambiguous what should be done. If we check if `jx` is a duplicate and it is skipped if so (as it is currently done) then this process depends on parallelization since one thread can mark it as duplicate before some other thread checks for it. This is what what causing the difference in duplicate rates between CPU and GPU. However, it is also not clear if it should just not be checked since presumably it might end up removing extra things that should have been kept. For now, I removed the second check, which makes CPU and GPU runs agree, but an alternative approach is possible.
2. The logic of [this line](https://github.com/SegmentLinking/TrackLooper/blob/8dbf8b213b272ab7fef5f7df071c5dfa7f7b5623/SDL/Kernels.h#L543) was being interpreted by the compiler as
```
npMatched >= 1 or (dR2 < 0.00075f and (ix < jx))
```
whereas the intended logic was presumably
```
(npMatched >= 1 or dR2 < 0.00075f) and (ix < jx)
```
Looking back at when this was introduced by [this PR](https://github.com/SegmentLinking/TrackLooper/pull/151/) corroborates this. However, adding parenthesis as in the second option it ends up producing a huge increase in duplicate rates. This is because the old logic didn't use the `ix < jx` condition. So I also removed it to match the previous logic.

The result of these changes is a huge decrease in duplicate rates, but it also comes with a small decrease in efficiencies. It's not clear to me whether this drop in efficiency is worth it, or if we should try to find a better fix for the above issues.

Here is how the drop in duplicate rates looks:
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/1121092f-9966-4aad-b94f-0707953a041d)

And this is how the drop in efficiencies looks:
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/8c9f7e58-09d3-47e5-bccf-862f6a3b3c63)

The CPU and GPU runs now agree almost perfectly. Here is a comparison of duplicate rates:
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/d8e32ea6-19e2-4f52-8c1b-ad2ac6586121)

Here is the timing before and after these changes:
![Screenshot 2023-09-14 at 2 40 43 PM](https://github.com/SegmentLinking/TrackLooper/assets/7596837/8917bef6-026d-4e51-b24c-31ebb3d1f1a7)
![Screenshot 2023-09-14 at 2 32 58 PM](https://github.com/SegmentLinking/TrackLooper/assets/7596837/52f02ee9-774f-49ac-85d8-33efe47047db)

All of the comparisons were done with the changes in #313 (which is still not merged at the time of writing) on the master branch.

Edit: Removed link to comparison plots, since now the correspond to a different change.