### PR TITLE
Cleaned up PR341 and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The above can be even simplified
 
     sdl_run -f -mc -s PU200 -n -1 -t myTag
 
+The `-f` flag can be ommitted when the code has already been compiled. If multiple backends were compiled then the `-b` flag can be used to specify a backend. For example
+
+    sdl_run -b cpu -s PU200 -n -1 -t myTag
+
 ## Command explanations
 
 Compile the code with option flags
@@ -44,6 +48,8 @@ Compile the code with option flags
     sdl_make_tracklooper -mc
     -m: make clean binaries
     -c: run with the cmssw caching allocator
+    -C: only compile CPU backend
+    -G: only compile GPU (CUDA) backend
     -h: show help screen with all options
 
 Run the code
@@ -57,7 +63,13 @@ Run the code
     -w: 0- no writeout; 1- minimum writeout; default: 1
     -o: provide an output root file name (e.g. LSTNtuple.root); default: debug.root
     -l: add lower level object (pT3, pT5, T5, etc.) branches to the output
+
+When running the `sdl` binary directly and multiple backends have been compiled, one can be chosen using the `LD_LIBRARY_PATH` environment variable. For example, one can explicitly use the CPU backend as follows.
+
+    LD_LIBRARY_PATH=$TRACKLOOPERDIR/SDL/cpu/:$LD_LIBRARY_PATH sdl <args>
     
+However, it is important to keep in mind that if that particular backend is was not compiled then it will find another backed without any notice.
+
 Plotting numerators and denominators of performance plots
 
     createPerfNumDenHists -i <input> -o <output> [-g <pdgids> -n <nevents>]

--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -1939,3 +1939,15 @@ SDL::modulesBuffer<alpaka::DevCpu>* SDL::Event::getModules()
     }
     return modulesInCPU;
 }
+
+unsigned int SDL::getBackend() {
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    return 0;
+#elif ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+    return 1;
+#elif ALPAKA_ACC_GPU_CUDA_ENABLED
+    return 2;
+#elif ALPAKA_ACC_GPU_HIP_ENABLED
+    return 3;
+#endif
+}

--- a/SDL/Event.h
+++ b/SDL/Event.h
@@ -166,5 +166,6 @@ namespace SDL
     void freeModules();
     void initModulesHost(); //read from file and init
     extern std::shared_ptr<SDL::pixelMap> pixelMapping;
+    unsigned int getBackend();
 }
 #endif

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -5,83 +5,81 @@
 
 CCSOURCES=$(filter-out LST.cc, $(wildcard *.cc))
 CCOBJECTS_CPU=$(CCSOURCES:.cc=_cpu.o)
-CCOBJECTS_GPU=$(CCSOURCES:.cc=_gpu.o)
+CCOBJECTS_CUDA=$(CCSOURCES:.cc=_cuda.o)
 
 LSTSOURCES=LST.cc
 LSTOBJECTS_CPU=$(LSTSOURCES:.cc=_cpu.o)
-LSTOBJECTS_GPU=$(LSTSOURCES:.cc=_gpu.o)
+LSTOBJECTS_CUDA=$(LSTSOURCES:.cc=_cuda.o)
 
-LIB_GPU=libsdl_gpu.so
+LIB_CUDA=libsdl_cuda.so
 LIB_CPU=libsdl_cpu.so
 
 ifeq ($(BACKEND), cpu)
-  LIB_GPU=
-else ifeq ($(BACKEND), gpu)
+  LIB_CUDA=
+else ifeq ($(BACKEND), cuda)
   LIB_CPU=
 endif
 
-LIBS=$(LIB_GPU) $(LIB_CPU)
+LIBS=$(LIB_CUDA) $(LIB_CPU)
 
 #
 # flags to keep track of
 #
 
 CXX                  = g++
-CXXFLAGS_CPU             = -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
-CXXFLAGS_GPU        = -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 --use_fast_math --default-stream per-thread -I..
+CXXFLAGS_CPU         = -O2 -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
+CXXFLAGS_CUDA        = -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 --use_fast_math --default-stream per-thread -I..
 ALPAKAINCLUDE        = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17
 ALPAKASERIAL         = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 ALPAKACUDA           = -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_ACC_GPU_CUDA_ONLY --expt-relaxed-constexpr
 ROOTCFLAGS           = -pthread -m64 -I/cvmfs/cms.cern.ch/slc7_amd64_gcc900/cms/cmssw/CMSSW_11_2_0_pre5/external/slc7_amd64_gcc900/bin/../../../../../../../slc7_amd64_gcc900/lcg/root/6.20.06-ghbfee3/include
 PRINTFLAG            = -DT4FromT3 #-DWarnings
 DUPLICATES           = -DDUP_pLS -DDUP_T5 -DDUP_pT5 -DDUP_pT3 -DCrossclean_T5 -DCrossclean_pT3 #-DFP16_Base
-MEMFLAG              =
 CACHEFLAG            =
-MEMFLAG_FLAGS        =
 CACHEFLAG_FLAGS      = -DCACHE_ALLOC
 T5CUTFLAGS           = $(T5DNNFLAG) $(T5RZCHI2FLAG) $(T5RPHICHI2FLAG)
 
 LD_CPU               = g++
 SOFLAGS_CPU          = -g -shared -fPIC
 ALPAKABACKEND_CPU    = $(ALPAKASERIAL)
-COMPILE_CMD_CPU      = $(LD_CPU) -c -O2
+COMPILE_CMD_CPU      = $(LD_CPU) -c
 
-LD_GPU               = nvcc
-SOFLAGS_GPU          = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70 -code=sm_72
-ALPAKABACKEND_GPU    = $(ALPAKACUDA)
-COMPILE_CMD_GPU      = $(LD_GPU) -x cu
+LD_CUDA              = nvcc
+SOFLAGS_CUDA         = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70 -code=sm_72
+ALPAKABACKEND_CUDA   = $(ALPAKACUDA)
+COMPILE_CMD_CUDA     = $(LD_CUDA) -x cu
 
 CUTVALUEFLAG =
 CUTVALUEFLAG_FLAGS = -DCUT_VALUE_DEBUG
 
-LST_%pu.o : LST.cc
-	 $(CXX) -c -O2 $(CXXFLAGS_CPU) $(ROOTLIBS) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(DUPLICATES) $(ROOTCFLAGS) $(ALPAKAINCLUDE) $(ALPAKASERIAL) $< -o $@
+LST_cpu.o: LST.cc
+	 $(CXX) -c $(CXXFLAGS_CPU) $(ROOTLIBS) $(PRINTFLAG) $(CACHEFLAG) $(DUPLICATES) $(ROOTCFLAGS) $(ALPAKAINCLUDE) $(ALPAKASERIAL) $< -o $@
 
-%_cpu.o : %.cc
-	$(COMPILE_CMD_CPU) $(CXXFLAGS_CPU) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUTVALUEFLAG) $(T5CUTFLAGS) $(NOPLSDUPCLEANFLAG) $(DUPLICATES) $(ALPAKAINCLUDE) $(ALPAKABACKEND_CPU) $< -o $@
+LST_cuda.o: LST.cc
+	 $(CXX) -c $(CXXFLAGS_CPU) $(ROOTLIBS) $(PRINTFLAG) $(CACHEFLAG) $(DUPLICATES) $(ROOTCFLAGS) $(ALPAKAINCLUDE) $(ALPAKASERIAL) $< -o $@
 
-%_gpu.o : %.cc
-	$(COMPILE_CMD_GPU) $(CXXFLAGS_GPU) $(MEMFLAG) $(PRINTFLAG) $(CACHEFLAG) $(CUTVALUEFLAG) $(T5CUTFLAGS) $(NOPLSDUPCLEANFLAG) $(DUPLICATES) $(ALPAKAINCLUDE) $(ALPAKABACKEND_GPU) $< -o $@
+%_cpu.o: %.cc
+	$(COMPILE_CMD_CPU) $(CXXFLAGS_CPU) $(PRINTFLAG) $(CACHEFLAG) $(CUTVALUEFLAG) $(T5CUTFLAGS) $(NOPLSDUPCLEANFLAG) $(DUPLICATES) $(ALPAKAINCLUDE) $(ALPAKABACKEND_CPU) $< -o $@
 
-$(LIB_GPU): $(CCOBJECTS_GPU) $(LSTOBJECTS_GPU)
-	$(LD_GPU) $(SOFLAGS_GPU) $^ -o $@
-	mkdir -p gpu
-	ln -sf ../$@ gpu/$(@:_gpu.so=.so)
+%_cuda.o: %.cc
+	$(COMPILE_CMD_CUDA) $(CXXFLAGS_CUDA) $(PRINTFLAG) $(CACHEFLAG) $(CUTVALUEFLAG) $(T5CUTFLAGS) $(NOPLSDUPCLEANFLAG) $(DUPLICATES) $(ALPAKAINCLUDE) $(ALPAKABACKEND_CUDA) $< -o $@
+
+$(LIB_CUDA): $(CCOBJECTS_CUDA) $(LSTOBJECTS_CUDA)
+	$(LD_CUDA) $(SOFLAGS_CUDA) $^ -o $@
+	mkdir -p cuda
+	ln -sf ../$@ cuda/$(@:_cuda.so=.so)
 
 $(LIB_CPU): $(CCOBJECTS_CPU) $(LSTOBJECTS_CPU)
 	$(LD_CPU) $(SOFLAGS_CPU) $^ -o $@
 	mkdir -p cpu
 	ln -sf ../$@ cpu/$(@:_cpu.so=.so)
 
-explicit: MEMFLAG += $(MEMFLAG_FLAGS)
 explicit: $(LIBS)
 
-explicit_cache: MEMFLAG += $(MEMFLAG_FLAGS)
 explicit_cache: CACHEFLAG += $(CACHEFLAG_FLAGS)
 explicit_cache: $(LIBS)
 
 explicit_cache_cutvalue: CUTVALUEFLAG = $(CUTVALUEFLAG_FLAGS)
-explicit_cache_cutvalue: MEMFLAG += $(MEMFLAG_FLAGS)
 explicit_cache_cutvalue: CACHEFLAG += $(CACHEFLAG_FLAGS)
 explicit_cache_cutvalue: $(LIBS)
 
@@ -90,5 +88,5 @@ clean:
 	rm -f *.o
 	rm -f *.d
 	rm -f *.so
-	rm -f cpu/*.so
-	rm -f gpu/*.so
+	rm -rf cpu/
+	rm -rf cuda/

--- a/bin/sdl.cc
+++ b/bin/sdl.cc
@@ -221,26 +221,11 @@ int main(int argc, char** argv)
 
     //_______________________________________________________________________________
     // check if cpu library was loaded
-    ana.do_run_cpu = false;
-    std::ifstream maps("/proc/self/maps");
-    if (!maps.is_open())
-    {
-        std::cout << "Warning: Failed to open /proc/self/maps. Backend cannot be determined." << std::endl;
-    }
-    else
-    {
-        std::string line;
-        while (std::getline(maps, line)) {
-            size_t pos = line.find("/"); // Find the starting position of the path
-            if (pos != std::string::npos) {
-                std::string libraryPath = line.substr(pos, line.find(" ", pos) - pos);
-                if (libraryPath.size() >= 14 && libraryPath.compare(libraryPath.size() - 14, 14, "/libsdl_cpu.so") == 0) {
-                    ana.do_run_cpu = true;
-                    break;
-                }
-            }
-        }
-    }
+    // 0 = cpu serial
+    // 1 = cpu threads
+    // 2 = cuda
+    // 3 = hip
+    ana.do_run_cpu = SDL::getBackend() < 2;
 
     //_______________________________________________________________________________
     // --optimization

--- a/bin/sdl_make_tracklooper
+++ b/bin/sdl_make_tracklooper
@@ -64,7 +64,11 @@ if [ -z ${ONLYCPUBACKEND} ]; then ONLYCPUBACKEND=false; fi
 if [ -z ${NOPLSDUPCLEAN} ]; then NOPLSDUPCLEAN=false; fi
 
 # If using both -G and -C, -G takes priority
-if [ "${ONLYGPUBACKEND}" == true ]; then ONLYCPUBACKEND=false; fi
+if [ "${ONLYGPUBACKEND}" == true ] && [ "${ONLYCPUBACKEND}" == true ]; then
+  echo "WARNING: -C and -G flags should not be used together."
+  echo "         Only the GPU backend will be compiled"
+  ONLYCPUBACKEND=false
+fi
 
 # Shift away the parsed options
 shift $(($OPTIND - 1))
@@ -138,9 +142,9 @@ else
     T5CUTOPT="T5RZCHI2FLAG=-DUSE_RZCHI2 T5DNNFLAG=-DUSE_T5_DNN"
 fi
 
-BACKENDOPT=
+BACKENDOPT="BACKEND=all"
 if [ "$ONLYGPUBACKEND" == true ]; then
-    BACKENDOPT="BACKEND=gpu"
+    BACKENDOPT="BACKEND=cuda"
 elif [ "$ONLYCPUBACKEND" == true ]; then
     BACKENDOPT="BACKEND=cpu"
 fi
@@ -167,12 +171,12 @@ else
     (cd SDL && make clean && make ${T3T3EXTENSIONOPT} ${T5CUTOPT} ${BACKENDOPT} ${NOPLSDUPCLEANOPT} -j 32 ${MAKETARGET} && cd -) >> ${LOG} 2>&1
 fi
 
-if [[ "$BACKENDOPT" != *"gpu"* ]] && [ ! -f SDL/libsdl_cpu.so ]; then
+if ([[ "$BACKENDOPT" == *"all"* ]] || [[ "$BACKENDOPT" == *"cpu"* ]]) && [ ! -f SDL/libsdl_cpu.so ]; then
   echo "ERROR: libsdl_cpu.so failed to compile!" | tee -a ${LOG}
   echo "See ${LOG} file for more detail..." | tee -a ${LOG}
   exit 1
-elif [[ "$BACKENDOPT" != *"cpu"* ]] && [ ! -f SDL/libsdl_gpu.so ]; then
-  echo "ERROR: libsdl_gpu.so failed to compile!" | tee -a ${LOG}
+elif ([[ "$BACKENDOPT" == *"all"* ]] || [[ "$BACKENDOPT" == *"cuda"* ]]) && [ ! -f SDL/libsdl_cuda.so ]; then
+  echo "ERROR: libsdl_cuda.so failed to compile!" | tee -a ${LOG}
   echo "See ${LOG} file for more detail..." | tee -a ${LOG}
   echo $BACKENDOPT
   exit 1

--- a/bin/sdl_run
+++ b/bin/sdl_run
@@ -63,22 +63,22 @@ fi
 # and set the environment variable to preload it.
 if [ -z ${BACKEND} ]; then
   BACKEND="default"
-elif [ "${BACKEND}" == "gpu" ]; then
+elif [ "${BACKEND}" == "cuda" ]; then
   if ([ ${PRECOMPILED} != true ] && [[ "${FLAGS}" == *"C"* ]]) ||
-       ([ ${PRECOMPILED} == true ] && ([ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_gpu.so ] || [ ! -f ${TRACKLOOPERDIR}/SDL/gpu/libsdl.so ])); then
-    echo "Error: GPU library was not compiled."
+       ([ ${PRECOMPILED} == true ] && ([ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cuda.so ] || [ ! -f ${TRACKLOOPERDIR}/SDL/cuda/libsdl.so ])); then
+    echo "Error: CUDA backend was not compiled."
     exit 1
   fi
-  export LD_LIBRARY_PATH=${TRACKLOOPERDIR}/SDL/gpu/:$LD_LIBRARY_PATH
+  export LD_LIBRARY_PATH=${TRACKLOOPERDIR}/SDL/cuda/:$LD_LIBRARY_PATH
 elif [ "${BACKEND}" == "cpu" ]; then
   if ([ ${PRECOMPILED} != true ] && [[ "${FLAGS}" == *"G"* ]]) ||
        ([ ${PRECOMPILED} == true ] && ([ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cpu.so ] || [ ! -f ${TRACKLOOPERDIR}/SDL/cpu/libsdl.so ])); then
-    echo "Error: CPU library was not compiled."
+    echo "Error: CPU backend was not compiled."
     exit 1
   fi
   export LD_LIBRARY_PATH=${TRACKLOOPERDIR}/SDL/cpu/:$LD_LIBRARY_PATH
 else
-  echo "Error: backend options are gpu or cpu."
+  echo "Error: backend options are gpu or cuda."
   exit 1
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -17,7 +17,7 @@ echo "Setup following ROOT. Make sure the appropriate setup file has been run. O
 which root
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-export LD_LIBRARY_PATH=$DIR/SDL/gpu:$DIR/SDL/cpu:$DIR:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DIR/SDL/cuda:$DIR/SDL/cpu:$DIR:$LD_LIBRARY_PATH
 export PATH=$DIR/bin:$PATH
 export PATH=$DIR/efficiency/bin:$PATH
 export PATH=$DIR/efficiency/python:$PATH

--- a/setup_hpg.sh
+++ b/setup_hpg.sh
@@ -23,7 +23,7 @@ echo "Setup following ROOT. Make sure the appropriate setup file has been run. O
 which root
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-export LD_LIBRARY_PATH=$DIR/SDL/gpu:$DIR/SDL/cpu:$DIR:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$DIR/SDL/cuda:$DIR/SDL/cpu:$DIR:$LD_LIBRARY_PATH
 export PATH=$DIR/bin:$PATH
 export PATH=$DIR/efficiency/bin:$PATH
 export PATH=$DIR/efficiency/python:$PATH


### PR DESCRIPTION
I cleaned up some issues brought up after #341 was merged. The backend name of the gpu version was changed to cuda, so that later on it's easier to add HIP. This means that the CMSSW repo will need to be updated to use `libsdl_cuda.so`.

The makefiles were cleaned up a bit, and the new instructions were added to the readme. Someone else should test this to make sure everything is working well.