### PR TITLE
Replace hardcoded values of MAX_CONNECTED_MODULES

### DIFF
--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -1855,7 +1855,8 @@ SDL::modulesBuffer<alpaka::DevCpu>* SDL::Event::getFullModules() {
     modulesInCPUFull->setData(*modulesInCPUFull);
 
     alpaka::memcpy(queue, modulesInCPUFull->detIds_buf, modulesBuffersES->detIds_buf, nModules);
-    alpaka::memcpy(queue, modulesInCPUFull->moduleMap_buf, modulesBuffersES->moduleMap_buf, 40 * nModules);
+    alpaka::memcpy(
+        queue, modulesInCPUFull->moduleMap_buf, modulesBuffersES->moduleMap_buf, MAX_CONNECTED_MODULES * nModules);
     alpaka::memcpy(queue, modulesInCPUFull->nConnectedModules_buf, modulesBuffersES->nConnectedModules_buf, nModules);
     alpaka::memcpy(queue, modulesInCPUFull->drdzs_buf, modulesBuffersES->drdzs_buf, nModules);
     alpaka::memcpy(queue, modulesInCPUFull->slopes_buf, modulesBuffersES->slopes_buf, nModules);

--- a/SDL/Module.h
+++ b/SDL/Module.h
@@ -286,7 +286,7 @@ namespace SDL {
     template <typename TDevAcc>
     modulesBuffer(TDevAcc const& devAccIn, unsigned int nMod = modules_size, unsigned int nPixs = pix_tot)
         : detIds_buf(allocBufWrapper<unsigned int>(devAccIn, nMod)),
-          moduleMap_buf(allocBufWrapper<uint16_t>(devAccIn, nMod * 40)),
+          moduleMap_buf(allocBufWrapper<uint16_t>(devAccIn, nMod * MAX_CONNECTED_MODULES)),
           mapdetId_buf(allocBufWrapper<unsigned int>(devAccIn, nMod)),
           mapIdx_buf(allocBufWrapper<uint16_t>(devAccIn, nMod)),
           nConnectedModules_buf(allocBufWrapper<uint16_t>(devAccIn, nMod)),

--- a/SDL/ModuleMethods.h
+++ b/SDL/ModuleMethods.h
@@ -132,7 +132,7 @@ namespace SDL {
   inline void fillConnectedModuleArrayExplicit(struct modulesBuffer<TDev>* modulesBuf,
                                                unsigned int nMod,
                                                TQueue queue) {
-    auto moduleMap_buf = allocBufWrapper<uint16_t>(devHost, nMod * 40);
+    auto moduleMap_buf = allocBufWrapper<uint16_t>(devHost, nMod * MAX_CONNECTED_MODULES);
     uint16_t* moduleMap = alpaka::getPtrNative(moduleMap_buf);
 
     auto nConnectedModules_buf = allocBufWrapper<uint16_t>(devHost, nMod);
@@ -144,11 +144,11 @@ namespace SDL {
       auto& connectedModules = moduleConnectionMap.getConnectedModuleDetIds(detId);
       nConnectedModules[index] = connectedModules.size();
       for (uint16_t i = 0; i < nConnectedModules[index]; i++) {
-        moduleMap[index * 40 + i] = (*detIdToIndex)[connectedModules[i]];
+        moduleMap[index * MAX_CONNECTED_MODULES + i] = (*detIdToIndex)[connectedModules[i]];
       }
     }
 
-    alpaka::memcpy(queue, modulesBuf->moduleMap_buf, moduleMap_buf, nMod * 40);
+    alpaka::memcpy(queue, modulesBuf->moduleMap_buf, moduleMap_buf, nMod * MAX_CONNECTED_MODULES);
     alpaka::memcpy(queue, modulesBuf->nConnectedModules_buf, nConnectedModules_buf, nMod);
     alpaka::wait(queue);
   };


### PR DESCRIPTION
There were a few places where the value of MAX_CONNECTED_MODULES was hardcoded. Closes #369 

Here are comparison plots showing what happens when MAX_CONNECTED_MODULES is increased from to 50, which in theory shouldn't have any effect.

![TC_base_0_0_eff_ptzoom](https://github.com/SegmentLinking/TrackLooper/assets/7596837/0fbcd462-75fd-465f-a0b3-374630652747)
![TC_base_0_0_eff_etacoarsezoom](https://github.com/SegmentLinking/TrackLooper/assets/7596837/02ea4b23-2f46-4b0b-9dbe-81d749f047e5)

The differences are just the usual small run-to-run variations.