### PR TITLE
CI tweaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -143,10 +143,6 @@ jobs:
               # Check if there is a branch after "/run cmssw"
               words=($line)
               cmssw_branch="${words[2]}"
-              # Validate the extracted branch to avoid code injection
-              if [ -n "$cmssw_branch" ]; then
-                cmssw_branch=$(git check-ref-format --branch $cmssw_branch || echo "default")
-              fi
             fi
           done <<< "$COMMENT_BODY"
           if [ -z "$cmssw_branch" ]; then

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -36,7 +36,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           skip-token-revoke: true
       - name: Create in progress check
-        uses: LouisBrunner/checks-action@v1.6.1
+        uses: LouisBrunner/checks-action@v2.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           sha: ${{ env.COMMIT_SHA }}
@@ -48,7 +48,7 @@ jobs:
       - name: Build and run PR
         timeout-minutes: 60
         id: build-and-run
-        uses: SegmentLinking/TrackLooper-actions/standalone@v1
+        uses: SegmentLinking/TrackLooper-actions/standalone@main
         with:
           pr-number: ${{ github.event.issue.number }}
       - name: Upload plots to archival repo
@@ -60,7 +60,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
           TARGET_DIR: ${{ steps.build-and-run.outputs.archive-dir }}
       - name: Comment on PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -71,7 +71,7 @@ jobs:
             })
       - name: Comment on PR if job failed.
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -88,7 +88,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create completed check
-        uses: LouisBrunner/checks-action@v1.6.1
+        uses: LouisBrunner/checks-action@v2.0.0
         if: always()
         with:
           token: ${{ steps.app-token-end.outputs.token }}
@@ -122,7 +122,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           skip-token-revoke: true
       - name: Create in progress check
-        uses: LouisBrunner/checks-action@v1.6.1
+        uses: LouisBrunner/checks-action@v2.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           sha: ${{ env.COMMIT_SHA }}
@@ -153,7 +153,7 @@ jobs:
       - name: Build and run PR
         timeout-minutes: 200
         id: build-and-run
-        uses: SegmentLinking/TrackLooper-actions/cmssw@v1
+        uses: SegmentLinking/TrackLooper-actions/cmssw@main
         with:
           pr-number: ${{ github.event.issue.number }}
           cmssw-branch: ${{ env.cmssw-branch }}
@@ -166,7 +166,7 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
           TARGET_DIR: ${{ steps.build-and-run.outputs.archive-dir }}
       - name: Comment on PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -177,7 +177,7 @@ jobs:
             })
       - name: Comment on PR if job failed.
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -194,7 +194,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create completed check
-        uses: LouisBrunner/checks-action@v1.6.1
+        uses: LouisBrunner/checks-action@v2.0.0
         if: always()
         with:
           token: ${{ steps.app-token-end.outputs.token }}


### PR DESCRIPTION
I made the following tweaks to the CI.

Here are the changes in this PR:
- Removed the cmssw branch validation code. There was a bug where if there was a new line after the name it would think that it was invalid. This was because new lines in GitHub are \r\n, so the branch name ended up being set to "some_branch\r". The branch validation code is now delegated to the action.
- Updated a few actions that were outdated, and moved to using the version of the `TrackLooper-actions` actions in the main branch instead of a specific tag since we're the only ones using them so there's no point in keeping tags.
- Added `dependabot.yml` so that GitHub keeps the actions in the CI up to date.

Here are the changes on the `TrackLooper-actions` side:
- Fixed the branch validation code to strip command characters.
- When an integer number is given as the branch name it is now interpreted as a PR number.
- GitHub is bumped runners on public repos to 4 cores, so I updated the script to use the extra cores. It should mainly be noticeable in the standalone testing. (For the cmssw testing there are other bottlenecks that I haven't figured out how to overcome.)