### PR TITLE
Make the DNN the default (the -N flag disables it)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ movetoweb.sh
 *.nsys-rep
 *.sqlite
 *.ncu-rep
+*.swp
 
 *.nfs*
 .directoryhash

--- a/bin/sdl_make_tracklooper
+++ b/bin/sdl_make_tracklooper
@@ -40,7 +40,7 @@ while getopts ":cxgsmdp3NCeh" OPTION; do
     d) MAKECUTVALUES=true;;
     p) PRIMITIVE=true;;
     3) T3T3EXTENSION=true;;
-    N) USENN=true;;
+    N) DONTUSENN=true;;
     C) CPUBACKEND=true;;
     h) usage;;
     :) usage;;
@@ -54,7 +54,7 @@ if [ -z ${MAKECLEANBINARIES} ]; then MAKECLEANBINARIES=false; fi
 if [ -z ${MAKECUTVALUES} ]; then MAKECUTVALUES=false; fi
 if [ -z ${PRIMITIVE} ]; then PRIMITIVE=false; fi
 if [ -z ${T3T3EXTENSION} ]; then T3T3EXTENSION=false; fi
-if [ -z ${USENN} ]; then USENN=false; fi
+if [ -z ${DONTUSENN} ]; then DONTUSENN=false; fi
 if [ -z ${CPUBACKEND} ]; then CPUBACKEND=false; fi
 
 # Shift away the parsed options
@@ -79,7 +79,7 @@ echo "  MAKECLEANBINARIES : ${MAKECLEANBINARIES}"             | tee -a ${LOG}
 echo "  MAKECUTVALUES     : ${MAKECUTVALUES}"                 | tee -a ${LOG}
 echo "  PRIMITIVE         : ${PRIMITIVE}"                     | tee -a ${LOG}
 echo "  T3T3EXTENSION     : ${T3T3EXTENSION}"                 | tee -a ${LOG}
-echo "  USENN             : ${USENN}"                         | tee -a ${LOG}
+echo "  DONTUSENN         : ${DONTUSENN}"                     | tee -a ${LOG}
 echo "  CPUBACKEND        : ${CPUBACKEND}"                    | tee -a ${LOG}
 echo ""                                                       | tee -a ${LOG}
 echo "  (cf. Run > sh $(basename $0) -h to see all options)"  | tee -a ${LOG}
@@ -121,10 +121,10 @@ if $T3T3EXTENSION; then
 fi
 
 T5CUTOPT=
-if $USENN; then
-    T5CUTOPT="T5RZCHI2FLAG=-DUSE_RZCHI2 T5DNNFLAG=-DUSE_T5_DNN"
-else
+if $DONTUSENN; then
     T5CUTOPT="T5RZCHI2FLAG=-DUSE_RZCHI2 T5RPHICHI2FLAG=-DUSE_RPHICHI2"
+else
+    T5CUTOPT="T5RZCHI2FLAG=-DUSE_RZCHI2 T5DNNFLAG=-DUSE_T5_DNN"
 fi
 
 BACKENDOPT=

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -7,7 +7,7 @@ run_gpu()
     nevents=$3
     shift 3
     # GPU backend
-    sdl_make_tracklooper -m $*
+    sdl_make_tracklooper -mN $*
     for s_value in 1 2 4 6 8; do
         sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s${s_value}.root -v 1 -w 0 -s ${s_value} -i ${sample} | tee -a timing_temp.txt
     done
@@ -20,7 +20,7 @@ run_cpu()
     nevents=$3
     shift 3
     # CPU backend
-    sdl_make_tracklooper -mC $*
+    sdl_make_tracklooper -mNC $*
     for s_value in 1 4 16 32 64; do
         sdl -n ${NEVENTS} -o ${OUTDIR}/cpu_${version}_s${s_value}.root -v 1 -w 0 -s ${s_value} -i ${sample} | tee -a timing_temp.txt
     done

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -7,7 +7,7 @@ run_gpu()
     nevents=$3
     shift 3
     # GPU backend
-    sdl_make_tracklooper -mN $*
+    sdl_make_tracklooper -m $*
     for s_value in 1 2 4 6 8; do
         sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s${s_value}.root -v 1 -w 0 -s ${s_value} -i ${sample} | tee -a timing_temp.txt
     done
@@ -20,7 +20,7 @@ run_cpu()
     nevents=$3
     shift 3
     # CPU backend
-    sdl_make_tracklooper -mNC $*
+    sdl_make_tracklooper -mC $*
     for s_value in 1 4 16 32 64; do
         sdl -n ${NEVENTS} -o ${OUTDIR}/cpu_${version}_s${s_value}.root -v 1 -w 0 -s ${s_value} -i ${sample} | tee -a timing_temp.txt
     done


### PR DESCRIPTION
Small change in the compilation flags, so that the T5 DNN selection runs by default, while the `-N` flag is not inverted to disable it. The changes have been validated by means of printouts, and they seem to be working fine.

I also added another extension to the `.gitignore` file to simplify the `git status` output.

When merging, please select to also squash the commits with the description of the last one, so as not to include the confusing intermediate commit.