### PR TITLE
Added compilation flags for more optimization

### DIFF
--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -27,8 +27,8 @@ LIBS=$(LIB_CUDA) $(LIB_CPU)
 #
 
 CXX                  = g++
-CXXFLAGS_CPU         = -O2 -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
-CXXFLAGS_CUDA        = -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 --use_fast_math --default-stream per-thread -I..
+CXXFLAGS_CPU         = -march=native -mtune=native -Ofast -fno-reciprocal-math -fopenmp-simd -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
+CXXFLAGS_CUDA        = -O3 -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 --use_fast_math --default-stream per-thread -I..
 ALPAKAINCLUDE        = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17
 ALPAKASERIAL         = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 ALPAKACUDA           = -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_ACC_GPU_CUDA_ONLY --expt-relaxed-constexpr


### PR DESCRIPTION
During the hackathon last week I tested a bunch of different compilation flags. This PR adds the best ones that I found, which turned out to be the same ones that were discussed in https://github.com/SegmentLinking/TrackLooper/pull/313#discussion_r1322064922. Closes #334.

## GPU

For the GPU version I simply added `-O3` so that the host code is also optimized. It makes a small, but noticeable difference. Here are the timings before and after.

<img width="1098" alt="Screenshot 2023-10-27 at 8 36 10 AM" src="https://github.com/SegmentLinking/TrackLooper/assets/7596837/4b29af3b-9032-4b43-a4d0-f19ed99f0170">
<img width="1096" alt="Screenshot 2023-10-27 at 8 42 54 AM" src="https://github.com/SegmentLinking/TrackLooper/assets/7596837/9cff8dad-b190-4068-8c86-e5bc78679e03">

The performance plots are unchanged. Here are a few comparisons.

![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/483f8eea-e58e-4018-ad92-ddeafe35f32b)
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/e8bed545-3c3d-425f-8339-b2d8457e7ceb)
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/8ededb8c-95fd-47ed-b3d1-7eeb3c957757)

The full set of plots can be found [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR349/comparison_gpu_before_vs_after_d481e6-PU200_9ff0f0-PU200/summary/).

## CPU

For the CPU version I ended up adding `-march=native -mtune=native -Ofast -fno-reciprocal-math -fopenmp-simd`, which is what Slava had suggested (plus `-march=native -mtune=native`, which are fairly standard). Here are the timings before and after.

<img width="1120" alt="Screenshot 2023-10-27 at 8 08 30 AM" src="https://github.com/SegmentLinking/TrackLooper/assets/7596837/a9938d08-f030-4fc1-9127-d85031f77fa8">
<img width="1116" alt="Screenshot 2023-10-27 at 8 30 06 AM" src="https://github.com/SegmentLinking/TrackLooper/assets/7596837/d9cb2c09-2176-4b45-8c2b-3d7f14b7b425">

You can see that there are improvements in all steps, some much larger than others. One thing that is very interesting is that the non-cached allocator is somehow faster than the cached one.

Here are some performance comparisons.

![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/b7ab5f7c-2320-4db5-aa0b-56dbc22e9b2a)
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/07ea7222-75c6-44a6-8d52-e4f6d6f4b1d6)
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/e94ec858-3cc4-45af-8d59-6fa2ea568af5)

The full set of plots can be found [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR349/comparison_cpu_before_vs_after_d481e6-PU200_9ff0f0-PU200/summary/).