### PR TITLE
Simplification of module maps loading

### DIFF
--- a/SDL/LST.cc
+++ b/SDL/LST.cc
@@ -32,17 +32,17 @@ void SDL::LST::loadMaps() {
     TString path;
 
     for(std::string &connect : connects) {
-      auto c = connect.data();
+      auto connectData = connect.data();
 
-      path = TString::Format("%s%s.txt", pLSMapDir.Data(), c).Data();
+      path = TString::Format("%s%s.txt", pLSMapDir.Data(), connectData).Data();
       SDL::moduleConnectionMap_pLStoLayer.emplace_back(
           ModuleConnectionMap(get_absolute_path_after_check_file_exists(path.Data()).Data()));
 
-      path = TString::Format("%s_pos%s.txt", pLSMapDir.Data(), c).Data();
+      path = TString::Format("%s_pos%s.txt", pLSMapDir.Data(), connectData).Data();
       SDL::moduleConnectionMap_pLStoLayer_pos.emplace_back(
           ModuleConnectionMap(get_absolute_path_after_check_file_exists(path.Data()).Data()));
 
-      path = TString::Format("%s_neg%s.txt", pLSMapDir.Data(), c).Data();
+      path = TString::Format("%s_neg%s.txt", pLSMapDir.Data(), connectData).Data();
       SDL::moduleConnectionMap_pLStoLayer_neg.emplace_back(
           ModuleConnectionMap(get_absolute_path_after_check_file_exists(path.Data()).Data()));
     }

--- a/SDL/LST.cc
+++ b/SDL/LST.cc
@@ -4,15 +4,21 @@ SDL::LST::LST() {
     TrackLooperDir_ = getenv("LST_BASE");
 }
 
-void SDL::LST::eventSetup() {
+void SDL::LST::eventSetup(const SDL::ModuleConnectionMap& mCM,
+                          const std::vector<SDL::ModuleConnectionMap>& mCM_pLS,
+                          const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_pos,
+                          const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_neg) {
     static std::once_flag mapsLoaded;
-    std::call_once(mapsLoaded, &SDL::LST::loadMaps, this);
+    std::call_once(mapsLoaded, &SDL::LST::loadMaps, this, mCM, mCM_pLS, mCM_pLS_pos, mCM_pLS_neg);
     TString path = get_absolute_path_after_check_file_exists(TString::Format("%s/data/centroid_CMSSW_12_2_0_pre2.txt",TrackLooperDir_.Data()).Data());
     static std::once_flag modulesInited;
     std::call_once(modulesInited, SDL::initModules, path);
 }
 
-void SDL::LST::loadMaps() {
+void SDL::LST::loadMaps(const SDL::ModuleConnectionMap& mCM,
+                        const std::vector<SDL::ModuleConnectionMap>& mCM_pLS,
+                        const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_pos,
+                        const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_neg) {
     // Module orientation information (DrDz or phi angles)
     TString endcap_geom = get_absolute_path_after_check_file_exists(TString::Format("%s/data/endcap_orientation_data_CMSSW_12_2_0_pre2.txt", TrackLooperDir_.Data()).Data());
     TString tilted_geom = get_absolute_path_after_check_file_exists(TString::Format("%s/data/tilted_orientation_data_CMSSW_12_2_0_pre2.txt", TrackLooperDir_.Data()).Data());
@@ -20,26 +26,10 @@ void SDL::LST::loadMaps() {
     SDL::tiltedGeometry.load(tilted_geom.Data());
 
     // Module connection map (for line segment building)
-    TString mappath = get_absolute_path_after_check_file_exists(TString::Format("%s/data/module_connection_tracing_CMSSW_12_2_0_pre2_merged.txt", TrackLooperDir_.Data()).Data());
-    SDL::moduleConnectionMap.load(mappath.Data());
-
-    TString pLSMapDir = TrackLooperDir_+"/data/pixelmaps_CMSSW_12_2_0_pre2_0p8minPt";
-
-    TString path;
-    path = TString::Format("%s/pLS_map_layer1_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet5.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_layer2_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet5.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_layer1_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet4.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_layer2_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet4.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-
-    path = TString::Format("%s/pLS_map_neg_layer1_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet5_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_neg_layer2_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet5_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_neg_layer1_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet4_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_neg_layer2_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet4_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-
-    path = TString::Format("%s/pLS_map_pos_layer1_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet5_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_pos_layer2_subdet5.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet5_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_pos_layer1_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer1Subdet4_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_pos_layer2_subdet4.txt", pLSMapDir.Data()).Data(); SDL::moduleConnectionMap_pLStoLayer2Subdet4_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+    SDL::moduleConnectionMap = mCM;
+    SDL::moduleConnectionMap_pLStoLayer = mCM_pLS;
+    SDL::moduleConnectionMap_pLStoLayer_pos = mCM_pLS_pos;
+    SDL::moduleConnectionMap_pLStoLayer_neg = mCM_pLS_neg;
 }
 
 TString SDL::LST::get_absolute_path_after_check_file_exists(const std::string name) {

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -20,10 +20,7 @@ namespace SDL {
     public:
         LST();
 
-        void eventSetup(const SDL::ModuleConnectionMap& mCM,
-                        const std::vector<SDL::ModuleConnectionMap>& mCM_pLS,
-                        const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_pos,
-                        const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_neg);
+        void eventSetup();
         template <typename TQueue>
         void run(TQueue& queue,
                  bool verbose,
@@ -179,10 +176,7 @@ namespace SDL {
         std::vector<int> seedIdx() { return out_tc_seedIdx_; }
         std::vector<short> trackCandidateType() { return out_tc_trackCandidateType_; }
     private:
-        void loadMaps(const SDL::ModuleConnectionMap& mCM,
-                      const std::vector<SDL::ModuleConnectionMap>& mCM_pLS,
-                      const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_pos,
-                      const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_neg);
+        void loadMaps();
         TString get_absolute_path_after_check_file_exists(const std::string name);
         void prepareInput(const std::vector<float> see_px,
                           const std::vector<float> see_py,

--- a/SDL/LST.h
+++ b/SDL/LST.h
@@ -20,7 +20,10 @@ namespace SDL {
     public:
         LST();
 
-        void eventSetup();
+        void eventSetup(const SDL::ModuleConnectionMap& mCM,
+                        const std::vector<SDL::ModuleConnectionMap>& mCM_pLS,
+                        const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_pos,
+                        const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_neg);
         template <typename TQueue>
         void run(TQueue& queue,
                  bool verbose,
@@ -176,7 +179,10 @@ namespace SDL {
         std::vector<int> seedIdx() { return out_tc_seedIdx_; }
         std::vector<short> trackCandidateType() { return out_tc_trackCandidateType_; }
     private:
-        void loadMaps();
+        void loadMaps(const SDL::ModuleConnectionMap& mCM,
+                      const std::vector<SDL::ModuleConnectionMap>& mCM_pLS,
+                      const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_pos,
+                      const std::vector<SDL::ModuleConnectionMap>& mCM_pLS_neg);
         TString get_absolute_path_after_check_file_exists(const std::string name);
         void prepareInput(const std::vector<float> see_px,
                           const std::vector<float> see_py,

--- a/SDL/Module.h
+++ b/SDL/Module.h
@@ -441,83 +441,32 @@ namespace SDL
         int totalSizes_neg = 0;
         for(unsigned int isuperbin = 0; isuperbin < size_superbins; isuperbin++)
         {
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer1Subdet5 = SDL::moduleConnectionMap_pLStoLayer1Subdet5.getConnectedModuleDetIds(isuperbin+size_superbins);// index adjustment to get high values
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer2Subdet5 = SDL::moduleConnectionMap_pLStoLayer2Subdet5.getConnectedModuleDetIds(isuperbin+size_superbins);// from the high pt bins
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer3Subdet5 = SDL::moduleConnectionMap_pLStoLayer3Subdet5.getConnectedModuleDetIds(isuperbin+size_superbins);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer1Subdet4 = SDL::moduleConnectionMap_pLStoLayer1Subdet4.getConnectedModuleDetIds(isuperbin+size_superbins);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer2Subdet4 = SDL::moduleConnectionMap_pLStoLayer2Subdet4.getConnectedModuleDetIds(isuperbin+size_superbins);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer3Subdet4 = SDL::moduleConnectionMap_pLStoLayer3Subdet4.getConnectedModuleDetIds(isuperbin+size_superbins);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer4Subdet4 = SDL::moduleConnectionMap_pLStoLayer4Subdet4.getConnectedModuleDetIds(isuperbin+size_superbins);
-            connectedModuleDetIds.insert(connectedModuleDetIds.end(),connectedModuleDetIds_pLStoLayer1Subdet5.begin(),connectedModuleDetIds_pLStoLayer1Subdet5.end());
-            connectedModuleDetIds.insert(connectedModuleDetIds.end(),connectedModuleDetIds_pLStoLayer2Subdet5.begin(),connectedModuleDetIds_pLStoLayer2Subdet5.end());
-            connectedModuleDetIds.insert(connectedModuleDetIds.end(),connectedModuleDetIds_pLStoLayer3Subdet5.begin(),connectedModuleDetIds_pLStoLayer3Subdet5.end());
-            connectedModuleDetIds.insert(connectedModuleDetIds.end(),connectedModuleDetIds_pLStoLayer1Subdet4.begin(),connectedModuleDetIds_pLStoLayer1Subdet4.end());
-            connectedModuleDetIds.insert(connectedModuleDetIds.end(),connectedModuleDetIds_pLStoLayer2Subdet4.begin(),connectedModuleDetIds_pLStoLayer2Subdet4.end());
-            connectedModuleDetIds.insert(connectedModuleDetIds.end(),connectedModuleDetIds_pLStoLayer3Subdet4.begin(),connectedModuleDetIds_pLStoLayer3Subdet4.end());
-            connectedModuleDetIds.insert(connectedModuleDetIds.end(),connectedModuleDetIds_pLStoLayer4Subdet4.begin(),connectedModuleDetIds_pLStoLayer4Subdet4.end());
-
             int sizes = 0;
-            sizes += connectedModuleDetIds_pLStoLayer1Subdet5.size();
-            sizes += connectedModuleDetIds_pLStoLayer2Subdet5.size();
-            sizes += connectedModuleDetIds_pLStoLayer3Subdet5.size();
-            sizes += connectedModuleDetIds_pLStoLayer1Subdet4.size();
-            sizes += connectedModuleDetIds_pLStoLayer2Subdet4.size();
-            sizes += connectedModuleDetIds_pLStoLayer3Subdet4.size();
-            sizes += connectedModuleDetIds_pLStoLayer4Subdet4.size();
+            for ( auto const& mCM_pLS : moduleConnectionMap_pLStoLayer ) {
+                std::vector<unsigned int> connectedModuleDetIds_pLS = mCM_pLS.getConnectedModuleDetIds(isuperbin+size_superbins);
+                connectedModuleDetIds.insert(connectedModuleDetIds.end(),connectedModuleDetIds_pLS.begin(),connectedModuleDetIds_pLS.end());
+                sizes += connectedModuleDetIds_pLS.size();
+            }
             pixelMapping.connectedPixelsIndex[isuperbin] = totalSizes;
             pixelMapping.connectedPixelsSizes[isuperbin] = sizes;
             totalSizes += sizes;
 
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer1Subdet5_pos = SDL::moduleConnectionMap_pLStoLayer1Subdet5_pos.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer2Subdet5_pos = SDL::moduleConnectionMap_pLStoLayer2Subdet5_pos.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer3Subdet5_pos = SDL::moduleConnectionMap_pLStoLayer3Subdet5_pos.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer1Subdet4_pos = SDL::moduleConnectionMap_pLStoLayer1Subdet4_pos.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer2Subdet4_pos = SDL::moduleConnectionMap_pLStoLayer2Subdet4_pos.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer3Subdet4_pos = SDL::moduleConnectionMap_pLStoLayer3Subdet4_pos.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer4Subdet4_pos = SDL::moduleConnectionMap_pLStoLayer4Subdet4_pos.getConnectedModuleDetIds(isuperbin);
-            connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLStoLayer1Subdet5_pos.begin(),connectedModuleDetIds_pLStoLayer1Subdet5_pos.end());
-            connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLStoLayer2Subdet5_pos.begin(),connectedModuleDetIds_pLStoLayer2Subdet5_pos.end());
-            connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLStoLayer3Subdet5_pos.begin(),connectedModuleDetIds_pLStoLayer3Subdet5_pos.end());
-            connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLStoLayer1Subdet4_pos.begin(),connectedModuleDetIds_pLStoLayer1Subdet4_pos.end());
-            connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLStoLayer2Subdet4_pos.begin(),connectedModuleDetIds_pLStoLayer2Subdet4_pos.end());
-            connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLStoLayer3Subdet4_pos.begin(),connectedModuleDetIds_pLStoLayer3Subdet4_pos.end());
-            connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLStoLayer4Subdet4_pos.begin(),connectedModuleDetIds_pLStoLayer4Subdet4_pos.end());
-
             int sizes_pos = 0;
-            sizes_pos += connectedModuleDetIds_pLStoLayer1Subdet5_pos.size();
-            sizes_pos += connectedModuleDetIds_pLStoLayer2Subdet5_pos.size();
-            sizes_pos += connectedModuleDetIds_pLStoLayer3Subdet5_pos.size();
-            sizes_pos += connectedModuleDetIds_pLStoLayer1Subdet4_pos.size();
-            sizes_pos += connectedModuleDetIds_pLStoLayer2Subdet4_pos.size();
-            sizes_pos += connectedModuleDetIds_pLStoLayer3Subdet4_pos.size();
-            sizes_pos += connectedModuleDetIds_pLStoLayer4Subdet4_pos.size();
+            for ( auto const& mCM_pLS : moduleConnectionMap_pLStoLayer_pos ) {
+                std::vector<unsigned int> connectedModuleDetIds_pLS = mCM_pLS.getConnectedModuleDetIds(isuperbin);
+                connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLS.begin(),connectedModuleDetIds_pLS.end());
+                sizes_pos += connectedModuleDetIds_pLS.size();
+            }
             pixelMapping.connectedPixelsIndexPos[isuperbin] = totalSizes_pos;
             pixelMapping.connectedPixelsSizesPos[isuperbin] = sizes_pos;
             totalSizes_pos += sizes_pos;
 
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer1Subdet5_neg = SDL::moduleConnectionMap_pLStoLayer1Subdet5_neg.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer2Subdet5_neg = SDL::moduleConnectionMap_pLStoLayer2Subdet5_neg.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer3Subdet5_neg = SDL::moduleConnectionMap_pLStoLayer3Subdet5_neg.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer1Subdet4_neg = SDL::moduleConnectionMap_pLStoLayer1Subdet4_neg.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer2Subdet4_neg = SDL::moduleConnectionMap_pLStoLayer2Subdet4_neg.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer3Subdet4_neg = SDL::moduleConnectionMap_pLStoLayer3Subdet4_neg.getConnectedModuleDetIds(isuperbin);
-            std::vector<unsigned int> connectedModuleDetIds_pLStoLayer4Subdet4_neg = SDL::moduleConnectionMap_pLStoLayer4Subdet4_neg.getConnectedModuleDetIds(isuperbin);
-            connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLStoLayer1Subdet5_neg.begin(),connectedModuleDetIds_pLStoLayer1Subdet5_neg.end());
-            connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLStoLayer2Subdet5_neg.begin(),connectedModuleDetIds_pLStoLayer2Subdet5_neg.end());
-            connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLStoLayer3Subdet5_neg.begin(),connectedModuleDetIds_pLStoLayer3Subdet5_neg.end());
-            connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLStoLayer1Subdet4_neg.begin(),connectedModuleDetIds_pLStoLayer1Subdet4_neg.end());
-            connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLStoLayer2Subdet4_neg.begin(),connectedModuleDetIds_pLStoLayer2Subdet4_neg.end());
-            connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLStoLayer3Subdet4_neg.begin(),connectedModuleDetIds_pLStoLayer3Subdet4_neg.end());
-            connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLStoLayer4Subdet4_neg.begin(),connectedModuleDetIds_pLStoLayer4Subdet4_neg.end());
-
             int sizes_neg = 0;
-            sizes_neg += connectedModuleDetIds_pLStoLayer1Subdet5_neg.size();
-            sizes_neg += connectedModuleDetIds_pLStoLayer2Subdet5_neg.size();
-            sizes_neg += connectedModuleDetIds_pLStoLayer3Subdet5_neg.size();
-            sizes_neg += connectedModuleDetIds_pLStoLayer1Subdet4_neg.size();
-            sizes_neg += connectedModuleDetIds_pLStoLayer2Subdet4_neg.size();
-            sizes_neg += connectedModuleDetIds_pLStoLayer3Subdet4_neg.size();
-            sizes_neg += connectedModuleDetIds_pLStoLayer4Subdet4_neg.size();
+            for ( auto const& mCM_pLS : moduleConnectionMap_pLStoLayer_neg ) {
+                std::vector<unsigned int> connectedModuleDetIds_pLS = mCM_pLS.getConnectedModuleDetIds(isuperbin);
+                connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLS.begin(),connectedModuleDetIds_pLS.end());
+                sizes_neg += connectedModuleDetIds_pLS.size();
+            }
             pixelMapping.connectedPixelsIndexNeg[isuperbin] = totalSizes_neg;
             pixelMapping.connectedPixelsSizesNeg[isuperbin] = sizes_neg;
             totalSizes_neg += sizes_neg;

--- a/SDL/Module.h
+++ b/SDL/Module.h
@@ -453,9 +453,9 @@ namespace SDL
 
             int sizes_pos = 0;
             for ( auto const& mCM_pLS : moduleConnectionMap_pLStoLayer_pos ) {
-                std::vector<unsigned int> connectedModuleDetIds_pLS = mCM_pLS.getConnectedModuleDetIds(isuperbin);
-                connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLS.begin(),connectedModuleDetIds_pLS.end());
-                sizes_pos += connectedModuleDetIds_pLS.size();
+                std::vector<unsigned int> connectedModuleDetIds_pLS_pos = mCM_pLS.getConnectedModuleDetIds(isuperbin);
+                connectedModuleDetIds_pos.insert(connectedModuleDetIds_pos.end(),connectedModuleDetIds_pLS_pos.begin(),connectedModuleDetIds_pLS_pos.end());
+                sizes_pos += connectedModuleDetIds_pLS_pos.size();
             }
             pixelMapping.connectedPixelsIndexPos[isuperbin] = totalSizes_pos;
             pixelMapping.connectedPixelsSizesPos[isuperbin] = sizes_pos;
@@ -463,9 +463,9 @@ namespace SDL
 
             int sizes_neg = 0;
             for ( auto const& mCM_pLS : moduleConnectionMap_pLStoLayer_neg ) {
-                std::vector<unsigned int> connectedModuleDetIds_pLS = mCM_pLS.getConnectedModuleDetIds(isuperbin);
-                connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLS.begin(),connectedModuleDetIds_pLS.end());
-                sizes_neg += connectedModuleDetIds_pLS.size();
+                std::vector<unsigned int> connectedModuleDetIds_pLS_neg = mCM_pLS.getConnectedModuleDetIds(isuperbin);
+                connectedModuleDetIds_neg.insert(connectedModuleDetIds_neg.end(),connectedModuleDetIds_pLS_neg.begin(),connectedModuleDetIds_pLS_neg.end());
+                sizes_neg += connectedModuleDetIds_pLS_neg.size();
             }
             pixelMapping.connectedPixelsIndexNeg[isuperbin] = totalSizes_neg;
             pixelMapping.connectedPixelsSizesNeg[isuperbin] = sizes_neg;

--- a/SDL/ModuleConnectionMap.cc
+++ b/SDL/ModuleConnectionMap.cc
@@ -1,27 +1,9 @@
 #include "ModuleConnectionMap.h"
 
 SDL::ModuleConnectionMap SDL::moduleConnectionMap;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer1Subdet5;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer2Subdet5;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer3Subdet5;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer1Subdet4;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer2Subdet4;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer3Subdet4;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer4Subdet4;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer1Subdet5_pos;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer2Subdet5_pos;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer3Subdet5_pos;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer1Subdet4_pos;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer2Subdet4_pos;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer3Subdet4_pos;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer4Subdet4_pos;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer1Subdet5_neg;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer2Subdet5_neg;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer3Subdet5_neg;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer1Subdet4_neg;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer2Subdet4_neg;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer3Subdet4_neg;
-SDL::ModuleConnectionMap SDL::moduleConnectionMap_pLStoLayer4Subdet4_neg;
+std::vector<SDL::ModuleConnectionMap> SDL::moduleConnectionMap_pLStoLayer(7);
+std::vector<SDL::ModuleConnectionMap> SDL::moduleConnectionMap_pLStoLayer_pos(7);
+std::vector<SDL::ModuleConnectionMap> SDL::moduleConnectionMap_pLStoLayer_neg(7);
 
 SDL::ModuleConnectionMap::ModuleConnectionMap()
 {

--- a/SDL/ModuleConnectionMap.h
+++ b/SDL/ModuleConnectionMap.h
@@ -31,27 +31,9 @@ namespace SDL
     };
 
     extern ModuleConnectionMap moduleConnectionMap;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer1Subdet5;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer2Subdet5;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer3Subdet5;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer1Subdet4;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer2Subdet4;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer3Subdet4;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer4Subdet4;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer1Subdet5_pos;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer2Subdet5_pos;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer3Subdet5_pos;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer1Subdet4_pos;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer2Subdet4_pos;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer3Subdet4_pos;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer4Subdet4_pos;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer1Subdet5_neg;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer2Subdet5_neg;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer3Subdet5_neg;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer1Subdet4_neg;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer2Subdet4_neg;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer3Subdet4_neg;
-    extern ModuleConnectionMap moduleConnectionMap_pLStoLayer4Subdet4_neg;
+    extern std::vector<ModuleConnectionMap> moduleConnectionMap_pLStoLayer;
+    extern std::vector<ModuleConnectionMap> moduleConnectionMap_pLStoLayer_pos;
+    extern std::vector<ModuleConnectionMap> moduleConnectionMap_pLStoLayer_neg;
 }
 
 #endif

--- a/code/core/trkCore.cc
+++ b/code/core/trkCore.cc
@@ -24,33 +24,17 @@ void loadMaps()
     SDL::tiltedGeometry.load(tilted_geom.Data());
     SDL::moduleConnectionMap.load(mappath.Data());
 
-    TString path;
-    path = TString::Format("%s/pLS_map_layer1_subdet5.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer1Subdet5.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_layer2_subdet5.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer2Subdet5.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_layer1_subdet4.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer1Subdet4.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_layer2_subdet4.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer2Subdet4.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+    vector<string> pLSMapPath{ "layer1_subdet5", "layer2_subdet5", "layer1_subdet4", "layer2_subdet4" };
+    for (unsigned int i=0; i<pLSMapPath.size(); i++) {
+        TString path = TString::Format("%s/pLS_map_%s.txt", pLSMapDir.Data(), pLSMapPath[i].c_str()).Data();
+        SDL::moduleConnectionMap_pLStoLayer[i].load( get_absolute_path_after_check_file_exists( path.Data() ).Data() );
 
-    path = TString::Format("%s/pLS_map_neg_layer1_subdet5.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer1Subdet5_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_neg_layer2_subdet5.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer2Subdet5_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_neg_layer1_subdet4.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer1Subdet4_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_neg_layer2_subdet4.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer2Subdet4_neg.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+        path = TString::Format("%s/pLS_map_pos_%s.txt", pLSMapDir.Data(), pLSMapPath[i].c_str()).Data();
+        SDL::moduleConnectionMap_pLStoLayer_pos[i].load( get_absolute_path_after_check_file_exists( path.Data() ).Data() );
 
-    path = TString::Format("%s/pLS_map_pos_layer1_subdet5.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer1Subdet5_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_pos_layer2_subdet5.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer2Subdet5_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_pos_layer1_subdet4.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer1Subdet4_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
-    path = TString::Format("%s/pLS_map_pos_layer2_subdet4.txt", pLSMapDir.Data()).Data();
-    SDL::moduleConnectionMap_pLStoLayer2Subdet4_pos.load(get_absolute_path_after_check_file_exists(path.Data()).Data());
+        path = TString::Format("%s/pLS_map_neg_%s.txt", pLSMapDir.Data(), pLSMapPath[i].c_str()).Data();
+        SDL::moduleConnectionMap_pLStoLayer_neg[i].load( get_absolute_path_after_check_file_exists( path.Data() ).Data() );
+    }
 
     // WARNING: initModules must come after above load commands!! keep it at the last line here!
     SDL::initModules(centroid.Data());


### PR DESCRIPTION
This PR aims to simplify the module map loading in the standalone setup and modify the CMSSW setup accordingly ~so that ESProducts can be accepted~.

~Connected and to be merged with SegmentLinking/cmssw#14.~

~Draft for now, as some updates in the CMSSW side are missing, and validation is pending.~

Standalone timing provided here:
https://github.com/SegmentLinking/TrackLooper/pull/343#issuecomment-1770954549

CMSSW short test shows ok physics performance:
https://uaf-10.t2.ucsd.edu/~evourlio/SDL/PR343/CMSSW/