### PR TITLE
Update library paths

### DIFF
--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -21,7 +21,7 @@ CXXFLAGS_CUDA        = -g --compiler-options -Wall --compiler-options -Wshadow -
 ALPAKAINCLUDE        = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17
 ALPAKASERIAL         = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 ALPAKACUDA           = -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_ACC_GPU_CUDA_ONLY --expt-relaxed-constexpr
-ROOTCFLAGS           = -pthread -m64 -I/cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0_pre5/external/slc7_amd64_gcc900/bin/../../../../../../../slc7_amd64_gcc900/lcg/root/6.20.06-ghbfee3/include
+ROOTCFLAGS           = -pthread -m64 -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/cms/cmssw/CMSSW_13_0_0_pre4/external/el8_amd64_gcc11/bin/../../../../../../../el8_amd64_gcc11/lcg/root/6.26.07-3c8fea8a0ce2aca35570ac22afed05d0/include
 PRINTFLAG            = -DT4FromT3 #-DWarnings
 DUPLICATES           = -DDUP_pLS -DDUP_T5 -DDUP_pT5 -DDUP_pT3 -DCrossclean_T5 -DCrossclean_pT3 #-DFP16_Base
 MEMFLAG              =

--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,7 @@ export LATEST_CPU_BENCHMARK_EFF_MUONGUN="/data2/segmentlinking/muonGun_cpu_effic
 export LATEST_CPU_BENCHMARK_EFF_PU200="/data2/segmentlinking/pu200_cpu_efficiencies.root"
 
 # Alpaka, Boost, and CUDA dependencies
-export BOOST_ROOT="/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/boost/1.80.0-5305613b2f750cf1a05dcadf0d672647"
-export ALPAKA_ROOT="/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/alpaka/develop-20230621-9e2225ac6c979464a40749ef9d1e0331"
-export CUDA_HOME=/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/cuda/11.8.0-9f0af0f4206be7b705fe550319c49a11/
+export BOOST_ROOT="/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/boost/1.80.0-9315a40e01ff57e21052216b26778fdb"
+export ALPAKA_ROOT="/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/alpaka/develop-20230209-42df146cfd8ac463d0d6342b03c76732"
+export CUDA_HOME="/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/cuda/11.5.2-66a9473808e7d5863d5bbec0824e2c4a"
 #eof

--- a/setup_hpg.sh
+++ b/setup_hpg.sh
@@ -40,6 +40,6 @@ export LSTPERFORMANCEWEBDIR=/home/users/phchang/public_html/LSTPerformanceWeb
 export LATEST_CPU_BENCHMARK_EFF_MUONGUN=
 export LATEST_CPU_BENCHMARK_EFF_PU200=
 
-export BOOST_ROOT="/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/boost/1.80.0-5305613b2f750cf1a05dcadf0d672647"
-export ALPAKA_ROOT="/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/alpaka/develop-20230621-9e2225ac6c979464a40749ef9d1e0331"
+export BOOST_ROOT="/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/boost/1.80.0-9315a40e01ff57e21052216b26778fdb"
+export ALPAKA_ROOT="/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/alpaka/develop-20230209-42df146cfd8ac463d0d6342b03c76732"
 #eof


### PR DESCRIPTION
While trying to build a self-contained image for Github Actions to use, I noticed that the library paths don't match what the chosen version of SCRAM/CMSSW uses. Everything seems to be working fine, but it might be possible to cause unexpected crashes due to version differences.

I only updated the paths to match the current SCRAM/CMSSW version (el8_amd64_gcc11/13_0_0_pre4), but it would be nice to have a more permanent fix. For CUDA/Boost/ROOT we could do something like this.
```bash
export CUDA_ROOT="$(readlink -f /cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/$CMSSW_VERSION/external/$SCRAM_ARCH/bin/nvcc | rev | cut -d'/' -f 1,2 --complement | rev)"
```
However, this doesn't work with Alpaka. In general, the selected versions are in xml files in `/cvmfs/cms.cern.ch/$SCRAM_ARCH/cms/cmssw/$CMSSW_VERSION/config/toolbox/$SCRAM_ARCH/tools/selected/`, but I don't know of an easy way to extract them.