### PR TITLE
Warnings cleanup

### DIFF
--- a/SDL/Constants.h
+++ b/SDL/Constants.h
@@ -102,7 +102,7 @@ namespace SDL {
   template <typename Vec>
   ALPAKA_FN_HOST ALPAKA_FN_INLINE WorkDiv createWorkDiv(const Vec& blocksPerGrid,
                                                         const Vec& threadsPerBlock,
-                                                        const Vec& elementsPerThread) {
+                                                        const Vec& elementsPerThreadArg) {
     Vec adjustedBlocks = blocksPerGrid;
     Vec adjustedThreads = threadsPerBlock;
 
@@ -117,7 +117,7 @@ namespace SDL {
     adjustedBlocks = Vec::all(static_cast<Idx>(1));
 #endif
 
-    return WorkDiv(adjustedBlocks, adjustedThreads, elementsPerThread);
+    return WorkDiv(adjustedBlocks, adjustedThreads, elementsPerThreadArg);
   }
 
 // If a compile time flag does not define PT_CUT, default to 0.8 (GeV)

--- a/SDL/Hit.h
+++ b/SDL/Hit.h
@@ -93,11 +93,11 @@ namespace SDL {
           hitRangesUpper_buf(allocBufWrapper<int>(devAccIn, nModules, queue)),
           hitRangesnLower_buf(allocBufWrapper<int8_t>(devAccIn, nModules, queue)),
           hitRangesnUpper_buf(allocBufWrapper<int8_t>(devAccIn, nModules, queue)) {
-      alpaka::memset(queue, hitRanges_buf, -1);
-      alpaka::memset(queue, hitRangesLower_buf, -1);
-      alpaka::memset(queue, hitRangesUpper_buf, -1);
-      alpaka::memset(queue, hitRangesnLower_buf, -1);
-      alpaka::memset(queue, hitRangesnUpper_buf, -1);
+      alpaka::memset(queue, hitRanges_buf, 0xff);
+      alpaka::memset(queue, hitRangesLower_buf, 0xff);
+      alpaka::memset(queue, hitRangesUpper_buf, 0xff);
+      alpaka::memset(queue, hitRangesnLower_buf, 0xff);
+      alpaka::memset(queue, hitRangesnUpper_buf, 0xff);
       alpaka::wait(queue);
     }
   };

--- a/SDL/Hit.h
+++ b/SDL/Hit.h
@@ -192,12 +192,8 @@ namespace SDL {
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::hits hitsInGPU,
                                   int const& nLowerModules) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (int lowerIndex = globalThreadIdx[2]; lowerIndex < nLowerModules; lowerIndex += gridThreadExtent[2]) {
         uint16_t upperIndex = modulesInGPU.partnerModuleIndices[lowerIndex];
@@ -226,12 +222,8 @@ namespace SDL {
                                   struct SDL::hits hitsInGPU,
                                   unsigned int const& nHits) const  // Total number of hits in event
     {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
       for (unsigned int ihit = globalThreadIdx[2]; ihit < nHits; ihit += gridThreadExtent[2]) {
         float ihit_x = hitsInGPU.xs[ihit];
         float ihit_y = hitsInGPU.ys[ihit];

--- a/SDL/Kernels.h
+++ b/SDL/Kernels.h
@@ -198,12 +198,8 @@ namespace SDL {
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::quintuplets quintupletsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (unsigned int lowmod = globalThreadIdx[0]; lowmod < *modulesInGPU.nLowerModules;
            lowmod += gridThreadExtent[0]) {
@@ -257,12 +253,8 @@ namespace SDL {
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
                                   struct SDL::quintuplets quintupletsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (unsigned int lowmodIdx1 = globalThreadIdx[1]; lowmodIdx1 < *(rangesInGPU.nEligibleT5Modules);
            lowmodIdx1 += gridThreadExtent[1]) {
@@ -336,12 +328,8 @@ namespace SDL {
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
                                   struct SDL::pixelTriplets pixelTripletsInGPU,
                                   bool secondPass) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (unsigned int ix = globalThreadIdx[1]; ix < *pixelTripletsInGPU.nPixelTriplets; ix += gridThreadExtent[1]) {
         for (unsigned int jx = globalThreadIdx[2]; jx < *pixelTripletsInGPU.nPixelTriplets; jx += gridThreadExtent[2]) {
@@ -375,12 +363,8 @@ namespace SDL {
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
                                   struct SDL::pixelQuintuplets pixelQuintupletsInGPU,
                                   bool secondPass) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       unsigned int nPixelQuintuplets = *pixelQuintupletsInGPU.nPixelQuintuplets;
       for (unsigned int ix = globalThreadIdx[1]; ix < nPixelQuintuplets; ix += gridThreadExtent[1]) {
@@ -414,12 +398,8 @@ namespace SDL {
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::segments segmentsInGPU,
                                   bool secondpass) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       int pixelModuleIndex = *modulesInGPU.nLowerModules;
       unsigned int nPixelSegments = segmentsInGPU.nSegments[pixelModuleIndex];

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -48,7 +48,10 @@ PTCUTFLAG            =
 LSTWARNINGSFLAG      =
 CMSSW_WERRORS_CPU    = -Werror=pointer-arith -Werror=overlength-strings -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label \
                        -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing \
-                       -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -Wno-attributes
+                       -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch \
+                       -Werror=main -Werror=overflow -Werror=format-contains-nul -Werror=type-limits -Wreturn-type -Wextra -Wpessimizing-move -Wclass-memaccess -Wunused \
+                       -Wparentheses -Wno-vla -Wno-non-template-friend -Wno-long-long -Wno-cast-function-type -Wno-unused-but-set-parameter -Wno-ignored-qualifiers \
+                       -Wno-unused-parameter -Wno-unused-local-typedefs -Wno-attributes
 CMSSW_WERRORS_CUDA   = $(patsubst %,-Xcompiler %,$(CMSSW_WERRORS_CPU))
 CACHEFLAG_FLAGS      = -DCACHE_ALLOC
 T5CUTFLAGS           = $(T5DNNFLAG) $(T5RZCHI2FLAG) $(T5RPHICHI2FLAG)

--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -48,7 +48,7 @@ PTCUTFLAG            =
 LSTWARNINGSFLAG      =
 CMSSW_WERRORS_CPU    = -Werror=pointer-arith -Werror=overlength-strings -Werror=return-type -Werror=missing-braces -Werror=unused-value -Werror=unused-label \
                        -Werror=address -Werror=format -Werror=sign-compare -Werror=write-strings -Werror=delete-non-virtual-dtor -Werror=strict-aliasing -Werror=narrowing \
-                       -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch
+                       -Werror=unused-but-set-variable -Werror=reorder -Werror=unused-variable -Werror=conversion-null -Werror=return-local-addr -Wnon-virtual-dtor -Werror=switch -Wno-attributes
 CMSSW_WERRORS_CUDA   = $(patsubst %,-Xcompiler %,$(CMSSW_WERRORS_CPU))
 CACHEFLAG_FLAGS      = -DCACHE_ALLOC
 T5CUTFLAGS           = $(T5DNNFLAG) $(T5RZCHI2FLAG) $(T5RPHICHI2FLAG)

--- a/SDL/MiniDoublet.h
+++ b/SDL/MiniDoublet.h
@@ -891,12 +891,8 @@ namespace SDL {
                                   struct SDL::hits hitsInGPU,
                                   struct SDL::miniDoublets mdsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (uint16_t lowerModuleIndex = globalThreadIdx[1]; lowerModuleIndex < (*modulesInGPU.nLowerModules);
            lowerModuleIndex += gridThreadExtent[1]) {
@@ -991,12 +987,8 @@ namespace SDL {
     ALPAKA_FN_ACC void operator()(TAcc const& acc,
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       // Initialize variables in shared memory and set to 0
       int& nTotalMDs = alpaka::declareSharedVar<int, __COUNTER__>(acc);
@@ -1087,12 +1079,8 @@ namespace SDL {
                                   struct SDL::miniDoublets mdsInGPU,
                                   struct SDL::objectRanges rangesInGPU,
                                   struct SDL::hits hitsInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2]) {
         if (mdsInGPU.nMDs[i] == 0 or hitsInGPU.hitRanges[i * 2] == -1) {

--- a/SDL/MiniDoublet.h
+++ b/SDL/MiniDoublet.h
@@ -923,7 +923,8 @@ namespace SDL {
           float zUpper = hitsInGPU.zs[upperHitArrayIndex];
           float rtUpper = hitsInGPU.rts[upperHitArrayIndex];
 
-          float dz, dphi, dphichange, shiftedX = 0, shiftedY = 0, shiftedZ = 0, noShiftedDz = 0, noShiftedDphi, noShiftedDphiChange;
+          float dz, dphi, dphichange, shiftedX = 0, shiftedY = 0, shiftedZ = 0, noShiftedDz = 0, noShiftedDphi,
+                                      noShiftedDphiChange;
           bool success = runMiniDoubletDefaultAlgo(acc,
                                                    modulesInGPU,
                                                    lowerModuleIndex,

--- a/SDL/MiniDoublet.h
+++ b/SDL/MiniDoublet.h
@@ -648,7 +648,7 @@ namespace SDL {
                                                      float& shiftedX,
                                                      float& shiftedY,
                                                      float& shiftedZ,
-                                                     float& noshiftedDz,
+                                                     float& noShiftedDz,
                                                      float& noShiftedDphi,
                                                      float& noShiftedDphiChange,
                                                      float xLower,
@@ -720,6 +720,9 @@ namespace SDL {
         noShiftedDphi = SDL::deltaPhi(acc, xLower, yLower, xUpper, yUpper);
       }
     } else {
+      shiftedX = 0;
+      shiftedY = 0;
+      shiftedZ = 0;
       dPhi = SDL::deltaPhi(acc, xLower, yLower, xUpper, yUpper);
       noShiftedDphi = dPhi;
     }
@@ -762,7 +765,7 @@ namespace SDL {
     }
 
     pass = pass && (alpaka::math::abs(acc, dPhiChange) < miniCut);
-
+    noShiftedDz = 0;  // not used anywhere
     return pass;
   };
 
@@ -779,7 +782,7 @@ namespace SDL {
                                                      float& shiftedX,
                                                      float& shiftedY,
                                                      float& shiftedZ,
-                                                     float& noshiftedDz,
+                                                     float& noShiftedDz,
                                                      float& noShiftedDphi,
                                                      float& noShiftedDphichange,
                                                      float xLower,
@@ -880,7 +883,7 @@ namespace SDL {
     dPhiChange = dPhi / dzFrac * (1.f + dzFrac);
     noShiftedDphichange = noShiftedDphi / dzFrac * (1.f + dzFrac);
     pass = pass && (alpaka::math::abs(acc, dPhiChange) < miniCut);
-
+    noShiftedDz = 0;  // not used anywhere
     return pass;
   };
 
@@ -923,8 +926,7 @@ namespace SDL {
           float zUpper = hitsInGPU.zs[upperHitArrayIndex];
           float rtUpper = hitsInGPU.rts[upperHitArrayIndex];
 
-          float dz, dphi, dphichange, shiftedX = 0, shiftedY = 0, shiftedZ = 0, noShiftedDz = 0, noShiftedDphi,
-                                      noShiftedDphiChange;
+          float dz, dphi, dphichange, shiftedX, shiftedY, shiftedZ, noShiftedDz, noShiftedDphi, noShiftedDphiChange;
           bool success = runMiniDoubletDefaultAlgo(acc,
                                                    modulesInGPU,
                                                    lowerModuleIndex,

--- a/SDL/MiniDoublet.h
+++ b/SDL/MiniDoublet.h
@@ -923,7 +923,7 @@ namespace SDL {
           float zUpper = hitsInGPU.zs[upperHitArrayIndex];
           float rtUpper = hitsInGPU.rts[upperHitArrayIndex];
 
-          float dz, dphi, dphichange, shiftedX, shiftedY, shiftedZ, noShiftedDz, noShiftedDphi, noShiftedDphiChange;
+          float dz, dphi, dphichange, shiftedX = 0, shiftedY = 0, shiftedZ = 0, noShiftedDz = 0, noShiftedDphi, noShiftedDphiChange;
           bool success = runMiniDoubletDefaultAlgo(acc,
                                                    modulesInGPU,
                                                    lowerModuleIndex,

--- a/SDL/Module.h
+++ b/SDL/Module.h
@@ -137,18 +137,18 @@ namespace SDL {
           device_nTotalSegs_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
           device_nTotalTrips_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
           device_nTotalQuints_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)) {
-      alpaka::memset(queue, hitRanges_buf, -1);
-      alpaka::memset(queue, hitRangesLower_buf, -1);
-      alpaka::memset(queue, hitRangesUpper_buf, -1);
-      alpaka::memset(queue, hitRangesnLower_buf, -1);
-      alpaka::memset(queue, hitRangesnUpper_buf, -1);
-      alpaka::memset(queue, mdRanges_buf, -1);
-      alpaka::memset(queue, segmentRanges_buf, -1);
-      alpaka::memset(queue, trackletRanges_buf, -1);
-      alpaka::memset(queue, tripletRanges_buf, -1);
-      alpaka::memset(queue, trackCandidateRanges_buf, -1);
-      alpaka::memset(queue, quintupletRanges_buf, -1);
-      alpaka::memset(queue, quintupletModuleIndices_buf, -1);
+      alpaka::memset(queue, hitRanges_buf, 0xff);
+      alpaka::memset(queue, hitRangesLower_buf, 0xff);
+      alpaka::memset(queue, hitRangesUpper_buf, 0xff);
+      alpaka::memset(queue, hitRangesnLower_buf, 0xff);
+      alpaka::memset(queue, hitRangesnUpper_buf, 0xff);
+      alpaka::memset(queue, mdRanges_buf, 0xff);
+      alpaka::memset(queue, segmentRanges_buf, 0xff);
+      alpaka::memset(queue, trackletRanges_buf, 0xff);
+      alpaka::memset(queue, tripletRanges_buf, 0xff);
+      alpaka::memset(queue, trackCandidateRanges_buf, 0xff);
+      alpaka::memset(queue, quintupletRanges_buf, 0xff);
+      alpaka::memset(queue, quintupletModuleIndices_buf, 0xff);
       alpaka::wait(queue);
     }
   };

--- a/SDL/PixelTriplet.h
+++ b/SDL/PixelTriplet.h
@@ -198,7 +198,7 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float computeRadiusFromThreeAnchorHitspT3(
-      TAcc const& acc, float* xs, float* ys, float& g, float& f) {
+      TAcc const& acc, const float* xs, const float* ys, float& g, float& f) {
     float radius = 0;
 
     //writing manual code for computing radius, which obviously sucks
@@ -760,16 +760,16 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE float computePT3RZChiSquared(TAcc const& acc,
-                                                              struct SDL::modules& modulesInGPU,
-                                                              uint16_t* lowerModuleIndices,
-                                                              float* rtPix,
-                                                              float* xPix,
-                                                              float* yPix,
-                                                              float* zPix,
-                                                              float* rts,
-                                                              float* xs,
-                                                              float* ys,
-                                                              float* zs,
+                                                              struct SDL::modules const& modulesInGPU,
+                                                              const uint16_t* lowerModuleIndices,
+                                                              const float* rtPix,
+                                                              const float* xPix,
+                                                              const float* yPix,
+                                                              const float* zPix,
+                                                              const float* rts,
+                                                              const float* xs,
+                                                              const float* ys,
+                                                              const float* zs,
                                                               float pixelSegmentPt,
                                                               float pixelSegmentPx,
                                                               float pixelSegmentPy,
@@ -786,8 +786,8 @@ namespace SDL {
     float z1 = zPix[1] / 100;
     float r1 = rtPix[1] / 100;
 
-    float B = SDL::magnetic_field;
-    float a = -0.299792 * B * charge;
+    float Bz = SDL::magnetic_field;
+    float a = -0.299792 * Bz * charge;
 
     for (size_t i = 0; i < 3; i++) {
       float zsi = zs[i] / 100;
@@ -992,8 +992,6 @@ namespace SDL {
     if (runChiSquaredCuts and pixelSegmentPt < 5.0f) {
       float rts[3] = {
           mdsInGPU.anchorRt[firstMDIndex], mdsInGPU.anchorRt[secondMDIndex], mdsInGPU.anchorRt[thirdMDIndex]};
-      float xs[3] = {mdsInGPU.anchorX[firstMDIndex], mdsInGPU.anchorX[secondMDIndex], mdsInGPU.anchorX[thirdMDIndex]};
-      float ys[3] = {mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorY[thirdMDIndex]};
       float zs[3] = {mdsInGPU.anchorZ[firstMDIndex], mdsInGPU.anchorZ[secondMDIndex], mdsInGPU.anchorZ[thirdMDIndex]};
       float rtPix[2] = {mdsInGPU.anchorRt[pixelInnerMDIndex], mdsInGPU.anchorRt[pixelOuterMDIndex]};
       float xPix[2] = {mdsInGPU.anchorX[pixelInnerMDIndex], mdsInGPU.anchorX[pixelOuterMDIndex]};
@@ -1057,14 +1055,10 @@ namespace SDL {
                                   unsigned int* connectedPixelSize,
                                   unsigned int* connectedPixelIndex,
                                   unsigned int nPixelSegments) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalBlockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc);
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridBlockExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalBlockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridBlockExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (unsigned int i_pLS = globalThreadIdx[1]; i_pLS < nPixelSegments; i_pLS += gridThreadExtent[1]) {
         auto iLSModule_max = connectedPixelIndex[i_pLS] + connectedPixelSize[i_pLS];
@@ -2707,14 +2701,10 @@ namespace SDL {
                                   unsigned int* connectedPixelIndex,
                                   unsigned int nPixelSegments,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalBlockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc);
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridBlockExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalBlockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridBlockExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (unsigned int i_pLS = globalThreadIdx[1]; i_pLS < nPixelSegments; i_pLS += gridThreadExtent[1]) {
         auto iLSModule_max = connectedPixelIndex[i_pLS] + connectedPixelSize[i_pLS];

--- a/SDL/PixelTriplet.h
+++ b/SDL/PixelTriplet.h
@@ -423,6 +423,8 @@ namespace SDL {
         angleM = -(absArctanSlope + 0.5f * float(M_PI));
       } else if (xs[i] > 0 and ys[i] < 0) {
         angleM = -(0.5f * float(M_PI) - absArctanSlope);
+      } else {
+        angleM = 0;
       }
 
       if (not isFlat[i]) {
@@ -450,8 +452,8 @@ namespace SDL {
                                                                 float& radius,
                                                                 float* xs,
                                                                 float* ys) {
-    float delta1[3], delta2[3], slopes[3];
-    bool isFlat[3];
+    float delta1[3]{}, delta2[3]{}, slopes[3];
+    bool isFlat[3]{};
     float chiSquared = 0;
     float inv1 = 0.01f / 0.009f;
     float inv2 = 0.15f / 0.009f;
@@ -640,9 +642,9 @@ namespace SDL {
   /*bounds for high Pt taken from : http://uaf-10.t2.ucsd.edu/~bsathian/SDL/T5_efficiency/efficiencies/new_efficiencies/efficiencies_20210513_T5_recovering_high_Pt_efficiencies/highE_radius_matching/highE_bounds.txt */
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterionBBB(TAcc const& acc,
-                                                             float& pixelRadius,
-                                                             float& pixelRadiusError,
-                                                             float& tripletRadius) {
+                                                             float const& pixelRadius,
+                                                             float const& pixelRadiusError,
+                                                             float const& tripletRadius) {
     float tripletInvRadiusErrorBound = 0.15624f;
     float pixelInvRadiusErrorBound = 0.17235f;
 
@@ -664,9 +666,9 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterionBBE(TAcc const& acc,
-                                                             float& pixelRadius,
-                                                             float& pixelRadiusError,
-                                                             float& tripletRadius) {
+                                                             float const& pixelRadius,
+                                                             float const& pixelRadiusError,
+                                                             float const& tripletRadius) {
     float tripletInvRadiusErrorBound = 0.45972f;
     float pixelInvRadiusErrorBound = 0.19644f;
 
@@ -688,9 +690,9 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterionBEE(TAcc const& acc,
-                                                             float& pixelRadius,
-                                                             float& pixelRadiusError,
-                                                             float& tripletRadius) {
+                                                             float const& pixelRadius,
+                                                             float const& pixelRadiusError,
+                                                             float const& tripletRadius) {
     float tripletInvRadiusErrorBound = 1.59294f;
     float pixelInvRadiusErrorBound = 0.255181f;
 
@@ -714,9 +716,9 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterionEEE(TAcc const& acc,
-                                                             float& pixelRadius,
-                                                             float& pixelRadiusError,
-                                                             float& tripletRadius) {
+                                                             float const& pixelRadius,
+                                                             float const& pixelRadiusError,
+                                                             float const& tripletRadius) {
     float tripletInvRadiusErrorBound = 1.7006f;
     float pixelInvRadiusErrorBound = 0.26367f;
 
@@ -740,13 +742,13 @@ namespace SDL {
 
   template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool passRadiusCriterion(TAcc const& acc,
-                                                          struct SDL::modules& modulesInGPU,
-                                                          float& pixelRadius,
-                                                          float& pixelRadiusError,
-                                                          float& tripletRadius,
-                                                          uint16_t& lowerModuleIndex,
-                                                          uint16_t& middleModuleIndex,
-                                                          uint16_t& upperModuleIndex) {
+                                                          struct SDL::modules const& modulesInGPU,
+                                                          float const& pixelRadius,
+                                                          float const& pixelRadiusError,
+                                                          float const& tripletRadius,
+                                                          uint16_t const& lowerModuleIndex,
+                                                          uint16_t const& middleModuleIndex,
+                                                          uint16_t const& upperModuleIndex) {
     if (modulesInGPU.subdets[lowerModuleIndex] == SDL::Endcap) {
       return passRadiusCriterionEEE(acc, pixelRadius, pixelRadiusError, tripletRadius);
     } else if (modulesInGPU.subdets[middleModuleIndex] == SDL::Endcap) {
@@ -1114,8 +1116,8 @@ namespace SDL {
             if (tripletsInGPU.partOfPT5[outerTripletIndex])
               continue;  //don't create pT3s for T3s accounted in pT5s
 
-            float pixelRadius, pixelRadiusError, tripletRadius, rPhiChiSquared, rzChiSquared, rPhiChiSquaredInwards,
-                centerX, centerY;
+            float pixelRadius, pixelRadiusError, tripletRadius, rPhiChiSquared, rzChiSquared = 1e9f, rPhiChiSquaredInwards,
+                centerX = 0, centerY = 0;
             bool success = runPixelTripletDefaultAlgo(acc,
                                                       modulesInGPU,
                                                       rangesInGPU,
@@ -2258,6 +2260,8 @@ namespace SDL {
         angleM = -(absArctanSlope + 0.5f * float(M_PI));
       } else if (xs[i] > 0 and ys[i] < 0) {
         angleM = -(0.5f * float(M_PI) - absArctanSlope);
+      } else {
+        angleM = 0;
       }
       if (not isFlat[i]) {
         xPrime = xs[i] * alpaka::math::cos(acc, angleM) + ys[i] * alpaka::math::sin(acc, angleM);
@@ -2571,7 +2575,7 @@ namespace SDL {
 
     rzChiSquared = computePT5RZChiSquared(acc, modulesInGPU, lowerModuleIndices, rtPix, zPix, rts, zs);
 
-    if (pixelRadius < 5.0f * kR1GeVf) {
+    if (/*pixelRadius*/ 0 < 5.0f * kR1GeVf) { // FIXME: pixelRadius is not defined yet
       pass = pass and passPT5RZChiSquaredCuts(modulesInGPU,
                                               lowerModuleIndex1,
                                               lowerModuleIndex2,
@@ -2596,7 +2600,6 @@ namespace SDL {
                    mdsInGPU.anchorY[fifthMDIndex]};
 
     //get the appropriate radii and centers
-    centerX = segmentsInGPU.circleCenterX[1];
     centerX = segmentsInGPU.circleCenterX[pixelSegmentArrayIndex];
     centerY = segmentsInGPU.circleCenterY[pixelSegmentArrayIndex];
     pixelRadius = segmentsInGPU.circleRadius[pixelSegmentArrayIndex];

--- a/SDL/PixelTriplet.h
+++ b/SDL/PixelTriplet.h
@@ -1116,8 +1116,8 @@ namespace SDL {
             if (tripletsInGPU.partOfPT5[outerTripletIndex])
               continue;  //don't create pT3s for T3s accounted in pT5s
 
-            float pixelRadius, pixelRadiusError, tripletRadius, rPhiChiSquared, rzChiSquared = 1e9f, rPhiChiSquaredInwards,
-                centerX = 0, centerY = 0;
+            float pixelRadius, pixelRadiusError, tripletRadius, rPhiChiSquared,
+                rzChiSquared = 1e9f, rPhiChiSquaredInwards, centerX = 0, centerY = 0;
             bool success = runPixelTripletDefaultAlgo(acc,
                                                       modulesInGPU,
                                                       rangesInGPU,
@@ -2575,7 +2575,7 @@ namespace SDL {
 
     rzChiSquared = computePT5RZChiSquared(acc, modulesInGPU, lowerModuleIndices, rtPix, zPix, rts, zs);
 
-    if (/*pixelRadius*/ 0 < 5.0f * kR1GeVf) { // FIXME: pixelRadius is not defined yet
+    if (/*pixelRadius*/ 0 < 5.0f * kR1GeVf) {  // FIXME: pixelRadius is not defined yet
       pass = pass and passPT5RZChiSquaredCuts(modulesInGPU,
                                               lowerModuleIndex1,
                                               lowerModuleIndex2,

--- a/SDL/PixelTriplet.h
+++ b/SDL/PixelTriplet.h
@@ -1020,6 +1020,8 @@ namespace SDL {
              passPT3RZChiSquaredCuts(modulesInGPU, lowerModuleIndex, middleModuleIndex, upperModuleIndex, rzChiSquared);
       if (not pass)
         return pass;
+    } else {
+      rzChiSquared = -1;
     }
 
     rPhiChiSquared =
@@ -1042,6 +1044,8 @@ namespace SDL {
       if (not pass)
         return pass;
     }
+    centerX = 0;
+    centerY = 0;
     return pass;
   };
 
@@ -1116,8 +1120,8 @@ namespace SDL {
             if (tripletsInGPU.partOfPT5[outerTripletIndex])
               continue;  //don't create pT3s for T3s accounted in pT5s
 
-            float pixelRadius, pixelRadiusError, tripletRadius, rPhiChiSquared,
-                rzChiSquared = 1e9f, rPhiChiSquaredInwards, centerX = 0, centerY = 0;
+            float pixelRadius, pixelRadiusError, tripletRadius, rPhiChiSquared, rzChiSquared, rPhiChiSquaredInwards,
+                centerX, centerY;
             bool success = runPixelTripletDefaultAlgo(acc,
                                                       modulesInGPU,
                                                       rangesInGPU,

--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -469,8 +469,8 @@ namespace SDL {
     float Pz = (z_init - z1) / ds * Pt;
     float p = alpaka::math::sqrt(acc, Px * Px + Py * Py + Pz * Pz);
 
-    float B = SDL::magnetic_field;
-    float a = -0.299792 * B * charge;
+    float Bz = SDL::magnetic_field;
+    float a = -0.299792 * Bz * charge;
 
     float zsi, rtsi;
     int layeri, moduleTypei;
@@ -523,7 +523,7 @@ namespace SDL {
         float paraB = 2 * (x_init * Px + y_init * Py) / a;
         float paraC = 2 * (y_init * Px - x_init * Py) / a + 2 * (Px * Px + Py * Py) / (a * a);
         float A = paraB * paraB + paraC * paraC;
-        B = 2 * paraA * paraB;
+        float B = 2 * paraA * paraB;
         float C = paraA * paraA - paraC * paraC;
         float sol1 = (-B + alpaka::math::sqrt(acc, B * B - 4 * A * C)) / (2 * A);
         float sol2 = (-B - alpaka::math::sqrt(acc, B * B - 4 * A * C)) / (2 * A);
@@ -3015,12 +3015,8 @@ namespace SDL {
                                   struct SDL::quintuplets quintupletsInGPU,
                                   struct SDL::objectRanges rangesInGPU,
                                   uint16_t nEligibleT5Modules) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (int iter = globalThreadIdx[0]; iter < nEligibleT5Modules; iter += gridThreadExtent[0]) {
         uint16_t lowerModule1 = rangesInGPU.indicesOfEligibleT5Modules[iter];
@@ -3144,12 +3140,8 @@ namespace SDL {
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::triplets tripletsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       // Initialize variables in shared memory and set to 0
       int& nEligibleT5Modulesx = alpaka::declareSharedVar<int, __COUNTER__>(acc);
@@ -3246,12 +3238,8 @@ namespace SDL {
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::quintuplets quintupletsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2]) {
         if (quintupletsInGPU.nQuintuplets[i] == 0 or rangesInGPU.quintupletModuleIndices[i] == -1) {

--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -1334,6 +1334,7 @@ namespace SDL {
 #ifdef Warnings
       printf("FATAL! r^2 < 0!\n");
 #endif
+      chiSquared = -1;
       return -1;
     }
 
@@ -2760,6 +2761,8 @@ namespace SDL {
     pass = pass and passRZChi2;
     if (not pass)
       return pass;
+#else
+    rzChiSquared = -1;
 #endif
     pass = pass && (innerRadius >= 0.95f * ptCut / (2.f * k2Rinv1GeVf));
 

--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -1292,6 +1292,8 @@ namespace SDL {
         angleM = -(absArctanSlope + 0.5f * float(M_PI));
       } else if (xs[i] > 0 and ys[i] < 0) {
         angleM = -(0.5f * float(M_PI) - absArctanSlope);
+      } else {
+        angleM = 0;
       }
 
       if (not isFlat[i]) {
@@ -1373,6 +1375,8 @@ namespace SDL {
         angleM = -(absArctanSlope + 0.5f * float(M_PI));
       } else if (xs[i] > 0 and ys[i] < 0) {
         angleM = -(0.5f * float(M_PI) - absArctanSlope);
+      } else {
+        angleM = 0;
       }
 
       if (not isFlat[i]) {
@@ -3047,7 +3051,7 @@ namespace SDL {
             float innerRadius, outerRadius, bridgeRadius, regressionG, regressionF, regressionRadius, rzChiSquared,
                 chiSquared, nonAnchorChiSquared;  //required for making distributions
 
-            bool TightCutFlag;
+            bool TightCutFlag = false;
             bool success = runQuintupletDefaultAlgo(acc,
                                                     modulesInGPU,
                                                     mdsInGPU,

--- a/SDL/Segment.h
+++ b/SDL/Segment.h
@@ -796,14 +796,10 @@ namespace SDL {
                                   struct SDL::miniDoublets mdsInGPU,
                                   struct SDL::segments segmentsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalBlockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc);
-      Vec const blockThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
-      Vec const gridBlockExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
-      Vec const blockThreadExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
+      auto const globalBlockIdx = alpaka::getIdx<alpaka::Grid, alpaka::Blocks>(acc);
+      auto const blockThreadIdx = alpaka::getIdx<alpaka::Block, alpaka::Threads>(acc);
+      auto const gridBlockExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+      auto const blockThreadExtent = alpaka::getWorkDiv<alpaka::Block, alpaka::Threads>(acc);
 
       for (uint16_t innerLowerModuleIndex = globalBlockIdx[2]; innerLowerModuleIndex < (*modulesInGPU.nLowerModules);
            innerLowerModuleIndex += gridBlockExtent[2]) {
@@ -913,12 +909,8 @@ namespace SDL {
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::objectRanges rangesInGPU,
                                   struct SDL::miniDoublets mdsInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       // Initialize variables in shared memory and set to 0
       int& nTotalSegments = alpaka::declareSharedVar<int, __COUNTER__>(acc);
@@ -1015,12 +1007,8 @@ namespace SDL {
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::segments segmentsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2]) {
         if (segmentsInGPU.nSegments[i] == 0) {
@@ -1049,12 +1037,8 @@ namespace SDL {
                                   float* dPhiChange,
                                   uint16_t pixelModuleIndex,
                                   const int size) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (int tid = globalThreadIdx[2]; tid < size; tid += gridThreadExtent[2]) {
         unsigned int innerMDIndex = rangesInGPU.miniDoubletModuleIndices[pixelModuleIndex] + 2 * (tid);

--- a/SDL/TrackCandidate.h
+++ b/SDL/TrackCandidate.h
@@ -203,12 +203,8 @@ namespace SDL {
                                   struct SDL::pixelTriplets pixelTripletsInGPU,
                                   struct SDL::segments segmentsInGPU,
                                   struct SDL::pixelQuintuplets pixelQuintupletsInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       unsigned int nPixelTriplets = *pixelTripletsInGPU.nPixelTriplets;
       for (unsigned int pixelTripletIndex = globalThreadIdx[2]; pixelTripletIndex < nPixelTriplets;
@@ -248,12 +244,8 @@ namespace SDL {
                                   struct SDL::pixelQuintuplets pixelQuintupletsInGPU,
                                   struct SDL::pixelTriplets pixelTripletsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (int innerInnerInnerLowerModuleArrayIndex = globalThreadIdx[0];
            innerInnerInnerLowerModuleArrayIndex < *(modulesInGPU.nLowerModules);
@@ -312,12 +304,8 @@ namespace SDL {
                                   struct SDL::miniDoublets mdsInGPU,
                                   struct SDL::hits hitsInGPU,
                                   struct SDL::quintuplets quintupletsInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       int pixelModuleIndex = *modulesInGPU.nLowerModules;
       unsigned int nPixels = segmentsInGPU.nSegments[pixelModuleIndex];
@@ -394,12 +382,8 @@ namespace SDL {
                                   struct SDL::trackCandidates trackCandidatesInGPU,
                                   struct SDL::segments segmentsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       unsigned int nPixelTriplets = *pixelTripletsInGPU.nPixelTriplets;
       unsigned int pLS_offset = rangesInGPU.segmentModuleIndices[nLowerModules];
@@ -449,12 +433,8 @@ namespace SDL {
                                   struct SDL::quintuplets quintupletsInGPU,
                                   struct SDL::trackCandidates trackCandidatesInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (int idx = globalThreadIdx[1]; idx < nLowerModules; idx += gridThreadExtent[1]) {
         if (rangesInGPU.quintupletModuleIndices[idx] == -1)
@@ -506,12 +486,8 @@ namespace SDL {
                                   uint16_t nLowerModules,
                                   struct SDL::trackCandidates trackCandidatesInGPU,
                                   struct SDL::segments segmentsInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       unsigned int nPixels = segmentsInGPU.nSegments[nLowerModules];
       for (unsigned int pixelArrayIndex = globalThreadIdx[2]; pixelArrayIndex < nPixels;
@@ -554,12 +530,8 @@ namespace SDL {
                                   struct SDL::trackCandidates trackCandidatesInGPU,
                                   struct SDL::segments segmentsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       int nPixelQuintuplets = *pixelQuintupletsInGPU.nPixelQuintuplets;
       unsigned int pLS_offset = rangesInGPU.segmentModuleIndices[nLowerModules];

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -1903,12 +1903,8 @@ namespace SDL {
                                   struct SDL::objectRanges rangesInGPU,
                                   uint16_t* index_gpu,
                                   uint16_t nonZeroModules) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (uint16_t innerLowerModuleArrayIdx = globalThreadIdx[0]; innerLowerModuleArrayIdx < nonZeroModules;
            innerLowerModuleArrayIdx += gridThreadExtent[0]) {
@@ -2039,12 +2035,8 @@ namespace SDL {
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::objectRanges rangesInGPU,
                                   struct SDL::segments segmentsInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       // Initialize variables in shared memory and set to 0
       int& nTotalTriplets = alpaka::declareSharedVar<int, __COUNTER__>(acc);
@@ -2140,12 +2132,8 @@ namespace SDL {
                                   struct SDL::modules modulesInGPU,
                                   struct SDL::triplets tripletsInGPU,
                                   struct SDL::objectRanges rangesInGPU) const {
-      using Dim = alpaka::Dim<TAcc>;
-      using Idx = alpaka::Idx<TAcc>;
-      using Vec = alpaka::Vec<Dim, Idx>;
-
-      Vec const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
-      Vec const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
+      auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
+      auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       for (uint16_t i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2]) {
         if (tripletsInGPU.nTriplets[i] == 0) {


### PR DESCRIPTION
This attempts to address compilation warnings in SDL/

- shadowing
- `alpaka::memset` 3rd argument is a byte (uint8)
- maybe-initialized
- a few consts are added in function arguments (mostly incidental; not systematic)

I think there is a bug in `runPixelQuintupletDefaultAlgo`  where the cut on `passPT5RZChiSquaredCuts` looks like it needs to be applied only for pLS pt < 5 GeV, but it's apparently applied to all because pLS pt at that point of the code is not defined.