### PR TITLE
Separate duplicate flags for first and second passes of checkHitspLS

### DIFF
--- a/SDL/Segment.h
+++ b/SDL/Segment.h
@@ -31,7 +31,7 @@ namespace SDL
         uint4* pLSHitsIdxs;
         int8_t* pixelType;
         char* isQuad;
-        bool* isDup;
+        char* isDup;
         bool* partOfPT5;
         float* ptIn;
         float* ptErr;
@@ -109,7 +109,7 @@ namespace SDL
         Buf<TAcc, uint4> pLSHitsIdxs_buf;
         Buf<TAcc, int8_t> pixelType_buf;
         Buf<TAcc, char> isQuad_buf;
-        Buf<TAcc, bool> isDup_buf;
+        Buf<TAcc, char> isDup_buf;
         Buf<TAcc, bool> partOfPT5_buf;
         Buf<TAcc, float> ptIn_buf;
         Buf<TAcc, float> ptErr_buf;
@@ -150,7 +150,7 @@ namespace SDL
             pLSHitsIdxs_buf(allocBufWrapper<uint4>(devAccIn, maxPixelSegments, queue)),
             pixelType_buf(allocBufWrapper<int8_t>(devAccIn, maxPixelSegments, queue)),
             isQuad_buf(allocBufWrapper<char>(devAccIn, maxPixelSegments, queue)),
-            isDup_buf(allocBufWrapper<bool>(devAccIn, maxPixelSegments, queue)),
+            isDup_buf(allocBufWrapper<char>(devAccIn, maxPixelSegments, queue)),
             partOfPT5_buf(allocBufWrapper<bool>(devAccIn, maxPixelSegments, queue)),
             ptIn_buf(allocBufWrapper<float>(devAccIn, maxPixelSegments, queue)),
             ptErr_buf(allocBufWrapper<float>(devAccIn, maxPixelSegments, queue)),


### PR DESCRIPTION
I made a small change to the `checkHitspLS` kernel. Now the duplicate flag is a `char` instead of a `bool`. The first pass uses the lowest bit to mark it as a duplicate, and the second pass uses the second lowest bit. In the second pass, only the ones marked as duplicate in the first pass are skipped. This way, we finally get perfect agreement between CPU and GPU, and additionally we slightly lower the duplicate rate, while maintaining the same efficiency.

Here is how duplicate rates looked before between CPU and GPU.
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/27eed640-7a1b-475a-a85e-5bc473ee1371)
And here is how they look now.
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/a206c6d8-25a7-4a9b-a3ce-0e5397e9a1f5)

Here is a comparison of duplicate rate on GPU before and after the change.
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/df0751fd-4264-44aa-9438-2dfd75ba4276)

And here are efficiency and fake rate comparisons on GPU.
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/2dc7c7b7-b74e-4b26-8218-ea0d1d18b0d6)
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/047bd92a-2b8c-451a-845a-24fa96644003)
![image](https://github.com/SegmentLinking/TrackLooper/assets/7596837/3905a0aa-9faf-49c7-9192-a978c0009637)

The full set of plots can be found [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR350/).

Here are the timings on GPU before and after. They seem to be the same within run-to-run variations.
<img width="1097" alt="Screenshot 2023-10-26 at 3 22 10 PM" src="https://github.com/SegmentLinking/TrackLooper/assets/7596837/57916141-ca51-42ac-905a-3fb9f40d1a0b">
<img width="1096" alt="Screenshot 2023-10-26 at 4 11 54 PM" src="https://github.com/SegmentLinking/TrackLooper/assets/7596837/9ed10e71-b234-4821-b44b-558ac344fe1e">
