### PR TITLE
specify C++ language in clang-tidy static-checks.yml

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -43,7 +43,7 @@ jobs:
           tidy-checks: ''
           lines-changed-only: true
           ignore: .github|bin|code|data|efficiency
-          extra-args: '-ferror-limit=0 -std=c++17 -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED ${{ env.include-flags }}'
+          extra-args: '-ferror-limit=0 --language=c++ -std=c++17 -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED ${{ env.include-flags }}'
       - name: Fail job if there were checks that failed
         if: steps.linter.outputs.checks-failed > 0
         run: exit 1


### PR DESCRIPTION
it looks like clang-tidy/clang does not recognize quite a few of our files as C++; I propose to add `--language=c++` next to  `-std=c++17` to resolve this

I tested it locally and the `error: invalid argument '-std=c++17' not allowed with 'C'` appearing while running is gone