### PR TITLE
Fix debug mode

### DIFF
--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -1690,10 +1690,10 @@ SDL::tripletsBuffer<alpaka::DevCpu>* SDL::Event::getTriplets()
 
         *alpaka::getPtrNative(tripletsInCPU->nMemoryLocations_buf) = nMemHost;
 #ifdef CUT_VALUE_DEBUG
-        alpaka::memcpy(queue, tripletsInCPU->zOut_buf, tripletsBuffers->zOut_buf, 4 * nMemHost);
+        alpaka::memcpy(queue, tripletsInCPU->zOut_buf, tripletsBuffers->zOut_buf, nMemHost);
         alpaka::memcpy(queue, tripletsInCPU->zLo_buf, tripletsBuffers->zLo_buf, nMemHost);
         alpaka::memcpy(queue, tripletsInCPU->zHi_buf, tripletsBuffers->zHi_buf, nMemHost);
-        alpaka::memcpy(queue, tripletsInCPU->zLoPointed_buf, tripletsBuffers->zLoPointed_buf, 4 * nMemHost);
+        alpaka::memcpy(queue, tripletsInCPU->zLoPointed_buf, tripletsBuffers->zLoPointed_buf, nMemHost);
         alpaka::memcpy(queue, tripletsInCPU->zHiPointed_buf, tripletsBuffers->zHiPointed_buf, nMemHost);
         alpaka::memcpy(queue, tripletsInCPU->sdlCut_buf, tripletsBuffers->sdlCut_buf, nMemHost);
         alpaka::memcpy(queue, tripletsInCPU->betaInCut_buf, tripletsBuffers->betaInCut_buf, nMemHost);


### PR DESCRIPTION
This fixes the crash found in Issue #327, where two memcopy's are trying to transfer data larger than the array size since those arrays were destacked when moved over to Alpaka.