### PR TITLE
Fix pT3 and pT5 construction

### DIFF
--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -854,7 +854,7 @@ void SDL::Event<SDL::Acc>::createPixelTriplets() {
   int pixelIndexOffsetPos = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndex[44999] +
                             Globals<SDL::Dev>::pixelMapping->connectedPixelsSizes[44999];
   int pixelIndexOffsetNeg = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndexPos[44999] +
-                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizes[44999] + pixelIndexOffsetPos;
+                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizesPos[44999] + pixelIndexOffsetPos;
 
   // TODO: check if a map/reduction to just eligible pLSs would speed up the kernel
   // the current selection still leaves a significant fraction of unmatchable pLSs
@@ -1088,7 +1088,7 @@ void SDL::Event<SDL::Acc>::createPixelQuintuplets() {
   int pixelIndexOffsetPos = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndex[44999] +
                             Globals<SDL::Dev>::pixelMapping->connectedPixelsSizes[44999];
   int pixelIndexOffsetNeg = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndexPos[44999] +
-                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizes[44999] + pixelIndexOffsetPos;
+                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizesPos[44999] + pixelIndexOffsetPos;
 
   // Loop over # pLS
   for (unsigned int i = 0; i < nInnerSegments; i++) {

--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -862,7 +862,7 @@ void SDL::Event<SDL::Acc>::createPixelTriplets() {
   for (unsigned int i = 0; i < nInnerSegments; i++) {  // loop over # pLS
     int8_t pixelType = pixelTypes[i];                  // Get pixel type for this pLS
     int superbin = superbins[i];                       // Get superbin for this pixel
-    if ((superbin < 0) or (superbin >= size_superbins) or (pixelType > 2) or (pixelType < 0)) {
+    if ((superbin < 0) or (superbin >= (int)size_superbins) or (pixelType > 2) or (pixelType < 0)) {
       connectedPixelSize_host[i] = 0;
       connectedPixelIndex_host[i] = 0;
       continue;
@@ -1096,7 +1096,7 @@ void SDL::Event<SDL::Acc>::createPixelQuintuplets() {
   for (unsigned int i = 0; i < nInnerSegments; i++) {
     int8_t pixelType = pixelTypes[i];  // Get pixel type for this pLS
     int superbin = superbins[i];       // Get superbin for this pixel
-    if ((superbin < 0) or (superbin >= size_superbins) or (pixelType > 2) or (pixelType < 0)) {
+    if ((superbin < 0) or (superbin >= (int)size_superbins) or (pixelType > 2) or (pixelType < 0)) {
       connectedPixelIndex_host[i] = 0;
       connectedPixelSize_host[i] = 0;
       continue;

--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -851,17 +851,18 @@ void SDL::Event<SDL::Acc>::createPixelTriplets() {
   unsigned int* connectedPixelIndex_host = alpaka::getPtrNative(connectedPixelIndex_host_buf);
   alpaka::wait(queue);
 
-  int pixelIndexOffsetPos = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndex[44999] +
-                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizes[44999];
-  int pixelIndexOffsetNeg = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndexPos[44999] +
-                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizesPos[44999] + pixelIndexOffsetPos;
+  int pixelIndexOffsetPos = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndex[size_superbins - 1] +
+                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizes[size_superbins - 1];
+  int pixelIndexOffsetNeg = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndexPos[size_superbins - 1] +
+                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizesPos[size_superbins - 1] +
+                            pixelIndexOffsetPos;
 
   // TODO: check if a map/reduction to just eligible pLSs would speed up the kernel
   // the current selection still leaves a significant fraction of unmatchable pLSs
   for (unsigned int i = 0; i < nInnerSegments; i++) {  // loop over # pLS
     int8_t pixelType = pixelTypes[i];                  // Get pixel type for this pLS
     int superbin = superbins[i];                       // Get superbin for this pixel
-    if ((superbin < 0) or (superbin >= 45000) or (pixelType > 2) or (pixelType < 0)) {
+    if ((superbin < 0) or (superbin >= size_superbins) or (pixelType > 2) or (pixelType < 0)) {
       connectedPixelSize_host[i] = 0;
       connectedPixelIndex_host[i] = 0;
       continue;
@@ -1085,16 +1086,17 @@ void SDL::Event<SDL::Acc>::createPixelQuintuplets() {
   unsigned int* connectedPixelIndex_host = alpaka::getPtrNative(connectedPixelIndex_host_buf);
   alpaka::wait(queue);
 
-  int pixelIndexOffsetPos = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndex[44999] +
-                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizes[44999];
-  int pixelIndexOffsetNeg = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndexPos[44999] +
-                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizesPos[44999] + pixelIndexOffsetPos;
+  int pixelIndexOffsetPos = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndex[size_superbins - 1] +
+                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizes[size_superbins - 1];
+  int pixelIndexOffsetNeg = Globals<SDL::Dev>::pixelMapping->connectedPixelsIndexPos[size_superbins - 1] +
+                            Globals<SDL::Dev>::pixelMapping->connectedPixelsSizesPos[size_superbins - 1] +
+                            pixelIndexOffsetPos;
 
   // Loop over # pLS
   for (unsigned int i = 0; i < nInnerSegments; i++) {
     int8_t pixelType = pixelTypes[i];  // Get pixel type for this pLS
     int superbin = superbins[i];       // Get superbin for this pixel
-    if ((superbin < 0) or (superbin >= 45000) or (pixelType > 2) or (pixelType < 0)) {
+    if ((superbin < 0) or (superbin >= size_superbins) or (pixelType > 2) or (pixelType < 0)) {
       connectedPixelIndex_host[i] = 0;
       connectedPixelSize_host[i] = 0;
       continue;


### PR DESCRIPTION
I fixed the `pixelIndexOffsetNeg` variable, which was being set incorrectly causing duplicate pT3s and pT5s to be constructed. I also replaced hardcoded values of `size_superbins`.