### PR TITLE
Fixed overflow when adding pLSs

### DIFF
--- a/SDL/Constants.h
+++ b/SDL/Constants.h
@@ -115,8 +115,8 @@ ALPAKA_FN_HOST ALPAKA_FN_INLINE WorkDiv createWorkDiv(
 
 const unsigned int MAX_BLOCKS = 80;
 const unsigned int MAX_CONNECTED_MODULES = 40;
-const unsigned int N_MAX_PIXEL_MD_PER_MODULES = 100000;
 const unsigned int N_MAX_PIXEL_SEGMENTS_PER_MODULE = 50000;
+const unsigned int N_MAX_PIXEL_MD_PER_MODULES = 2*N_MAX_PIXEL_SEGMENTS_PER_MODULE;
 
 const unsigned int N_MAX_PIXEL_TRIPLETS = 5000;
 const unsigned int N_MAX_PIXEL_QUINTUPLETS = 15000;

--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -260,8 +260,6 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
 void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> eta, std::vector<float> etaErr, std::vector<float> phi, std::vector<int> charge, std::vector<unsigned int> seedIdx, std::vector<int> superbin, std::vector<int8_t> pixelType, std::vector<char> isQuad)
 {
     int size = ptIn.size();
-    int mdSize = 2 * size;
-    uint16_t pixelModuleIndex = (*detIdToIndex)[1];
 
     if (size > N_MAX_PIXEL_SEGMENTS_PER_MODULE)
     {
@@ -273,6 +271,9 @@ void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,st
                );
         size = N_MAX_PIXEL_SEGMENTS_PER_MODULE;
     }
+
+    int mdSize = 2 * size;
+    uint16_t pixelModuleIndex = (*detIdToIndex)[1];
 
     if(mdsInGPU == nullptr)
     {

--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -259,9 +259,20 @@ void SDL::Event::addHitToEvent(std::vector<float> x, std::vector<float> y, std::
 
 void SDL::Event::addPixelSegmentToEvent(std::vector<unsigned int> hitIndices0,std::vector<unsigned int> hitIndices1,std::vector<unsigned int> hitIndices2,std::vector<unsigned int> hitIndices3, std::vector<float> dPhiChange, std::vector<float> ptIn, std::vector<float> ptErr, std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> eta, std::vector<float> etaErr, std::vector<float> phi, std::vector<int> charge, std::vector<unsigned int> seedIdx, std::vector<int> superbin, std::vector<int8_t> pixelType, std::vector<char> isQuad)
 {
-    const int size = ptIn.size();
+    int size = ptIn.size();
     int mdSize = 2 * size;
     uint16_t pixelModuleIndex = (*detIdToIndex)[1];
+
+    if (size > N_MAX_PIXEL_SEGMENTS_PER_MODULE)
+    {
+        printf(
+               "*********************************************************\n"
+               "* Warning: Pixel line segments will be truncated.       *\n"
+               "* You need to increase N_MAX_PIXEL_SEGMENTS_PER_MODULE. *\n"
+               "*********************************************************\n"
+               );
+        size = N_MAX_PIXEL_SEGMENTS_PER_MODULE;
+    }
 
     if(mdsInGPU == nullptr)
     {

--- a/SDL/Segment.h
+++ b/SDL/Segment.h
@@ -802,7 +802,7 @@ namespace SDL
             unsigned int* hitIndices3,
             float* dPhiChange,
             uint16_t pixelModuleIndex,
-            const int size) const
+            int size) const
         {
             using Dim = alpaka::Dim<TAcc>;
             using Idx = alpaka::Idx<TAcc>;

--- a/SDL/Segment.h
+++ b/SDL/Segment.h
@@ -802,7 +802,7 @@ namespace SDL
             unsigned int* hitIndices3,
             float* dPhiChange,
             uint16_t pixelModuleIndex,
-            int size) const
+            const int size) const
         {
             using Dim = alpaka::Dim<TAcc>;
             using Idx = alpaka::Idx<TAcc>;


### PR DESCRIPTION
This PR fixes an issue that @VourMa found out. When loading pLSs into memory there was no check to make sure that the full array fits in the allocated space. What is done now is that if there are too many pLSs then it prints a warning and truncates the array, similar to what was done for track candidates in #324. We also changed the definition of `N_MAX_PIXEL_MD_PER_MODULES` since it should always be twice `N_MAX_PIXEL_SEGMENTS_PER_MODULE`.

No significant part of the algorithm was modified so there are no changes in timing or performance.