### PR TITLE
Support/README for lnx4555

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 ## Quick Start
 
 
-### Setting up LSTPerformanceWeb (only for lnx7188)
+### Setting up LSTPerformanceWeb (only for lnx7188 and lnx4555)
 
-For lnx7188 this needs to be done once
+For lnx7188 and lnx4555 this needs to be done once
 
     cd /cdat/tem/${USER}/
     git clone git@github.com:SegmentLinking/LSTPerformanceWeb.git
 
-### Setting up container (only for lnx7188)
+### Setting up container (only for lnx7188 and lnx4555)
 
-For lnx7188 this needs to be done before compiling or running the code:
+For lnx7188 and lnx4555 this needs to be done before compiling or running the code:
 
     singularity shell --nv --bind /mnt/data1:/data --bind /data2/segmentlinking/ --bind /opt --bind /nfs --bind /mnt --bind /usr/local/cuda/bin/ --bind /cvmfs  /cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el8:x86_64
 

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -26,9 +26,13 @@ LIBS=$(LIB_CUDA) $(LIB_CPU)
 # flags to keep track of
 #
 
+# Different architectures to optimize for
+GENCODE_SM70 := -gencode arch=compute_70,code=sm_70
+GENCODE_SM89 := -gencode arch=compute_89,code=sm_89
+
 CXX                  = g++
 CXXFLAGS_CPU         = -march=native -mtune=native -Ofast -fno-reciprocal-math -fopenmp-simd -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
-CXXFLAGS_CUDA        = -O3 -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared -arch=compute_70 --use_fast_math --default-stream per-thread -I..
+CXXFLAGS_CUDA        = -O3 -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared $(GENCODE_SM70) $(GENCODE_SM89) --use_fast_math --default-stream per-thread -I..
 ALPAKAINCLUDE        = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17 -I$(CMSSW_BASE)/src
 ALPAKASERIAL         = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 ALPAKACUDA           = -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_ACC_GPU_CUDA_ONLY --expt-relaxed-constexpr
@@ -47,7 +51,7 @@ ALPAKABACKEND_CPU    = $(ALPAKASERIAL)
 COMPILE_CMD_CPU      = $(LD_CPU) -c
 
 LD_CUDA              = nvcc
-SOFLAGS_CUDA         = -g -shared --compiler-options -fPIC --cudart shared -arch=compute_70 -code=sm_72
+SOFLAGS_CUDA         = -g -shared --compiler-options -fPIC --cudart shared $(GENCODE_SM70) $(GENCODE_SM89)
 ALPAKABACKEND_CUDA   = $(ALPAKACUDA)
 COMPILE_CMD_CUDA     = $(LD_CUDA) -x cu
 


### PR DESCRIPTION
Small PR that adds the relevant flags to optimize for the L4 and L40 GPU's on lnx4555, and updates the README with relevant info. Also, below is the timing for the L4. I checked the timing for a higher number of streams, but it plateaus at 8 streams.

<img width="1103" alt="Screenshot 2024-01-22 at 11 07 08 AM" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/a9f08472-9b57-4a47-9882-45feca1f008f">
