### PR TITLE
adapting ModuleConnectionMap to event setup

### DIFF
--- a/SDL/ModuleConnectionMap.cc
+++ b/SDL/ModuleConnectionMap.cc
@@ -121,11 +121,13 @@ void SDL::ModuleConnectionMap::print()
     }
 }
 
-const std::vector<unsigned int>& SDL::ModuleConnectionMap::getConnectedModuleDetIds(unsigned int detid)
+const std::vector<unsigned int>& SDL::ModuleConnectionMap::getConnectedModuleDetIds(unsigned int detid) const
 {
-    return moduleConnections_[detid];
+  static const std::vector<unsigned int> dummy;
+  auto const mList = moduleConnections_.find(detid);
+  return mList != moduleConnections_.end() ? mList->second : dummy;
 }
-/*const*/ int SDL::ModuleConnectionMap::size()
+int SDL::ModuleConnectionMap::size() const
 {
     return moduleConnections_.size();
 }

--- a/SDL/ModuleConnectionMap.h
+++ b/SDL/ModuleConnectionMap.h
@@ -25,8 +25,8 @@ namespace SDL
             void add(std::string);
             void print();
 
-            const std::vector<unsigned int>& getConnectedModuleDetIds(unsigned int detid);
-            /*const*/ int size();
+            const std::vector<unsigned int>& getConnectedModuleDetIds(unsigned int detid) const;
+            int size() const;
 
     };
 


### PR DESCRIPTION
I'm opening a longer running branch to move away from using singletons.

The first commit is relatively trivial to make the access const. We could as well just merge it as is; there is no change in the interface or behavior.