### PR TITLE
Updates to make LST on CPU run in CMSSW

### DIFF
--- a/SDL/Constants.h
+++ b/SDL/Constants.h
@@ -27,7 +27,11 @@ using Dim = alpaka::DimInt<3u>;
 using Dim1d = alpaka::DimInt<1u>;
 using Vec = alpaka::Vec<Dim,Idx>;
 using Vec1d = alpaka::Vec<Dim1d,Idx>;
-using QueueProperty = alpaka::NonBlocking;
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+  using QueueProperty = alpaka::NonBlocking;
+#else
+  using QueueProperty = alpaka::Blocking;
+#endif
 using WorkDiv = alpaka::WorkDivMembers<Dim, Idx>;
 
 Vec const elementsPerThread(Vec::all(static_cast<Idx>(1)));


### PR DESCRIPTION
Change needed because CMSSW complains about the QueueProperty when running the serial backend with 1 thread/stream.

Timing for this PR (f0c6bcbfde8d7eefe891a67d2521231fdd1ad285):
```
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate
   avg     33.4    327.7    102.9     60.4     99.3    494.1    589.3    124.7     88.1      7.7    1927.6    1400.1+/- 373.4    1928.5   explicit_cache[s=1]
   avg     37.5    333.0    103.5     59.7     98.8    496.4    591.5    126.0     88.4      2.9    1937.7    1403.8+/- 377.4     499.5   explicit_cache[s=4]
   avg    108.3    380.0    134.5     81.9    117.0    548.4    653.7    141.3     96.8      3.0    2265.0    1608.3+/- 441.4     167.9   explicit_cache[s=16]
   avg    278.0    390.1    170.2     99.7    117.5    558.1    666.3    142.4     98.9      2.0    2523.2    1687.2+/- 453.0     109.7   explicit_cache[s=32]
   avg    821.7    474.5    368.2    200.9    130.8    573.1    673.6    143.4    100.3      2.0    3488.5    2093.7+/- 690.2      80.3   explicit_cache[s=64]
```

Timing for master (034c7ced)
```
   Evt    Hits       MD       LS      T3       T5       pLS       pT5      pT3      TC       Reset    Event     Short             Rate
   avg     35.1    325.9    103.7     62.1    103.3    513.6    573.6    125.1     90.0      0.6    1933.0    1384.4+/- 369.3    1943.1   explicit_cache[s=1]
   avg     40.0    328.6    108.5     61.6    101.1    516.1    577.6    126.9     90.8      0.8    1952.2    1396.0+/- 384.3     509.9   explicit_cache[s=4]
   avg    108.7    372.6    136.2     81.6    118.4    568.5    630.9    138.9     98.4      0.9    2255.2    1578.0+/- 416.2     165.0   explicit_cache[s=16]
   avg    254.8    386.4    179.3    104.1    120.1    580.3    648.5    142.5    101.0      0.7    2517.6    1682.5+/- 447.3     109.7   explicit_cache[s=32]
   avg    911.2    467.6    339.5    186.4    133.8    594.3    662.0    144.0    103.1      0.5    3542.3    2036.8+/- 659.7      80.6   explicit_cache[s=64]
```
