### PR TITLE
Add ability to select backend at run time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ EXES=bin/sdl
 
 ROOUTIL=code/rooutil/
 
-SOURCES=$(wildcard code/core/*.cc)  #$(wildcard SDL/*.cc)
-OBJECTS=$(SOURCES:.cc=.o) $(wildcard ${TRACKLOOPERDIR}/SDL/libsdl.so)
+SOURCES=$(wildcard code/core/*.cc)
+OBJECTS=$(SOURCES:.cc=.o)
 HEADERS=$(SOURCES:.cc=.h)
 
 CXX         = g++
@@ -14,7 +14,7 @@ CXXFLAGS    = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual -lineinfo  -fopen
 LDFLAGS     = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual
 SOFLAGS     = -g -shared
 CXXFLAGS    = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual
-LDFLAGS     = -g -O2
+LDFLAGS     = -g -O2 -lsdl -L${TRACKLOOPERDIR}/SDL/gpu -L${TRACKLOOPERDIR}/SDL/cpu
 ROOTLIBS    = $(shell root-config --libs)
 ROOTCFLAGS  = $(foreach option, $(shell root-config --cflags), $(option))
 ALPAKAINCLUDE = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17 -DALPAKA_DEBUG=0

--- a/README.md
+++ b/README.md
@@ -186,8 +186,7 @@ Run the command and modify the output configuration file with the following:
    - Add the following lines below the part where the import of the standard configurations happens:
      ```python
      process.load('Configuration.StandardSequences.Accelerators_cff')
-     process.AlpakaServiceCudaAsync = cms.Service('AlpakaServiceCudaAsync')
-     process.AlpakaServiceSerialSync = cms.Service('AlpakaServiceSerialSync')
+     process.load("HeterogeneousCore.AlpakaCore.ProcessAcceleratorAlpaka_cfi")
      ```
    - Find the line that starts with process.mix.input.fileNames and change it to (supposing that the PU files are available locally, as is the case at the UCSD machines):
      ```python

--- a/README.md
+++ b/README.md
@@ -125,18 +125,31 @@ git remote add SegLink git@github.com:SegmentLinking/cmssw.git
 git fetch SegLink CMSSW_13_0_0_pre4_LST_X_alpaka
 git cms-addpkg RecoTracker Configuration
 git checkout CMSSW_13_0_0_pre4_LST_X_alpaka
-cat <<EOF >lst.xml
-<tool name="lst" version="1.0">
+#To include both the CPU library and GPU library into CMSSW, create 2 xml files. Before writing the following xml file, check that libsdl_cpu.so and libsdl_gpu.so can be found under the ../../../TrackLooper/SDL/ folder.
+cat <<EOF >lst_cpu.xml
+<tool name="lst_cpu" version="1.0">
   <client>
     <environment name="LSTBASE" default="$PWD/../../../TrackLooper"/>
     <environment name="LIBDIR" default="\$LSTBASE/SDL"/>
     <environment name="INCLUDE" default="\$LSTBASE"/>
   </client>
   <runtime name="LST_BASE" value="\$LSTBASE"/>
-  <lib name="sdl"/>
+  <lib name="sdl_cpu"/>
 </tool>
 EOF
-scram setup lst.xml
+cat <<EOF >lst_gpu.xml
+<tool name="lst_gpu" version="1.0">
+  <client>
+    <environment name="LSTBASE" default="$PWD/../../../TrackLooper"/>
+    <environment name="LIBDIR" default="\$LSTBASE/SDL"/>
+    <environment name="INCLUDE" default="\$LSTBASE"/>
+  </client>
+  <runtime name="LST_BASE" value="\$LSTBASE"/>
+  <lib name="sdl_gpu"/>
+</tool>
+EOF
+scram setup lst_cpu.xml
+scram setup lst_gpu.xml
 cmsenv
 git cms-checkdeps -a -A
 scram b -j 12
@@ -166,6 +179,10 @@ This is based on the step3 command of the 21034.1 workflow with the following ch
    - Add at the end of the command: `--procModifiers gpu,trackingLST,trackingIters01 --no_exec`
 
 Run the command and modify the output configuration file with the following:
+   - If want to run a cpu version, delete the line below, and remove the ```gpu``` in the line ```process = cms.Process('RECO',Phase2C17I13M9,gpu,trackingLST,trackingIters01)```
+     ```
+     from Configuration.ProcessModifiers.gpu_cff import gpu
+     ```
    - Add the following lines below the part where the import of the standard configurations happens:
      ```python
      process.load('Configuration.StandardSequences.Accelerators_cff')

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -4,20 +4,31 @@
 #
 
 CCSOURCES=$(filter-out LST.cc, $(wildcard *.cc))
-CCOBJECTS=$(CCSOURCES:.cc=_$(BACKEND).o)
+CCOBJECTS_CPU=$(CCSOURCES:.cc=_cpu.o)
+CCOBJECTS_GPU=$(CCSOURCES:.cc=_gpu.o)
 
 LSTSOURCES=LST.cc
-LSTOBJECTS=$(LSTSOURCES:.cc=_cpu.o)
+LSTOBJECTS_CPU=$(LSTSOURCES:.cc=_cpu.o)
+LSTOBJECTS_GPU=$(LSTSOURCES:.cc=_gpu.o)
 
-LIB=libsdl.so
+LIB_GPU=libsdl_gpu.so
+LIB_CPU=libsdl_cpu.so
+
+ifeq ($(BACKEND), cpu)
+  LIB_GPU=
+else ifeq ($(BACKEND), gpu)
+  LIB_CPU=
+endif
+
+LIBS=$(LIB_GPU) $(LIB_CPU)
 
 #
 # flags to keep track of
 #
 
 CXX                  = g++
-CXXFLAGS             = -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
-CXXFLAGS_CUDA        = -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 --use_fast_math --default-stream per-thread -I..
+CXXFLAGS_CPU             = -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
+CXXFLAGS_GPU        = -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 --use_fast_math --default-stream per-thread -I..
 ALPAKAINCLUDE        = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17
 ALPAKASERIAL         = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 ALPAKACUDA           = -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_ACC_GPU_CUDA_ONLY --expt-relaxed-constexpr
@@ -30,46 +41,54 @@ MEMFLAG_FLAGS        =
 CACHEFLAG_FLAGS      = -DCACHE_ALLOC
 T5CUTFLAGS           = $(T5DNNFLAG) $(T5RZCHI2FLAG) $(T5RPHICHI2FLAG)
 
-ifeq ($(BACKEND), cpu)
-  LD                 = g++
-  SOFLAGS            = -g -shared -fPIC
-  ALPAKABACKEND      = $(ALPAKASERIAL)
-  COMPILE_CMD        = $(LD) -c -O2
-  ACTUAL_CXXFLAGS    = $(CXXFLAGS)
-else
-  LD                 = nvcc
-  SOFLAGS            = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70 -code=sm_72
-  ALPAKABACKEND      = $(ALPAKACUDA)
-  COMPILE_CMD        = $(LD) -x cu
-  ACTUAL_CXXFLAGS    = $(CXXFLAGS_CUDA)
-endif
+LD_CPU               = g++
+SOFLAGS_CPU          = -g -shared -fPIC
+ALPAKABACKEND_CPU    = $(ALPAKASERIAL)
+COMPILE_CMD_CPU      = $(LD_CPU) -c -O2
+
+LD_GPU               = nvcc
+SOFLAGS_GPU          = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70 -code=sm_72
+ALPAKABACKEND_GPU    = $(ALPAKACUDA)
+COMPILE_CMD_GPU      = $(LD_GPU) -x cu
 
 CUTVALUEFLAG =
 CUTVALUEFLAG_FLAGS = -DCUT_VALUE_DEBUG
 
-%_$(BACKEND).o : %.cc
-	$(COMPILE_CMD) $(ACTUAL_CXXFLAGS) $(LDFLAGS) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUTVALUEFLAG) $(T5CUTFLAGS) $(NOPLSDUPCLEANFLAG) $(DUPLICATES) $(ALPAKAINCLUDE) $(ALPAKABACKEND) $< -o $@
+LST_%pu.o : LST.cc
+	 $(CXX) -c -O2 $(CXXFLAGS_CPU) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(DUPLICATES) $(ROOTCFLAGS) $(ALPAKAINCLUDE) $(ALPAKASERIAL) $< -o $@
 
-LST_cpu.o : LST.cc
-	$(CXX) -c -O2 $(CXXFLAGS) $(LDFLAGS) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(DUPLICATES) $(ROOTCFLAGS) $(ALPAKAINCLUDE) $(ALPAKASERIAL) $< -o $@
+%_cpu.o : %.cc
+	$(COMPILE_CMD_CPU) $(CXXFLAGS_CPU) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUTVALUEFLAG) $(T5CUTFLAGS) $(NOPLSDUPCLEANFLAG) $(DUPLICATES) $(ALPAKAINCLUDE) $(ALPAKABACKEND_CPU) $< -o $@
 
-$(LIB):$(CCOBJECTS) $(LSTOBJECTS)
-	$(LD) $(SOFLAGS) $^ -o $@
+%_gpu.o : %.cc
+	$(COMPILE_CMD_GPU) $(CXXFLAGS_GPU) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUTVALUEFLAG) $(T5CUTFLAGS) $(NOPLSDUPCLEANFLAG) $(DUPLICATES) $(ALPAKAINCLUDE) $(ALPAKABACKEND_GPU) $< -o $@
+
+$(LIB_GPU): $(CCOBJECTS_GPU) $(LSTOBJECTS_GPU)
+	$(LD_GPU) $(SOFLAGS_GPU) $^ -o $@
+	mkdir -p gpu
+	ln -sf ../$@ gpu/$(@:_gpu.so=.so)
+
+$(LIB_CPU): $(CCOBJECTS_CPU) $(LSTOBJECTS_CPU)
+	$(LD_CPU) $(SOFLAGS_CPU) $^ -o $@
+	mkdir -p cpu
+	ln -sf ../$@ cpu/$(@:_cpu.so=.so)
 
 explicit: MEMFLAG += $(MEMFLAG_FLAGS)
-explicit: $(LIB)
+explicit: $(LIBS)
 
 explicit_cache: MEMFLAG += $(MEMFLAG_FLAGS)
 explicit_cache: CACHEFLAG += $(CACHEFLAG_FLAGS)
-explicit_cache: $(LIB)
+explicit_cache: $(LIBS)
 
 explicit_cache_cutvalue: CUTVALUEFLAG = $(CUTVALUEFLAG_FLAGS)
 explicit_cache_cutvalue: MEMFLAG += $(MEMFLAG_FLAGS)
 explicit_cache_cutvalue: CACHEFLAG += $(CACHEFLAG_FLAGS)
-explicit_cache_cutvalue: $(LIB)
+explicit_cache_cutvalue: $(LIBS)
 
 clean:
-	rm -f *.opp \
-	rm -f *.o \
-	rm -f *.d \
-	rm -f *.so \
+	rm -f *.opp
+	rm -f *.o
+	rm -f *.d
+	rm -f *.so
+	rm -f cpu/*.so
+	rm -f gpu/*.so

--- a/bin/sdl_make_tracklooper
+++ b/bin/sdl_make_tracklooper
@@ -26,14 +26,15 @@ usage()
   echo "  -p    primitive object ntuple   (With extra variables related to primitive objects)"
   echo "  -3    do T3T3 extensions        (-e turned on if not specified)"
   echo "  -N    neural networks           (Toggle LST neural networks)"
-  echo "  -C    cpu backend               (Run code on CPU, serially)"
+  echo "  -G    gpu backend               (Compile only for GPU, takes priority over -C)"
+  echo "  -C    cpu backend               (Compile only for CPU)"
   echo "  -2    no pLS duplicate cleaning (Don't perform the pLS duplicate cleaning step)"
   echo
   exit
 }
 
 # Parsing command-line opts
-while getopts ":cxgsmdp3NC2eh" OPTION; do
+while getopts ":cxgsmdp3NGC2eh" OPTION; do
   case $OPTION in
     c) MAKECACHE=true;;
     s) SHOWLOG=true;;
@@ -42,7 +43,8 @@ while getopts ":cxgsmdp3NC2eh" OPTION; do
     p) PRIMITIVE=true;;
     3) T3T3EXTENSION=true;;
     N) DONTUSENN=true;;
-    C) CPUBACKEND=true;;
+    G) ONLYGPUBACKEND=true;;
+    C) ONLYCPUBACKEND=true;;
     2) NOPLSDUPCLEAN=true;;
     h) usage;;
     :) usage;;
@@ -57,8 +59,12 @@ if [ -z ${MAKECUTVALUES} ]; then MAKECUTVALUES=false; fi
 if [ -z ${PRIMITIVE} ]; then PRIMITIVE=false; fi
 if [ -z ${T3T3EXTENSION} ]; then T3T3EXTENSION=false; fi
 if [ -z ${DONTUSENN} ]; then DONTUSENN=false; fi
-if [ -z ${CPUBACKEND} ]; then CPUBACKEND=false; fi
+if [ -z ${ONLYGPUBACKEND} ]; then ONLYGPUBACKEND=false; fi
+if [ -z ${ONLYCPUBACKEND} ]; then ONLYCPUBACKEND=false; fi
 if [ -z ${NOPLSDUPCLEAN} ]; then NOPLSDUPCLEAN=false; fi
+
+# If using both -G and -C, -G takes priority
+if [ "${ONLYGPUBACKEND}" == true ]; then ONLYCPUBACKEND=false; fi
 
 # Shift away the parsed options
 shift $(($OPTIND - 1))
@@ -83,7 +89,8 @@ echo "  MAKECUTVALUES     : ${MAKECUTVALUES}"                 | tee -a ${LOG}
 echo "  PRIMITIVE         : ${PRIMITIVE}"                     | tee -a ${LOG}
 echo "  T3T3EXTENSION     : ${T3T3EXTENSION}"                 | tee -a ${LOG}
 echo "  DONTUSENN         : ${DONTUSENN}"                     | tee -a ${LOG}
-echo "  CPUBACKEND        : ${CPUBACKEND}"                    | tee -a ${LOG}
+echo "  ONLYGPUBACKEND    : ${ONLYGPUBACKEND}"                | tee -a ${LOG}
+echo "  ONLYCPUBACKEND    : ${ONLYCPUBACKEND}"                | tee -a ${LOG}
 echo "  NOPLSDUPCLEAN     : ${NOPLSDUPCLEAN}"                 | tee -a ${LOG}
 echo ""                                                       | tee -a ${LOG}
 echo "  (cf. Run > sh $(basename $0) -h to see all options)"  | tee -a ${LOG}
@@ -132,7 +139,9 @@ else
 fi
 
 BACKENDOPT=
-if $CPUBACKEND; then
+if [ "$ONLYGPUBACKEND" == true ]; then
+    BACKENDOPT="BACKEND=gpu"
+elif [ "$ONLYCPUBACKEND" == true ]; then
     BACKENDOPT="BACKEND=cpu"
 fi
 
@@ -158,10 +167,15 @@ else
     (cd SDL && make clean && make ${T3T3EXTENSIONOPT} ${T5CUTOPT} ${BACKENDOPT} ${NOPLSDUPCLEANOPT} -j 32 ${MAKETARGET} && cd -) >> ${LOG} 2>&1
 fi
 
-if [ ! -f SDL/libsdl.so ]; then
-    echo "ERROR: SDL/libsdl.so failed to compile!" | tee -a ${LOG}
-    echo "See ${LOG} file for more detail..." | tee -a ${LOG}
-    exit 1
+if [[ "$BACKENDOPT" != *"gpu"* ]] && [ ! -f SDL/libsdl_cpu.so ]; then
+  echo "ERROR: libsdl_cpu.so failed to compile!" | tee -a ${LOG}
+  echo "See ${LOG} file for more detail..." | tee -a ${LOG}
+  exit 1
+elif [[ "$BACKENDOPT" != *"cpu"* ]] && [ ! -f SDL/libsdl_gpu.so ]; then
+  echo "ERROR: libsdl_gpu.so failed to compile!" | tee -a ${LOG}
+  echo "See ${LOG} file for more detail..." | tee -a ${LOG}
+  echo $BACKENDOPT
+  exit 1
 fi
 
 echo "" >> ${LOG}

--- a/bin/sdl_run
+++ b/bin/sdl_run
@@ -24,6 +24,7 @@ usage()
   echo "  -n    number of events        (Number of events to run over)"
   echo "  -t    tag for this run        (Tag for this run)"
   echo "  -d    delete previous output  (Delete the previous outputs and re-run)"
+  echo "  -b    backend                 (Select between GPU and CPU backend)"
   echo
   exit
 }
@@ -31,12 +32,13 @@ usage()
 DELETE=false
 
 # Parsing command-line opts
-while getopts ":f:s:n:t:dh" OPTION; do
+while getopts ":f:s:n:t:b:dh" OPTION; do
   case $OPTION in
     f) FLAGS=${OPTARG};;
     s) SAMPLE=${OPTARG};;
     n) NEVENTS=${OPTARG};;
     t) TAG=${OPTARG};;
+    b) BACKEND=${OPTARG};;
     d) DELETE=true;;
     h) usage;;
     :) usage;;
@@ -44,13 +46,44 @@ while getopts ":f:s:n:t:dh" OPTION; do
 done
 
 # If the command line options are not provided set it to default value of false
-if [ -z ${FLAGS} ]; then usage; fi
+if [ -z ${FLAGS} ]; then PRECOMPILED=true; else PRECOMPILED=false; fi
 if [ -z ${SAMPLE} ]; then usage; fi
 if [ -z ${NEVENTS} ]; then NEVENTS=-1; fi
 if [ -z ${TAG} ]; then usage; fi
 
+# If it will not be compiled, then make sure that it was precompiled
+if ${PRECOMPILED}; then
+  if [ ! -f ${TRACKLOOPERDIR}/bin/sdl ] || ( [ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_gpu.so ] && [ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cpu.so ] ); then
+    echo "SDL library or binary has not been compiled. Please use -f flag."
+    usage
+  fi
+fi
+
+# If a backend is specified then make sure that corresponding library exists
+# and set the environment variable to preload it.
+if [ -z ${BACKEND} ]; then
+  PRELOAD=
+elif [ "${BACKEND}" == "gpu" ]; then
+  if ([ ${PRECOMPILED} != true ] && [[ "${FLAGS}" == *"C"* ]]) ||
+       ([ ${PRECOMPILED} == true ] && ([ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_gpu.so ] || [ ! -f ${TRACKLOOPERDIR}/SDL/gpu/libsdl.so ])); then
+    echo "Error: GPU library was not compiled."
+    exit 1
+  fi
+  PRELOAD="LD_PRELOAD=${TRACKLOOPERDIR}/SDL/gpu/libsdl.so"
+elif [ "${BACKEND}" == "cpu" ]; then
+  if ([ ${PRECOMPILED} != true ] && [[ "${FLAGS}" == *"G"* ]]) ||
+       ([ ${PRECOMPILED} == true ] && ([ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cpu.so ] || [ ! -f ${TRACKLOOPERDIR}/SDL/cpu/libsdl.so ])); then
+    echo "Error: CPU library was not compiled."
+    exit 1
+  fi
+  PRELOAD="LD_PRELOAD=${TRACKLOOPERDIR}/SDL/cpu/libsdl.so"
+else
+  echo "Error: backend options are gpu or cpu."
+  exit 1
+fi
+
 # Check that the FLAGS start with "-" character
-if [[ ${FLAGS:0:1} == "-" ]]; then
+if [[ ${PRECOMPILED} == true ]] || [[ ${FLAGS:0:1} == "-" ]]; then
     :
 else
     echo "ERROR:"
@@ -118,10 +151,12 @@ fi
 mkdir -p ${LSTOUTPUTDIR}
 
 rm -f ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log
-echo "Compiling code..."
-sdl_make_tracklooper ${FLAGS} >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log
+if [[ ${PRECOMPILED} != true ]]; then
+  echo "Compiling code..."
+  sdl_make_tracklooper ${FLAGS} >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log
+fi
 echo "Running LST code..."
-sdl -i ${SAMPLE} -o ${LSTOUTPUTDIR}/${JOBTAG}__LSTNtuple.root -n ${NEVENTS} >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log 2>&1 || { echo 'ERROR: sdl command failed!' ; exit 1; }
+eval "${PRELOAD} sdl -i ${SAMPLE} -o ${LSTOUTPUTDIR}/${JOBTAG}__LSTNtuple.root -n ${NEVENTS} >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log 2>&1" || { echo 'ERROR: sdl command failed!' ; exit 1; }
 echo "Creating performance histograms..."
 createPerfNumDenHists -i ${LSTOUTPUTDIR}/${JOBTAG}__LSTNtuple.root -o ${LSTOUTPUTDIR}/${JOBTAG}__LSTNumDen.root >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log 2>&1 || { echo 'ERROR: createPerfNumDenHists command failed!' ; exit 1; }
 echo "Creating plots..."

--- a/bin/sdl_run
+++ b/bin/sdl_run
@@ -62,21 +62,21 @@ fi
 # If a backend is specified then make sure that corresponding library exists
 # and set the environment variable to preload it.
 if [ -z ${BACKEND} ]; then
-  PRELOAD=
+  BACKEND="default"
 elif [ "${BACKEND}" == "gpu" ]; then
   if ([ ${PRECOMPILED} != true ] && [[ "${FLAGS}" == *"C"* ]]) ||
        ([ ${PRECOMPILED} == true ] && ([ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_gpu.so ] || [ ! -f ${TRACKLOOPERDIR}/SDL/gpu/libsdl.so ])); then
     echo "Error: GPU library was not compiled."
     exit 1
   fi
-  PRELOAD="LD_PRELOAD=${TRACKLOOPERDIR}/SDL/gpu/libsdl.so"
+  export LD_LIBRARY_PATH=${TRACKLOOPERDIR}/SDL/gpu/:$LD_LIBRARY_PATH
 elif [ "${BACKEND}" == "cpu" ]; then
   if ([ ${PRECOMPILED} != true ] && [[ "${FLAGS}" == *"G"* ]]) ||
        ([ ${PRECOMPILED} == true ] && ([ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cpu.so ] || [ ! -f ${TRACKLOOPERDIR}/SDL/cpu/libsdl.so ])); then
     echo "Error: CPU library was not compiled."
     exit 1
   fi
-  PRELOAD="LD_PRELOAD=${TRACKLOOPERDIR}/SDL/cpu/libsdl.so"
+  export LD_LIBRARY_PATH=${TRACKLOOPERDIR}/SDL/cpu/:$LD_LIBRARY_PATH
 else
   echo "Error: backend options are gpu or cpu."
   exit 1
@@ -100,6 +100,10 @@ shift $(($OPTIND - 1))
 # Move to the TRACKLOOPERDIR
 pushd ${TRACKLOOPERDIR}
 
+if [[ ${PRECOMPILED} == true ]]; then
+  FLAGS="No compilation"
+fi
+
 # Verbose
 echo "====================================================="
 echo "Line Segment Tracking Run Script                     "
@@ -110,6 +114,7 @@ echo "  SAMPLE            : ${SAMPLE}"
 echo "  NEVENTS           : ${NEVENTS}"
 echo "  TAG               : ${TAG}"
 echo "  DELETE            : ${DELETE}"
+echo "  BACKEND           : ${BACKEND}"
 echo ""
 echo "  (cf. Run > sh $(basename $0) -h to see all options)"
 echo ""
@@ -156,7 +161,7 @@ if [[ ${PRECOMPILED} != true ]]; then
   sdl_make_tracklooper ${FLAGS} >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log
 fi
 echo "Running LST code..."
-eval "${PRELOAD} sdl -i ${SAMPLE} -o ${LSTOUTPUTDIR}/${JOBTAG}__LSTNtuple.root -n ${NEVENTS} >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log 2>&1" || { echo 'ERROR: sdl command failed!' ; exit 1; }
+sdl -i ${SAMPLE} -o ${LSTOUTPUTDIR}/${JOBTAG}__LSTNtuple.root -n ${NEVENTS} >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log 2>&1 || { echo 'ERROR: sdl command failed!' ; exit 1; }
 echo "Creating performance histograms..."
 createPerfNumDenHists -i ${LSTOUTPUTDIR}/${JOBTAG}__LSTNtuple.root -o ${LSTOUTPUTDIR}/${JOBTAG}__LSTNumDen.root >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log 2>&1 || { echo 'ERROR: createPerfNumDenHists command failed!' ; exit 1; }
 echo "Creating plots..."

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ echo "Setup following ROOT. Make sure the appropriate setup file has been run. O
 which root
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-export LD_LIBRARY_PATH=$DIR:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DIR/SDL/gpu:$DIR/SDL/cpu:$DIR:$LD_LIBRARY_PATH
 export PATH=$DIR/bin:$PATH
 export PATH=$DIR/efficiency/bin:$PATH
 export PATH=$DIR/efficiency/python:$PATH

--- a/setup_hpg.sh
+++ b/setup_hpg.sh
@@ -23,7 +23,7 @@ echo "Setup following ROOT. Make sure the appropriate setup file has been run. O
 which root
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-export LD_LIBRARY_PATH=$DIR:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DIR/SDL/gpu:$DIR/SDL/cpu:$DIR:$LD_LIBRARY_PATH
 export PATH=$DIR/bin:$PATH
 export PATH=$DIR/efficiency/bin:$PATH
 export PATH=$DIR/efficiency/python:$PATH


### PR DESCRIPTION
Added the ability to select a backend during run time in a way that works both for the standalone version and for the CMSSW setup. This was done by compiling two separate libraries and selecting one at run time. Here are some points describing the reasoning for the changes.

- For CMSSW both libraries need to have different names. We went with `sdl_gpu` and `sdl_cpu`, i.e. the files are `libsdl_gpu.so` and `libsdl_cpu.so`. @YonsiG and @VourMa will add additional changes to this PR and to the CMSSW repo to make it work.
- For the standalone version it is much easier to pick between the two libraries when they have the same name. This is why symlinks are created in `SDL/gpu/libsdl.so` and `SDL/cpu/libsdl.so`. The library is now dynamically linked at runtime, allowing us to override the which one it links to.
- By default, `sdl_make_tracklooper` will now compile both libraries, but to save some time it is possible to exclusively compile the GPU or CPU library with the `-G` and `-C` flags. When both libraries are compiled, the GPU one is used as the default one since its path appears first in `LD_LIBRARY_PATH`.
- `sdl_run` now has the option of only running the code and not recompiling it, simply by omitting the `-f` flag. A backend can be specified with the `-b` flag, e.g. `-b cpu`. This is the easiest way to pick a backend, but when running the `sdl` binary directly ~~it can be done with `LD_PRELOAD=${TRACKLOOPERDIR}/SDL/cpu/libsdl.so sdl <args>`.~~ EDIT: To run the `sdl` binary directly you need to use `LD_LIBRARY_PATH=${TRACKLOOPERDIR}/SDL/cpu/:$LD_LIBRARY_PATH sdl <args>` (see comment below).

I'll do some more testing to make sure that everything looks good, and other people should also test it and review the changes closely because there were significant modifications to scripts and makefiles. I can  update the readme when it's all settled.