### PR TITLE
Fix a few issues with the CI

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -15,22 +15,28 @@ permissions:
 jobs:
   linter:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
       - name: Mount cvmfs
         uses: cvmfs-contrib/github-action-cvmfs@v3
-      - name: Gather paths of needed headers
-        shell: bash
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Generate compilation database
         run: |
-          source setup.sh
-          INCLUDE_FLAGS="-I$TRACKLOOPERDIR -I$BOOST_ROOT/include -I$ALPAKA_ROOT/include -I$CUDA_HOME/include -I$ROOT_ROOT/include -I$CMSSW_BASE/src"
-          INCLUDE_FLAGS="$INCLUDE_FLAGS -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1"
-          INCLUDE_FLAGS="$INCLUDE_FLAGS -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1/x86_64-redhat-linux-gnu/"
-          INCLUDE_FLAGS="$INCLUDE_FLAGS -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/lib/gcc/x86_64-redhat-linux-gnu/11.4.1/include"
-          echo "include-flags=$INCLUDE_FLAGS" >> $GITHUB_ENV
-          # Note: Ideally we would use compiledb to generate a compile_commands.json file, but I couldn't get it to work properly with clang-tidy.
-          # This alternative of simply passing some extra arguments to clang-tidy seems to work fine (at least for now).
+          # There are some errors when running the script, but they don't affect anything important.
+          # We only need to run it to set up some environment variables, so we suppress the output.
+          source setup.sh 1> /dev/null 2> /dev/null
+          pip install compiledb compdb
+          cd SDL
+          make BACKEND=cpu explicit -Bnwk > build_log.txt
+          compiledb < build_log.txt
+          # This extra step is needed to generate compilation commands for headers
+          compdb list > compile_commands_new.json
+          mv compile_commands_new.json compile_commands.json
       - name: Run linter
         uses: cpp-linter/cpp-linter-action@v2
         id: linter
@@ -43,7 +49,7 @@ jobs:
           tidy-checks: ''
           lines-changed-only: true
           ignore: .github|bin|code|data|efficiency
-          extra-args: '-ferror-limit=0 -std=c++17 -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED ${{ env.include-flags }}'
+          extra-args: '-U_OPENMP -ferror-limit=0'
       - name: Fail job if there were checks that failed
         if: steps.linter.outputs.checks-failed > 0
         run: exit 1

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          version: 16
           style: file
           thread-comments: true
           # only use checks in .clang-tidy file

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -32,7 +32,7 @@ jobs:
           source setup.sh 1> /dev/null 2> /dev/null
           pip install compiledb compdb
           cd SDL
-          make BACKEND=cpu explicit -Bnwk > build_log.txt
+          make BACKEND=cpu explicit_cache -Bnwk > build_log.txt
           compiledb < build_log.txt
           # This extra step is needed to generate compilation commands for headers
           compdb list > compile_commands_new.json

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}-${{ contains(github.event.comment.body, '/run standalone') }}-${{ contains(github.event.comment.body, '/run cmssw') }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,11 +20,31 @@ jobs:
       (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'CONTRIBUTOR')
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR
+      - name: Check out PR
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
+      - name: Get commit SHA
+        run: |
+          sha=$(git rev-parse HEAD)
+          echo "COMMIT_SHA=$sha" >> $GITHUB_ENV
+      - name: Create App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: LouisBrunner/checks-action@v1.6.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          sha: ${{ env.COMMIT_SHA }}
+          name: Run Standalone PU200
+          status: in_progress
+          details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: |
+            {"title": "This check has started...", "summary": "The logs can be found [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."}
       - name: Build and run PR
+        timeout-minutes: 60
         id: build-and-run
         uses: SegmentLinking/TrackLooper-actions/standalone@v1
         with:
@@ -56,8 +76,25 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `There was a problem while building and running in standalone mode. You can find a log of the job [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).`
+              body: `There was a problem while building and running in standalone mode. The logs can be found [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).`
             })
+      - name: Create App Token
+        if: always()
+        uses: actions/create-github-app-token@v1
+        id: app-token-end
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: LouisBrunner/checks-action@v1.6.1
+        if: always()
+        with:
+          token: ${{ steps.app-token-end.outputs.token }}
+          sha: ${{ env.COMMIT_SHA }}
+          name: Run Standalone PU200
+          conclusion: ${{ job.status }}
+          details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: |
+            {"title": "Status: ${{ job.status }}", "summary": "The logs can be found [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."}
        
   cmssw:
     if: >
@@ -70,6 +107,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
+      - name: Get commit SHA
+        run: |
+          sha=$(git rev-parse HEAD)
+          echo "COMMIT_SHA=$sha" >> $GITHUB_ENV
+      - name: Create App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: LouisBrunner/checks-action@v1.6.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          sha: ${{ env.COMMIT_SHA }}
+          name: Run CMSSW 21034.1
+          status: in_progress
+          details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: |
+            {"title": "This check has started...", "summary": "The logs can be found [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."}
       - name: Get CMSSW branch name
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
@@ -94,6 +150,7 @@ jobs:
           echo "Using CMSSW branch: $cmssw_branch"
           echo "cmssw-branch=$cmssw_branch" >> $GITHUB_ENV
       - name: Build and run PR
+        timeout-minutes: 200
         id: build-and-run
         uses: SegmentLinking/TrackLooper-actions/cmssw@v1
         with:
@@ -126,5 +183,22 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `There was a problem while building and running with CMSSW. You can find a log of the job [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).`
+              body: `There was a problem while building and running with CMSSW. The logs can be found [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).`
             })
+      - name: Create App Token
+        if: always()
+        uses: actions/create-github-app-token@v1
+        id: app-token-end
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: LouisBrunner/checks-action@v1.6.1
+        if: always()
+        with:
+          token: ${{ steps.app-token-end.outputs.token }}
+          sha: ${{ env.COMMIT_SHA }}
+          name: Run CMSSW 21034.1
+          conclusion: ${{ job.status }}
+          details_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: |
+            {"title": "Status: ${{ job.status }}", "summary": "The logs can be found [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,14 +78,13 @@ jobs:
           cmssw_branch=
           while IFS= read -r line; do
             echo "$line"
-            if [[ $line == *"/run cmssw"* ]]; then
+            if [[ $line == "/run cmssw"* ]]; then
               # Check if there is a branch after "/run cmssw"
               words=($line)
               cmssw_branch="${words[2]}"
               # Validate the extracted branch to avoid code injection
-              if ! [[ $cmssw_branch =~ ^[[:alnum:]_-]+$ ]]; then
-                echo "Branch name is invalid. Ignoring..."
-                cmssw_branch=
+              if [ -n "$cmssw_branch" ]; then
+                cmssw_branch=$(git check-ref-format --branch $cmssw_branch || echo "default")
               fi
             fi
           done <<< "$COMMENT_BODY"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: LouisBrunner/checks-action@v1.6.1
+          skip-token-revoke: true
+      - name: Create in progress check
+        uses: LouisBrunner/checks-action@v1.6.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           sha: ${{ env.COMMIT_SHA }}
@@ -85,7 +87,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: LouisBrunner/checks-action@v1.6.1
+      - name: Create completed check
+        uses: LouisBrunner/checks-action@v1.6.1
         if: always()
         with:
           token: ${{ steps.app-token-end.outputs.token }}
@@ -117,7 +120,9 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: LouisBrunner/checks-action@v1.6.1
+          skip-token-revoke: true
+      - name: Create in progress check
+        uses: LouisBrunner/checks-action@v1.6.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           sha: ${{ env.COMMIT_SHA }}
@@ -192,7 +197,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: LouisBrunner/checks-action@v1.6.1
+      - name: Create completed check
+        uses: LouisBrunner/checks-action@v1.6.1
         if: always()
         with:
           token: ${{ steps.app-token-end.outputs.token }}

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,6 @@ bin/sdl: bin/sdl.o $(OBJECTS)
 %.o: %.cc
 	$(CXX) $(PTCUTFLAG) $(T3T3EXTENSION) $(CFLAGS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKASERIAL) $< -c -o $@
 
-
-.PHONY: $(ROOUTIL) efficiency clean format check check-fix
-
 $(ROOUTIL):
 	$(MAKE) -C code/rooutil/
 
@@ -70,11 +67,4 @@ clean:
 	rm -f SDL/*.o
 	cd efficiency/ && make clean
 
-format:
-	clang-format -i SDL/*.cc SDL/*.h
-
-check:
-	clang-tidy SDL/*.cc SDL/*.h -- --language=c++ -std=c++17 -I. -I$(ROOT_ROOT)/include -I$(CMSSW_BASE)/src -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1 -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1/x86_64-redhat-linux-gnu/
-
-check-fix:
-	clang-tidy --fix --fix-errors --fix-notes SDL/*.cc SDL/*.h -- --language=c++ -std=c++17 -I. -I$(ROOT_ROOT)/include -I$(CMSSW_BASE)/src -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1 -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1/x86_64-redhat-linux-gnu/
+.PHONY: $(ROOUTIL) efficiency

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ bin/sdl: bin/sdl.o $(OBJECTS)
 %.o: %.cc
 	$(CXX) $(PTCUTFLAG) $(T3T3EXTENSION) $(CFLAGS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKASERIAL) $< -c -o $@
 
+
+.PHONY: $(ROOUTIL) efficiency clean format check check-fix
+
 $(ROOUTIL):
 	$(MAKE) -C code/rooutil/
 
@@ -67,4 +70,11 @@ clean:
 	rm -f SDL/*.o
 	cd efficiency/ && make clean
 
-.PHONY: $(ROOUTIL) efficiency
+format:
+	clang-format -i SDL/*.cc SDL/*.h
+
+check:
+	clang-tidy SDL/*.cc SDL/*.h -- --language=c++ -std=c++17 -I. -I$(ROOT_ROOT)/include -I$(CMSSW_BASE)/src -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1 -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1/x86_64-redhat-linux-gnu/
+
+check-fix:
+	clang-tidy --fix --fix-errors --fix-notes SDL/*.cc SDL/*.h -- --language=c++ -std=c++17 -I. -I$(ROOT_ROOT)/include -I$(CMSSW_BASE)/src -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1 -I/cvmfs/cms.cern.ch/el8_amd64_gcc11/external/gcc/11.4.1-30ebdc301ebd200f2ae0e3d880258e65/include/c++/11.4.1/x86_64-redhat-linux-gnu/

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ sdl_run -f -mc -s PU200 -n -1 -t myTag
 
 ## Code formatting and checking
 
-The makefile includes phony targets to run `clang-format` and `clang-tidy` on the code in the `SDL` directory using the formatting and checks used in CMSSW. The following are the available commands.
+The makefile in the `SDL` directory includes phony targets to run `clang-format` and `clang-tidy` on the code using the formatting and checks used in CMSSW. The following are the available commands.
 
 - `make format`
   Formats the code in the `SDL` directory using `clang-format` following the rules specified in `.clang-format`.

--- a/README.md
+++ b/README.md
@@ -270,3 +270,14 @@ source $PWD/code/rooutil/thisrooutil.sh
 # After this, you can compile and run LST as usual.
 sdl_run -f -mc -s PU200 -n -1 -t myTag
 ```
+
+## Code formatting and checking
+
+The makefile includes phony targets to run `clang-format` and `clang-tidy` on the code in the `SDL` directory using the formatting and checks used in CMSSW. The following are the available commands.
+
+- `make format`
+  Formats the code in the `SDL` directory using `clang-format` following the rules specified in `.clang-format`.
+- `make check`
+  Runs `clang-tidy` on the code in the `SDL` directory to performs the checks specified in `.clang-tidy`.
+- `make check-fix`
+  Same as `make check`, but fixes the issues that it knows how to fix.

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -92,3 +92,19 @@ clean:
 	rm -f *.so
 	rm -rf cpu/
 	rm -rf cuda/
+
+.PHONY: clean explicit explicit_cache explicit_cache_cutvalue format check check-fix
+
+format:
+	clang-format --style=file:../.clang-format -i *.cc *.h
+
+# Collect all the include paths from the compiler.
+# The .../gcc/x86_64-redhat-linux-gnu/*/include path is excluded since .../gcc/x86_64-redhat-linux-gnu/*/include-fixed should be used instead.
+TIDYINCLUDEFLAGS := $(shell g++ -E -x c++ - -v < /dev/null 2>&1 | awk '/#include <...>/,/^End of search/{if (/^ / && !/x86_64-redhat-linux-gnu\/[0-9.]+\/include$$/) print "-I"$$1}' | tr '\n' ' ')
+TIDYFLAGS := --language=c++ $(CXXFLAGS_CPU) $(ALPAKAINCLUDE) $(ALPAKASERIAL) $(ROOTCFLAGS) $(PRINTFLAG) $(DUPLICATED) $(CACHEFLAG_FLAGS) $(TIDYINCLUDEFLAGS)
+
+check:
+	clang-tidy --config-file=../.clang-tidy *.cc *.h -- $(TIDYFLAGS)
+
+check-fix:
+	clang-tidy --config-file=../.clang-tidy --format-style=file:../.clang-format --fix --fix-errors --fix-notes *.cc *.h -- $(TIDYFLAGS)


### PR DESCRIPTION
I fixed a few issues that came up after the CI was implemented. Here they are:

- `clang-tidy` defaults to interpreting `.h` files as C code. The action used to run this check does not allow enough control over the command that is run to specify the right parameters. This issue is also not solved by a standard `compile_commands.json` compilation database since it typically only contains commands for `.cc` files. This was solved by using the `compdb` python package to also generate compilation commands for headers.
- The version of `clang-format` and `clang-tidy` was 12, but now it was set to 16 to match the version in CMSSW 13_3_0.
- The CI was implemented in a way that prevents equivalent jobs to run at the same time. However, there was a bug where new comments were cancelling previous jobs because the concurrency grouping was not precise enough.
- When running the CMSSW checks, there is the option to specify a branch. There is a check of the branch name to prevent code injection, but the regex that was used was not generic enough. The check is now done with a `git` command, so it should be completely accurate.
- It used to not be very visible when things were running in the CI. Now the CI adds associated checks to the commit that is being used.
- There are now phony targets in the makefile to fix formatting and check for issues. Instructions were added to the readme.

There was also the issue of the linter not being able to post comments. I'm not sure why that is happening, but I found online that turning actions off and on again might solve this issue. I did this, so hopefully it will work now.

I will also update the CMSSW workflow so that it produces comparison plots instead of just validation plots. But that is all done in [TrackLooper-actions](https://github.com/SegmentLinking/TrackLooper-actions) so no changes need to be made here.