### PR TITLE
Add ROCm backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ bin/doAnalysis
 bin/sdl
 bin/sdl_cuda
 bin/sdl_cpu
+bin/sdl_rocm
 code/rooutil/librooutil.so
 code/rooutil/rooutil.so
 .gitversion.txt

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SOURCES=$(wildcard code/core/*.cc)
 OBJECTS=$(SOURCES:.cc=.o)
 OBJECTS_CPU=$(SOURCES:.cc=_cpu.o)
 OBJECTS_CUDA=$(SOURCES:.cc=_cuda.o)
+OBJECTS_ROCM=$(SOURCES:.cc=_rocm.o)
 HEADERS=$(SOURCES:.cc=.h)
 
 CXX         = g++
@@ -20,6 +21,7 @@ ROOTCFLAGS  = $(foreach option, $(shell root-config --cflags), $(option))
 ALPAKAINCLUDE = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17 -DALPAKA_DEBUG=0
 ALPAKA_CPU = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 ALPAKA_CUDA = -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_HOST_ONLY
+ALPAKA_ROCM = -DALPAKA_ACC_GPU_HIP_ENABLED -DALPAKA_HOST_ONLY -DALPAKA_DISABLE_VENDOR_RNG
 CFLAGS      = $(ROOTCFLAGS)  -Wall  -Wno-unused-function  -g  -O2  -fPIC  -fno-var-tracking -ISDL -I$(shell pwd) -Icode  -Icode/core -I${CUDA_HOME}/include  -fopenmp
 EXTRACFLAGS = $(shell rooutil-config) -g
 EXTRAFLAGS  = -fPIC -ITMultiDrawTreePlayer -Wunused-variable -lTMVA -lEG -lGenVector -lXMLIO -lMLP -lTreePlayer -L${CUDA_HOME}/lib64 -lcudart -fopenmp
@@ -53,11 +55,16 @@ bin/sdl_cpu: bin/sdl_cpu.o $(OBJECTS_CPU)
 bin/sdl_cuda: SDLLIB=-lsdl_cuda
 bin/sdl_cuda: bin/sdl_cuda.o $(OBJECTS_CUDA)
 	$(CXX) $(PTCUTFLAG) $(LDFLAGS) $^ $(ROOTLIBS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(EXTRAFLAGS) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_CUDA) -o $@
+bin/sdl_rocm: SDLLIB=-lsdl_rocm
+bin/sdl_rocm: bin/sdl_rocm.o $(OBJECTS_ROCM)
+	$(CXX) $(PTCUTFLAG) $(LDFLAGS) $^ $(ROOTLIBS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(EXTRAFLAGS) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_ROCM) -o $@
 
 %_cpu.o: %.cc rooutil
 	$(CXX) $(PTCUTFLAG) $(CFLAGS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_CPU) $< -c -o $@
 %_cuda.o: %.cc rooutil
 	$(CXX) $(PTCUTFLAG) $(CFLAGS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_CUDA) $< -c -o $@
+%_rocm.o: %.cc rooutil
+	$(CXX) $(PTCUTFLAG) $(CFLAGS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_ROCM) $< -c -o $@
 
 rooutil:
 	$(MAKE) -C code/rooutil/

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ runTheMatrix.py -w upgrade -n -e -l 21034.1
 
 For convenience, the workflow has been run for 100 events and the output is stored here:
 ```bash
-/ceph/cms/store/user/evourlio/LST/step2_21034.1_100Events.root
+/data2/segmentlinking/CMSSW_14_1_0_pre0/step2_21034.1_100Events.root
 ```
 
 For enabling the LST reconstruction in the CMSSW tracking workflow, a modified step3 needs to be run.

--- a/README.md
+++ b/README.md
@@ -43,18 +43,20 @@ The `-f` flag can be omitted when the code has already been compiled. If multipl
 
 ## Command explanations
 
-Compile the code with option flags
+Compile the code with option flags. If none of `C,G,R,A` are used, then it defaults to compiling for CUDA and CPU.
 
     sdl_make_tracklooper -mc
     -m: make clean binaries
     -c: run with the cmssw caching allocator
-    -C: only compile CPU backend
-    -G: only compile GPU (CUDA) backend
+    -C: compile CPU backend
+    -G: compile CUDA backend
+    -R: compile ROCm backend
+    -A: compile all backends
     -h: show help screen with all options
 
 Run the code
  
-    sdl -n <nevents> -v <verbose> -w <writeout> -s <streams> -i <dataset> -o <output>
+    sdl_<backend> -n <nevents> -v <verbose> -w <writeout> -s <streams> -i <dataset> -o <output>
 
     -i: PU200; muonGun, etc
     -n: number of events; default: all
@@ -63,12 +65,6 @@ Run the code
     -w: 0- no writeout; 1- minimum writeout; default: 1
     -o: provide an output root file name (e.g. LSTNtuple.root); default: debug.root
     -l: add lower level object (pT3, pT5, T5, etc.) branches to the output
-
-When running the `sdl` binary directly and multiple backends have been compiled, one can be chosen using the `LD_LIBRARY_PATH` environment variable. For example, one can explicitly use the CPU backend as follows.
-
-    LD_LIBRARY_PATH=$TRACKLOOPERDIR/SDL/cpu/:$LD_LIBRARY_PATH sdl <args>
-    
-However, it is important to keep in mind that, if that particular backend was not compiled, then it will find another backed without any notice.
 
 Plotting numerators and denominators of performance plots
 

--- a/SDL/Constants.h
+++ b/SDL/Constants.h
@@ -66,7 +66,7 @@ namespace SDL {
   auto const platformHost = alpaka::Platform<alpaka::DevCpu>{};
   auto const devHost = alpaka::getDevByIdx(platformHost, 0u);
 #if defined ALPAKA_ACC_GPU_CUDA_ENABLED || defined ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED || \
-    defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    defined ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED || defined ALPAKA_ACC_GPU_HIP_ENABLED
   auto const devAcc = alpaka::getDevByIdx(platformAcc, 0u);
   using QueueAcc = alpaka::Queue<Acc, QueueProperty>;
 #endif

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -99,18 +99,12 @@ CUTVALUEFLAG_FLAGS = -DCUT_VALUE_DEBUG
 
 $(LIB_CPU): $(CCOBJECTS_CPU) $(LSTOBJECTS_CPU)
 	$(LD_CPU) $(SOFLAGS_CPU) $^ -o $@
-	mkdir -p cpu
-	ln -sf ../$@ cpu/$(@:_cpu.so=.so)
 
 $(LIB_CUDA): $(CCOBJECTS_CUDA) $(LSTOBJECTS_CUDA)
 	$(LD_CUDA) $(SOFLAGS_CUDA) $^ -o $@
-	mkdir -p cuda
-	ln -sf ../$@ cuda/$(@:_cuda.so=.so)
 
 $(LIB_ROCM): $(CCOBJECTS_ROCM) $(LSTOBJECTS_ROCM)
 	$(LD_ROCM) $(SOFLAGS_ROCM) $^ -o $@
-	mkdir -p rocm
-	ln -sf ../$@ rocm/$(@:_rocm.so=.so)
 
 explicit: $(LIBS)
 
@@ -126,9 +120,6 @@ clean:
 	rm -f *.o
 	rm -f *.d
 	rm -f *.so
-	rm -rf cpu/
-	rm -rf cuda/
-	rm -rf rocm/
 
 .PHONY: clean explicit explicit_cache explicit_cache_cutvalue format check check-fix
 

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -6,21 +6,35 @@
 CCSOURCES=$(filter-out LST.cc, $(wildcard *.cc))
 CCOBJECTS_CPU=$(CCSOURCES:.cc=_cpu.o)
 CCOBJECTS_CUDA=$(CCSOURCES:.cc=_cuda.o)
+CCOBJECTS_ROCM=$(CCSOURCES:.cc=_rocm.o)
 
 LSTSOURCES=LST.cc
 LSTOBJECTS_CPU=$(LSTSOURCES:.cc=_cpu.o)
 LSTOBJECTS_CUDA=$(LSTSOURCES:.cc=_cuda.o)
+LSTOBJECTS_ROCM=$(LSTSOURCES:.cc=_rocm.o)
 
-LIB_CUDA=libsdl_cuda.so
-LIB_CPU=libsdl_cpu.so
-
-ifeq ($(BACKEND), cpu)
-  LIB_CUDA=
-else ifeq ($(BACKEND), cuda)
-  LIB_CPU=
+# Default to CPU and CUDA backends
+ifeq ($(BACKEND),)
+  LIB_CPU=libsdl_cpu.so
+  LIB_CUDA=libsdl_cuda.so
 endif
 
-LIBS=$(LIB_CUDA) $(LIB_CPU)
+ifneq ($(findstring cpu,$(BACKEND)),)
+  LIB_CPU=libsdl_cpu.so
+endif
+ifneq ($(findstring cuda,$(BACKEND)),)
+  LIB_CUDA=libsdl_cuda.so
+endif
+ifneq ($(findstring rocm,$(BACKEND)),)
+  LIB_ROCM=libsdl_rocm.so
+endif
+ifneq ($(findstring all,$(BACKEND)),)
+  LIB_CPU=libsdl_cpu.so
+  LIB_CUDA=libsdl_cuda.so
+  LIB_ROCM=libsdl_rocm.so
+endif
+
+LIBS=$(LIB_CPU) $(LIB_CUDA) $(LIB_ROCM)
 
 #
 # flags to keep track of
@@ -32,6 +46,7 @@ GENCODE_CUDA := -gencode arch=compute_70,code=[sm_70,compute_70] -gencode arch=c
 CXX                  = g++
 CXXFLAGS_CPU         = -march=native -mtune=native -Ofast -fno-reciprocal-math -fopenmp-simd -g -Wall -Wshadow -Woverloaded-virtual -fPIC -fopenmp -I..
 CXXFLAGS_CUDA        = -O3 -g --compiler-options -Wall --compiler-options -Wshadow --compiler-options -Woverloaded-virtual --compiler-options -fPIC --compiler-options -fopenmp -dc -lineinfo --ptxas-options=-v --cudart shared $(GENCODE_CUDA) --use_fast_math --default-stream per-thread -I..
+CXXFLAGS_ROCM        = -O3 -g -Wall -Wshadow -Woverloaded-virtual -fPIC -I${ROCM_ROOT}/include -I..
 CMSSWINCLUDE        := -I${CMSSW_BASE}/src
 ifdef CMSSW_RELEASE_BASE
 CMSSWINCLUDE        := ${CMSSWINCLUDE} -I${CMSSW_RELEASE_BASE}/src
@@ -39,6 +54,7 @@ endif
 ALPAKAINCLUDE        = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17 ${CMSSWINCLUDE}
 ALPAKASERIAL         = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 ALPAKACUDA           = -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_ACC_GPU_CUDA_ONLY --expt-relaxed-constexpr
+ALPAKAROCM           = -DALPAKA_ACC_GPU_HIP_ENABLED -DALPAKA_ACC_GPU_HIP_ONLY -DALPAKA_DISABLE_VENDOR_RNG
 ROOTINCLUDE          = -I$(ROOT_ROOT)/include
 ROOTCFLAGS           = -pthread -m64 $(ROOTINCLUDE)
 PRINTFLAG            = -DT4FromT3
@@ -50,6 +66,7 @@ CMSSW_WERRORS_CPU    = -Werror=pointer-arith -Werror=overlength-strings -Werror=
                        -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing \
                        -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch
 CMSSW_WERRORS_CUDA   = $(patsubst %,-Xcompiler %,$(CMSSW_WERRORS_CPU))
+CMSSW_WERRORS_ROCM   = $(CMSSW_WERRORS_CPU)
 CACHEFLAG_FLAGS      = -DCACHE_ALLOC
 T5CUTFLAGS           = $(T5DNNFLAG) $(T5RZCHI2FLAG) $(T5RPHICHI2FLAG)
 
@@ -63,6 +80,11 @@ SOFLAGS_CUDA         = -g -shared --compiler-options -fPIC --cudart shared $(GEN
 ALPAKABACKEND_CUDA   = $(ALPAKACUDA)
 COMPILE_CMD_CUDA     = $(LD_CUDA) -x cu
 
+LD_ROCM              = hipcc
+SOFLAGS_ROCM         = -g -shared -fPIC
+ALPAKABACKEND_ROCM   = $(ALPAKAROCM)
+COMPILE_CMD_ROCM     = $(LD_ROCM) -c
+
 CUTVALUEFLAG =
 CUTVALUEFLAG_FLAGS = -DCUT_VALUE_DEBUG
 
@@ -72,15 +94,23 @@ CUTVALUEFLAG_FLAGS = -DCUT_VALUE_DEBUG
 %_cuda.o: %.cc
 	$(COMPILE_CMD_CUDA) $(CXXFLAGS_CUDA) $(ROOTINCLUDE) $(PRINTFLAG) $(CACHEFLAG) $(CUTVALUEFLAG) $(LSTWARNINGSFLAG) $(CMSSW_WERRORS_CUDA) $(T5CUTFLAGS) $(NOPLSDUPCLEANFLAG) $(TCPLSTRIPLETSFLAG) $(PTCUTFLAG) $(DUPLICATES) $(ALPAKAINCLUDE) $(ALPAKABACKEND_CUDA) $< -o $@
 
-$(LIB_CUDA): $(CCOBJECTS_CUDA) $(LSTOBJECTS_CUDA)
-	$(LD_CUDA) $(SOFLAGS_CUDA) $^ -o $@
-	mkdir -p cuda
-	ln -sf ../$@ cuda/$(@:_cuda.so=.so)
+%_rocm.o: %.cc
+	$(COMPILE_CMD_ROCM) $(CXXFLAGS_ROCM) $(ROOTINCLUDE) $(PRINTFLAG) $(CACHEFLAG) $(CUTVALUEFLAG) $(LSTWARNINGSFLAG) $(CMSSW_WERRORS_ROCM) $(T5CUTFLAGS) $(NOPLSDUPCLEANFLAG) $(TCPLSTRIPLETSFLAG) $(PTCUTFLAG) $(DUPLICATES) $(ALPAKAINCLUDE) $(ALPAKABACKEND_ROCM) $< -o $@
 
 $(LIB_CPU): $(CCOBJECTS_CPU) $(LSTOBJECTS_CPU)
 	$(LD_CPU) $(SOFLAGS_CPU) $^ -o $@
 	mkdir -p cpu
 	ln -sf ../$@ cpu/$(@:_cpu.so=.so)
+
+$(LIB_CUDA): $(CCOBJECTS_CUDA) $(LSTOBJECTS_CUDA)
+	$(LD_CUDA) $(SOFLAGS_CUDA) $^ -o $@
+	mkdir -p cuda
+	ln -sf ../$@ cuda/$(@:_cuda.so=.so)
+
+$(LIB_ROCM): $(CCOBJECTS_ROCM) $(LSTOBJECTS_ROCM)
+	$(LD_ROCM) $(SOFLAGS_ROCM) $^ -o $@
+	mkdir -p rocm
+	ln -sf ../$@ rocm/$(@:_rocm.so=.so)
 
 explicit: $(LIBS)
 
@@ -98,6 +128,7 @@ clean:
 	rm -f *.so
 	rm -rf cpu/
 	rm -rf cuda/
+	rm -rf rocm/
 
 .PHONY: clean explicit explicit_cache explicit_cache_cutvalue format check check-fix
 

--- a/bin/sdl_make_tracklooper
+++ b/bin/sdl_make_tracklooper
@@ -26,8 +26,10 @@ usage()
   echo "  -p    primitive object ntuple   (With extra variables related to primitive objects)"
   echo "  -3    TC pLS triplets           (Allow triplet pLSs in TC collection)"
   echo "  -N    neural networks           (Toggle LST neural networks)"
-  echo "  -G    GPU (CUDA) backend        (Compile only for CUDA, takes priority over -C)"
-  echo "  -C    CPU serial backend        (Compile only for CPU)"
+  echo "  -C    CPU serial backend        (Compile for CPU)"
+  echo "  -G    GPU (CUDA) backend        (Compile for CUDA)"
+  echo "  -R    ROCm backend              (Compile for ROCm)"
+  echo "  -A    All backends              (Compile for all backends, including ROCm)"
   echo "  -P    PT Cut Value              (In GeV, Default is 0.8, Works only for standalone version of code)"
   echo "  -w    Warning mode              (Print extra warning outputs)"
   echo "  -2    no pLS duplicate cleaning (Don't perform the pLS duplicate cleaning step)"
@@ -36,7 +38,7 @@ usage()
 }
 
 # Parsing command-line opts
-while getopts ":cxgsmdp3NGC2ehwP:" OPTION; do
+while getopts ":cxgsmdp3NCGRA2ehwP:" OPTION; do
   case $OPTION in
     c) MAKECACHE=true;;
     s) SHOWLOG=true;;
@@ -45,8 +47,10 @@ while getopts ":cxgsmdp3NGC2ehwP:" OPTION; do
     p) PRIMITIVE=true;;
     3) TCPLSTRIPLETS=true;;
     N) DONTUSENN=true;;
-    G) ONLYCUDABACKEND=true;;
-    C) ONLYCPUBACKEND=true;;
+    G) CUDABACKEND=true;;
+    C) CPUBACKEND=true;;
+    R) ROCMBACKEND=true;;
+    A) ALLBACKENDS=true;;
     2) NOPLSDUPCLEAN=true;;
     w) PRINTWARNINGS=true;;
     P) PTCUTVALUE=$OPTARG;;
@@ -63,17 +67,22 @@ if [ -z ${MAKECUTVALUES} ]; then MAKECUTVALUES=false; fi
 if [ -z ${PRIMITIVE} ]; then PRIMITIVE=false; fi
 if [ -z ${TCPLSTRIPLETS} ]; then TCPLSTRIPLETS=false; fi
 if [ -z ${DONTUSENN} ]; then DONTUSENN=false; fi
-if [ -z ${ONLYCUDABACKEND} ]; then ONLYCUDABACKEND=false; fi
-if [ -z ${ONLYCPUBACKEND} ]; then ONLYCPUBACKEND=false; fi
+if [ -z ${CPUBACKEND} ]; then CPUBACKEND=false; fi
+if [ -z ${CUDABACKEND} ]; then CUDABACKEND=false; fi
+if [ -z ${ROCMBACKEND} ]; then ROCMBACKEND=false; fi
+if [ -z ${ALLBACKENDS} ]; then ALLBACKENDS=false; fi
 if [ -z ${NOPLSDUPCLEAN} ]; then NOPLSDUPCLEAN=false; fi
 if [ -z ${PRINTWARNINGS} ]; then PRINTWARNINGS=false; fi
 if [ -z ${PTCUTVALUE} ]; then PTCUTVALUE=0.8; fi
 
-# If using both -G and -C, -G takes priority
-if [ "${ONLYCUDABACKEND}" == true ] && [ "${ONLYCPUBACKEND}" == true ]; then
-  echo "WARNING: -C and -G flags should not be used together."
-  echo "         Only the CUDA backend will be compiled"
-  ONLYCPUBACKEND=false
+# Default to only CPU and CUDA backends
+if [ "${CPUBACKEND}" == false ] && [ "${CUDABACKEND}" == false ] && [ "${ROCMBACKEND}" == false ]; then
+  CPUBACKEND=true
+  CUDABACKEND=true
+elif [ "${ALLBACKENDS}" == true ]; then
+  CPUBACKEND=true
+  CUDABACKEND=true
+  ROCMBACKEND=true
 fi
 
 # Shift away the parsed options
@@ -99,8 +108,9 @@ echo "  MAKECUTVALUES     : ${MAKECUTVALUES}"                 | tee -a ${LOG}
 echo "  PRIMITIVE         : ${PRIMITIVE}"                     | tee -a ${LOG}
 echo "  TCPLSTRIPLETS     : ${TCPLSTRIPLETS}"                 | tee -a ${LOG}
 echo "  DONTUSENN         : ${DONTUSENN}"                     | tee -a ${LOG}
-echo "  ONLYCUDABACKEND   : ${ONLYCUDABACKEND}"               | tee -a ${LOG}
-echo "  ONLYCPUBACKEND    : ${ONLYCPUBACKEND}"                | tee -a ${LOG}
+echo "  CPUBACKEND        : ${CPUBACKEND}"                    | tee -a ${LOG}
+echo "  CUDABACKEND       : ${CUDABACKEND}"                   | tee -a ${LOG}
+echo "  ROCMBACKEND       : ${ROCMBACKEND}"                   | tee -a ${LOG}
 echo "  NOPLSDUPCLEAN     : ${NOPLSDUPCLEAN}"                 | tee -a ${LOG}
 echo "  PRINTWARNINGS     : ${PRINTWARNINGS}"                 | tee -a ${LOG}
 echo "  PTCUTVALUE        : ${PTCUTVALUE} GeV"                | tee -a ${LOG}
@@ -150,14 +160,24 @@ else
     T5CUTOPT="T5RZCHI2FLAG=-DUSE_RZCHI2 T5DNNFLAG=-DUSE_T5_DNN"
 fi
 
-BACKENDOPT="BACKEND=all"
-EXES="bin/sdl_cpu bin/sdl_cuda"
-if [ "$ONLYCUDABACKEND" == true ]; then
-    BACKENDOPT="BACKEND=cuda"
-    EXES="bin/sdl_cuda"
-elif [ "$ONLYCPUBACKEND" == true ]; then
-    BACKENDOPT="BACKEND=cpu"
-    EXES="bin/sdl_cpu"
+BACKENDOPT="BACKEND="
+EXES=
+if [ "${ALLBACKENDS}" == true ]; then
+  BACKENDOPT="BACKEND=all"
+  EXES="bin/sdl_cpu bin/sdl_cuda bin/sdl_rocm"
+else
+  if [ "${CPUBACKEND}" == true ]; then
+    BACKENDOPT=$BACKENDOPT"cpu,"
+    EXES="$EXES bin/sdl_cpu"
+  fi
+  if [ "${CUDABACKEND}" == true ]; then
+    BACKENDOPT=$BACKENDOPT"cuda,"
+    EXES="$EXES bin/sdl_cuda"
+  fi
+  if [ "${ROCMBACKEND}" == true ]; then
+    BACKENDOPT=$BACKENDOPT"rocm,"
+    EXES="$EXES bin/sdl_rocm"
+  fi
 fi
 
 NOPLSDUPCLEANOPT=
@@ -197,6 +217,10 @@ elif ([[ "$BACKENDOPT" == *"all"* ]] || [[ "$BACKENDOPT" == *"cuda"* ]]) && [ ! 
   echo "ERROR: libsdl_cuda.so failed to compile!" | tee -a ${LOG}
   echo "See ${LOG} file for more detail..." | tee -a ${LOG}
   exit 1
+elif ([[ "$BACKENDOPT" == *"all"* ]] || [[ "$BACKENDOPT" == *"rocm"* ]]) && [ ! -f SDL/libsdl_rocm.so ]; then
+  echo "ERROR: libsdl_rocm.so failed to compile!" | tee -a ${LOG}
+  echo "See ${LOG} file for more detail..." | tee -a ${LOG}
+  exit 1
 fi
 
 echo "" >> ${LOG}
@@ -231,12 +255,14 @@ elif ([[ "$BACKENDOPT" == *"all"* ]] || [[ "$BACKENDOPT" == *"cuda"* ]]) && [ ! 
   echo "See ${LOG} file for more detail..." | tee -a ${LOG}
   exit 1
 fi
-if [ "${ONLYCPUBACKEND}" == true ]; then
-    ln -sfr bin/sdl_cpu bin/sdl
-elif [ "${ONLYCUDABACKEND}" == true ]; then
+
+# Make a symlink with priority CUDA > CPU > ROCM
+if [ "${CUDABACKEND}" == true ]; then
     ln -sfr bin/sdl_cuda bin/sdl
-else
+elif [ "${CPUBACKEND}" == true ]; then
     ln -sfr bin/sdl_cpu bin/sdl
+elif [ "${ROCMBACKEND}" == true ]; then
+    ln -sfr bin/sdl_rocm bin/sdl
 fi
 
 echo "" >> ${LOG}

--- a/bin/sdl_make_tracklooper
+++ b/bin/sdl_make_tracklooper
@@ -79,7 +79,8 @@ if [ -z ${PTCUTVALUE} ]; then PTCUTVALUE=0.8; fi
 if [ "${CPUBACKEND}" == false ] && [ "${CUDABACKEND}" == false ] && [ "${ROCMBACKEND}" == false ]; then
   CPUBACKEND=true
   CUDABACKEND=true
-elif [ "${ALLBACKENDS}" == true ]; then
+fi
+if [ "${ALLBACKENDS}" == true ]; then
   CPUBACKEND=true
   CUDABACKEND=true
   ROCMBACKEND=true

--- a/bin/sdl_run
+++ b/bin/sdl_run
@@ -50,38 +50,7 @@ if [ -z ${FLAGS} ]; then PRECOMPILED=true; else PRECOMPILED=false; fi
 if [ -z ${SAMPLE} ]; then usage; fi
 if [ -z ${NEVENTS} ]; then NEVENTS=-1; fi
 if [ -z ${TAG} ]; then usage; fi
-if [ -z ${BACKEND} ]; then  BACKEND="cuda"; fi
-
-# If a backend is specified then make sure that corresponding library exists
-# and set the environment variable to preload it.
-if [ "${BACKEND}" == "cuda" ]; then
-  if ([ ${PRECOMPILED} != true ] && [[ "${FLAGS}" == *"C"* ]]) ||
-       ([ ${PRECOMPILED} == true ] && [ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cuda.so ]); then
-    echo "Error: CUDA backend was not compiled."
-    exit 1
-  fi
-  export LD_LIBRARY_PATH=${TRACKLOOPERDIR}/SDL/:$LD_LIBRARY_PATH
-  ln -s -f ${TRACKLOOPERDIR}/bin/sdl_cuda ${TRACKLOOPERDIR}/bin/sdl
-elif [ "${BACKEND}" == "cpu" ]; then
-  if ([ ${PRECOMPILED} != true ] && [[ "${FLAGS}" == *"G"* ]]) ||
-       ([ ${PRECOMPILED} == true ] && [ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cpu.so ]); then
-    echo "Error: CPU backend was not compiled."
-    exit 1
-  fi
-  export LD_LIBRARY_PATH=${TRACKLOOPERDIR}/SDL/:$LD_LIBRARY_PATH
-  ln -s -f ${TRACKLOOPERDIR}/bin/sdl_cpu ${TRACKLOOPERDIR}/bin/sdl
-else
-  echo "Error: backend options are cpu or cuda."
-  exit 1
-fi
-
-# If it will not be compiled, then make sure that it was precompiled
-if ${PRECOMPILED}; then
-  if [ ! -h ${TRACKLOOPERDIR}/bin/sdl ] || ( [ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cuda.so ] && [ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cpu.so ] ); then
-    echo "SDL library or binary has not been compiled. Please use -f flag."
-    usage
-  fi
-fi
+if [ -z ${BACKEND} ]; then  BACKEND="default"; fi
 
 # Check that the FLAGS start with "-" character
 if [[ ${PRECOMPILED} == true ]] || [[ ${FLAGS:0:1} == "-" ]]; then
@@ -161,6 +130,37 @@ if [[ ${PRECOMPILED} != true ]]; then
   echo "Compiling code..."
   sdl_make_tracklooper ${FLAGS} >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log
 fi
+
+# If a backend is specified then make sure that corresponding library exists
+# and make a symbolic link to the correct binary
+if [ "${BACKEND}" == "cuda" ]; then
+  if [ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cuda.so ]; then
+    echo "Error: CUDA backend was not compiled."
+    exit 1
+  fi
+  ln -s -f ${TRACKLOOPERDIR}/bin/sdl_cuda ${TRACKLOOPERDIR}/bin/sdl
+elif [ "${BACKEND}" == "cpu" ]; then
+  if [ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_cpu.so ]; then
+    echo "Error: CPU backend was not compiled."
+    exit 1
+  fi
+  ln -s -f ${TRACKLOOPERDIR}/bin/sdl_cpu ${TRACKLOOPERDIR}/bin/sdl
+elif [ "${BACKEND}" == "rocm" ]; then
+  if [ ! -f ${TRACKLOOPERDIR}/SDL/libsdl_rocm.so ]; then
+    echo "Error: ROCM backend was not compiled."
+    exit 1
+  fi
+  ln -s -f ${TRACKLOOPERDIR}/bin/sdl_rocm ${TRACKLOOPERDIR}/bin/sdl
+elif [ "${BACKEND}" == "default" ]; then
+  if [[ ! -L ${TRACKLOOPERDIR}/bin/sdl || ! -e ${TRACKLOOPERDIR}/bin/sdl ]]; then
+    echo "Error: default backend was not found. Please recompile."
+    exit 1
+  fi
+else
+  echo "Error: backend options are cpu, cuda, rocm, or default."
+  exit 1
+fi
+
 echo "Running LST code..."
 sdl -i ${SAMPLE} -o ${LSTOUTPUTDIR}/${JOBTAG}__LSTNtuple.root -n ${NEVENTS} >> ${LSTOUTPUTDIR}/${JOBTAG}__LSTRun.log 2>&1 || { echo 'ERROR: sdl command failed!' ; exit 1; }
 echo "Creating performance histograms..."

--- a/bin/sdl_run
+++ b/bin/sdl_run
@@ -152,7 +152,7 @@ elif [ "${BACKEND}" == "rocm" ]; then
   fi
   ln -s -f ${TRACKLOOPERDIR}/bin/sdl_rocm ${TRACKLOOPERDIR}/bin/sdl
 elif [ "${BACKEND}" == "default" ]; then
-  if [[ ! -L ${TRACKLOOPERDIR}/bin/sdl || ! -e ${TRACKLOOPERDIR}/bin/sdl ]]; then
+  if [[ ! -e ${TRACKLOOPERDIR}/bin/sdl ]]; then
     echo "Error: default backend was not found. Please recompile."
     exit 1
   fi

--- a/efficiency/bin/sdl_timing
+++ b/efficiency/bin/sdl_timing
@@ -1,15 +1,28 @@
 #!/bin/bash
 
-run_gpu()
+run_rocm()
 {
     version=$1
     sample=$2
     nevents=$3
     shift 3
-    # GPU backend
+    # ROCm backend
+    sdl_make_tracklooper -mR $*
+    for s_value in 1 2 4 6 8; do
+        sdl -n ${NEVENTS} -o ${OUTDIR}/rocm_${version}_s${s_value}.root -v 1 -w 0 -s ${s_value} -i ${sample} | tee -a timing_temp.txt
+    done
+}
+
+run_cuda()
+{
+    version=$1
+    sample=$2
+    nevents=$3
+    shift 3
+    # CUDA backend
     sdl_make_tracklooper -mG $*
     for s_value in 1 2 4 6 8; do
-        sdl -n ${NEVENTS} -o ${OUTDIR}/gpu_${version}_s${s_value}.root -v 1 -w 0 -s ${s_value} -i ${sample} | tee -a timing_temp.txt
+        sdl -n ${NEVENTS} -o ${OUTDIR}/cuda_${version}_s${s_value}.root -v 1 -w 0 -s ${s_value} -i ${sample} | tee -a timing_temp.txt
     done
 }
 
@@ -33,7 +46,7 @@ run_timing_test_usage()
     echo "      sh $(basename $0) [-b BACKEND] SAMPLETYPE [SPECIFICGPUVERISON] [NEVENTS]"
     echo
     echo "Options:"
-    echo "   -b BACKEND                         cpu or gpu (default is gpu)"
+    echo "   -b BACKEND                         cpu, cuda, or rocm (default is cuda)"
     echo
     echo "Arguments:"
     echo "   SAMPLETYPE                         muonGun, PU200, or pionGun"
@@ -45,7 +58,7 @@ run_timing_test_usage()
 }
 
 # Parsing command-line opts
-BACKEND="gpu"  # Default to GPU if no backend specified
+BACKEND="cuda"  # Default to cuda if no backend specified
 while getopts ":hb:" OPTION; do
   case $OPTION in
     h) usage;;
@@ -77,10 +90,12 @@ else
 fi
 
 # Decide which function to run
-if [ "$BACKEND" == "gpu" ]; then
-    run_func=run_gpu
+if [ "$BACKEND" == "cuda" ]; then
+    run_func=run_cuda
 elif [ "$BACKEND" == "cpu" ]; then
     run_func=run_cpu
+elif [ "$BACKEND" == "rocm" ]; then
+    run_func=run_rocm
 else
     echo "Invalid backend specified."
     exit 1

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,7 @@ export BOOST_ROOT=$(scram tool info boost | grep BOOST_BASE | cut -d'=' -f2)
 export ALPAKA_ROOT=$(scram tool info alpaka | grep ALPAKA_BASE | cut -d'=' -f2)
 export CUDA_HOME=$(scram tool info cuda | grep CUDA_BASE | cut -d'=' -f2)
 export ROOT_ROOT=$(scram tool info root_interface | grep ROOT_INTERFACE_BASE | cut -d'=' -f2)
+export ROCM_ROOT=$(scram tool info rocm | grep ROCM_BASE | cut -d'=' -f2)
 
 cd - > /dev/null
 echo "Setup following ROOT. Make sure the appropriate setup file has been run. Otherwise the looper won't compile."

--- a/setup_hpg.sh
+++ b/setup_hpg.sh
@@ -23,6 +23,7 @@ eval `scramv1 runtime -sh`
 export BOOST_ROOT=$(scram tool info boost | grep BOOST_BASE | cut -d'=' -f2)
 export ALPAKA_ROOT=$(scram tool info alpaka | grep ALPAKA_BASE | cut -d'=' -f2)
 export ROOT_ROOT=$(scram tool info root_interface | grep ROOT_INTERFACE_BASE | cut -d'=' -f2)
+export ROCM_ROOT=$(scram tool info rocm | grep ROCM_BASE | cut -d'=' -f2)
 
 cd - > /dev/null
 echo "Setup following ROOT. Make sure the appropriate setup file has been run. Otherwise the looper won't compile."


### PR DESCRIPTION
Since the CMSSW integration is now in progress, I think it makes sense to include the ROCm backend so that the CI can check if it compiles correctly (even if we currently don't have a machine to test it).

I modified things a bit, but it still defaults to only compiling for CUDA and CPU. The backend compilation flags are no longer exclusive, so for example `-GR` would compile it for both CUDA and ROCm`.

I did have to fix a missing ifdef in `Constants.h`, but apart from that it was just adjusting scripts and updating the readme. I also removed the mention of `bin/sdl` instead mentioning `bin/sdl_<backend>`, so we can start to deprecate it.

I tested all the scripts and everything seems to be working, but I'll mark this as a draft PR for now while I make sure it's ready. The ROCm compilation flags are probably not optimal, but they work.

Closes #347