### PR TITLE
Fixed buffer overflow with track candidates

### DIFF
--- a/SDL/Constants.h
+++ b/SDL/Constants.h
@@ -117,8 +117,8 @@ const unsigned int N_MAX_PIXEL_SEGMENTS_PER_MODULE = 50000;
 const unsigned int N_MAX_PIXEL_TRIPLETS = 5000;
 const unsigned int N_MAX_PIXEL_QUINTUPLETS = 15000;
 
-const unsigned int N_MAX_TRACK_CANDIDATES = 1000;
-const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES = 4000;
+const unsigned int N_MAX_PIXEL_TRACK_CANDIDATES = 30000;
+const unsigned int N_MAX_NONPIXEL_TRACK_CANDIDATES = 1000;
 
 const unsigned int N_MAX_TRACK_CANDIDATE_EXTENSIONS = 200000;
 const unsigned int N_MAX_TRACK_EXTENSIONS_PER_TC = 30;

--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -649,7 +649,7 @@ void SDL::Event::createTrackCandidates()
     if(trackCandidatesInGPU == nullptr)
     {
         trackCandidatesInGPU = new SDL::trackCandidates();
-        trackCandidatesBuffers = new SDL::trackCandidatesBuffer<Acc>(N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devAcc, queue);
+        trackCandidatesBuffers = new SDL::trackCandidatesBuffer<Acc>(N_MAX_NONPIXEL_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devAcc, queue);
         trackCandidatesInGPU->setData(*trackCandidatesBuffers);
     }
 
@@ -1026,7 +1026,7 @@ void SDL::Event::createPixelQuintuplets()
     if(trackCandidatesInGPU == nullptr)
     {
         trackCandidatesInGPU = new SDL::trackCandidates();
-        trackCandidatesBuffers = new SDL::trackCandidatesBuffer<Acc>(N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devAcc, queue);
+        trackCandidatesBuffers = new SDL::trackCandidatesBuffer<Acc>(N_MAX_NONPIXEL_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devAcc, queue);
         trackCandidatesInGPU->setData(*trackCandidatesBuffers);
     }
 
@@ -1817,7 +1817,7 @@ SDL::trackCandidatesBuffer<alpaka::DevCpu>* SDL::Event::getTrackCandidates()
         alpaka::wait(queue);
 
         int nTrackCanHost = *alpaka::getPtrNative(nTrackCanHost_buf);
-        trackCandidatesInCPU = new SDL::trackCandidatesBuffer<alpaka::DevCpu>(N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devHost, queue);
+        trackCandidatesInCPU = new SDL::trackCandidatesBuffer<alpaka::DevCpu>(N_MAX_NONPIXEL_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devHost, queue);
         trackCandidatesInCPU->setData(*trackCandidatesInCPU);
 
         *alpaka::getPtrNative(trackCandidatesInCPU->nTrackCandidates_buf) = nTrackCanHost;
@@ -1842,7 +1842,7 @@ SDL::trackCandidatesBuffer<alpaka::DevCpu>* SDL::Event::getTrackCandidatesInCMSS
         alpaka::wait(queue);
 
         int nTrackCanHost = *alpaka::getPtrNative(nTrackCanHost_buf);
-        trackCandidatesInCPU = new SDL::trackCandidatesBuffer<alpaka::DevCpu>(N_MAX_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devHost, queue);
+        trackCandidatesInCPU = new SDL::trackCandidatesBuffer<alpaka::DevCpu>(N_MAX_NONPIXEL_TRACK_CANDIDATES + N_MAX_PIXEL_TRACK_CANDIDATES, devHost, queue);
         trackCandidatesInCPU->setData(*trackCandidatesInCPU);
 
         *alpaka::getPtrNative(trackCandidatesInCPU->nTrackCandidates_buf) = nTrackCanHost;


### PR DESCRIPTION
This PR addresses (at least partially) issue #317. The issue occurs due a buffer overflow since code that save track candidate objects doesn't check if the maximum allocated number has been reached.

There are multiple ways to address the issue. The simplest one would be to simply check if the maximum number is reached and then just exit out of the loop to stop the process. However, to be more consistent with the rest of the code, I have made it so that it keeps track of the number of track candidates even if they are not saved. This is done in all other steps of the code, for example when creating line segments it works like this:
https://github.com/SegmentLinking/TrackLooper/blob/8dbf8b213b272ab7fef5f7df071c5dfa7f7b5623/SDL/Segment.h#L651-L663
So I have used an equivalent implementation for track candidates. It is probably beneficial to keep track of this number even if all of them are not actually saved. It ended up needing more changes than I expected to get it working properly.

**Note: When it is used with CMSSW the `nTrackCandidates` variable is set to the number that are actually saved so as to avoid potential issues.**

Another improvement is that now respects the separate limits for `N_MAX_TRACK_CANDIDATES` and `N_MAX_PIXEL_TRACK_CANDIDATES`.

Here are the timings before and after the change. Seems like they're within the run-to-run variation.
![Screenshot 2023-09-18 at 1 27 35 PM](https://github.com/SegmentLinking/TrackLooper/assets/7596837/371149e6-03b3-409a-93e2-11c9e11f4bba)
![Screenshot 2023-09-18 at 1 34 47 PM](https://github.com/SegmentLinking/TrackLooper/assets/7596837/546dafce-daff-4ef6-9893-f08283283e80)

Comparison plots are [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR324/). They look identical, up to small run-to-run variations, most likely due to the issue described in #323.

All of the comparisons were done with the changes in #313 (which is still not merged at the time of writing) on the master branch.