### PR TITLE
Fix race conditions in duplicate removal

### DIFF
--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -930,11 +930,8 @@ void SDL::Event<SDL::Acc>::createPixelTriplets() {
       createWorkDiv(blocksPerGridDupPixTrip, threadsPerBlockDupPixTrip, elementsPerThread);
 
   SDL::removeDupPixelTripletsInGPUFromMap removeDupPixelTripletsInGPUFromMap_kernel;
-  auto const removeDupPixelTripletsInGPUFromMapTask(
-      alpaka::createTaskKernel<Acc>(removeDupPixelTripletsInGPUFromMap_workDiv,
-                                    removeDupPixelTripletsInGPUFromMap_kernel,
-                                    *pixelTripletsInGPU,
-                                    false));
+  auto const removeDupPixelTripletsInGPUFromMapTask(alpaka::createTaskKernel<Acc>(
+      removeDupPixelTripletsInGPUFromMap_workDiv, removeDupPixelTripletsInGPUFromMap_kernel, *pixelTripletsInGPU));
 
   alpaka::enqueue(queue, removeDupPixelTripletsInGPUFromMapTask);
   alpaka::wait(queue);

--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -1158,8 +1158,7 @@ void SDL::Event<SDL::Acc>::createPixelQuintuplets() {
   auto const removeDupPixelQuintupletsInGPUFromMapTask(
       alpaka::createTaskKernel<Acc>(removeDupPixelQuintupletsInGPUFromMap_workDiv,
                                     removeDupPixelQuintupletsInGPUFromMap_kernel,
-                                    *pixelQuintupletsInGPU,
-                                    false));
+                                    *pixelQuintupletsInGPU));
 
   alpaka::enqueue(queue, removeDupPixelQuintupletsInGPUFromMapTask);
 

--- a/SDL/Kernels.h
+++ b/SDL/Kernels.h
@@ -325,9 +325,7 @@ namespace SDL {
 
   struct removeDupPixelTripletsInGPUFromMap {
     template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::pixelTriplets pixelTripletsInGPU,
-                                  bool secondPass) const {
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, struct SDL::pixelTriplets pixelTripletsInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 

--- a/SDL/Kernels.h
+++ b/SDL/Kernels.h
@@ -276,7 +276,7 @@ namespace SDL {
 
           for (unsigned int ix1 = 0; ix1 < nQuintuplets_lowmod1; ix1 += 1) {
             unsigned int ix = quintupletModuleIndices_lowmod1 + ix1;
-            if (quintupletsInGPU.partOfPT5[ix] || quintupletsInGPU.isDup[ix])
+            if (quintupletsInGPU.partOfPT5[ix])
               continue;
 
             for (unsigned int jx1 = 0; jx1 < nQuintuplets_lowmod2; jx1++) {
@@ -284,7 +284,7 @@ namespace SDL {
               if (ix == jx)
                 continue;
 
-              if (quintupletsInGPU.partOfPT5[jx] || quintupletsInGPU.isDup[jx])
+              if (quintupletsInGPU.partOfPT5[jx])
                 continue;
 
               float eta1 = __H2F(quintupletsInGPU.eta[ix]);
@@ -360,23 +360,15 @@ namespace SDL {
 
   struct removeDupPixelQuintupletsInGPUFromMap {
     template <typename TAcc>
-    ALPAKA_FN_ACC void operator()(TAcc const& acc,
-                                  struct SDL::pixelQuintuplets pixelQuintupletsInGPU,
-                                  bool secondPass) const {
+    ALPAKA_FN_ACC void operator()(TAcc const& acc, struct SDL::pixelQuintuplets pixelQuintupletsInGPU) const {
       auto const globalThreadIdx = alpaka::getIdx<alpaka::Grid, alpaka::Threads>(acc);
       auto const gridThreadExtent = alpaka::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
 
       unsigned int nPixelQuintuplets = *pixelQuintupletsInGPU.nPixelQuintuplets;
       for (unsigned int ix = globalThreadIdx[1]; ix < nPixelQuintuplets; ix += gridThreadExtent[1]) {
-        if (secondPass && pixelQuintupletsInGPU.isDup[ix])
-          continue;
-
         float score1 = __H2F(pixelQuintupletsInGPU.score[ix]);
         for (unsigned int jx = globalThreadIdx[2]; jx < nPixelQuintuplets; jx += gridThreadExtent[2]) {
           if (ix == jx)
-            continue;
-
-          if (secondPass && pixelQuintupletsInGPU.isDup[jx])
             continue;
 
           int nMatched = checkHitspT5(ix, jx, pixelQuintupletsInGPU);

--- a/SDL/Kernels.h
+++ b/SDL/Kernels.h
@@ -233,13 +233,8 @@ namespace SDL {
             if (nMatched >= 7) {
               if (score_rphisum1 > score_rphisum2) {
                 rmQuintupletFromMemory(quintupletsInGPU, ix);
-                continue;
               } else if ((score_rphisum1 == score_rphisum2) && (ix < jx)) {
                 rmQuintupletFromMemory(quintupletsInGPU, ix);
-                continue;
-              } else {
-                rmQuintupletFromMemory(quintupletsInGPU, jx);
-                continue;
               }
             }
           }


### PR DESCRIPTION
There were some minor race conditions during duplicate removal that were found by @YonsiG. The one in `removeDupPixelQuintupletsInGPUFromMap` didn't affect anything since it only happens for a second pass, but a second pass was never done. The one in `removeDupQuintupletsInGPUBeforeTC` was causing small run-to-run variations that were contributing to #265.

The change doesn't seem to have any effect on efficiency, but the fake rate and duplicate rate decrease a tiny bit. (these plots are from cpu runs for consistency)

<table>
<tr>
<td>
<img src=https://www.classe.cornell.edu/~ar2285/www/LST/PR387/PR387_cpu_comparison_fc97a6-PU200_09ce68-PU200/mtv/var/TC_base_0_0_eff_etacoarsezoom.png />
</td>
<td>
<img src=https://www.classe.cornell.edu/~ar2285/www/LST/PR387/PR387_cpu_comparison_fc97a6-PU200_09ce68-PU200/mtv/var/TC_fakerate_etacoarsezoom.png />
</td>
<td>
<img src=https://www.classe.cornell.edu/~ar2285/www/LST/PR387/PR387_cpu_comparison_fc97a6-PU200_09ce68-PU200/mtv/var/TC_duplrate_etacoarsezoom.png />
</td>
</tr>
</table>

The full set of comparison plots can be found [here](https://www.classe.cornell.edu/~ar2285/www/LST/PR387/PR387_cpu_comparison_fc97a6-PU200_09ce68-PU200/compare/).

I'll add some more plots below showing the improvement to #265.



