### PR TITLE
test first pass pLS cleaning with 2 hits

### DIFF
--- a/SDL/Kernels.h
+++ b/SDL/Kernels.h
@@ -486,7 +486,7 @@ namespace SDL {
                 break;
             }
           }
-          if (npMatched >= 3) {
+          if (npMatched >= 2) {
             rmPixelSegmentFromMemory(segmentsInGPU, idxToRemove, secondpass);
           }
           if (secondpass) {


### PR DESCRIPTION
3 hit requirement seems too restrictive; at least as a reference I wanted to check if performance changes for the better or not by reducing the check down to 2 hits