### PR TITLE
Fix ROCm compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ ROOTCFLAGS  = $(foreach option, $(shell root-config --cflags), $(option))
 ALPAKAINCLUDE = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17 -DALPAKA_DEBUG=0
 ALPAKA_CPU = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 ALPAKA_CUDA = -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_HOST_ONLY
-ALPAKA_ROCM = -DALPAKA_ACC_GPU_HIP_ENABLED -DALPAKA_HOST_ONLY -DALPAKA_DISABLE_VENDOR_RNG
-CFLAGS      = $(ROOTCFLAGS)  -Wall  -Wno-unused-function  -g  -O2  -fPIC  -fno-var-tracking -ISDL -I$(shell pwd) -Icode  -Icode/core -I${CUDA_HOME}/include  -fopenmp
+ALPAKA_ROCM = -DALPAKA_ACC_GPU_HIP_ENABLED -DALPAKA_HOST_ONLY -DALPAKA_DISABLE_VENDOR_RNG -D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__
+CFLAGS      = $(ROOTCFLAGS)  -Wall  -Wno-unused-function  -g  -O2  -fPIC  -fno-var-tracking -ISDL -I$(shell pwd) -Icode  -Icode/core -I${CUDA_HOME}/include -I${ROCM_ROOT}/include -fopenmp
 EXTRACFLAGS = $(shell rooutil-config) -g
-EXTRAFLAGS  = -fPIC -ITMultiDrawTreePlayer -Wunused-variable -lTMVA -lEG -lGenVector -lXMLIO -lMLP -lTreePlayer -L${CUDA_HOME}/lib64 -lcudart -fopenmp
+EXTRAFLAGS  = -fPIC -ITMultiDrawTreePlayer -Wunused-variable -lTMVA -lEG -lGenVector -lXMLIO -lMLP -lTreePlayer -L${CUDA_HOME}/lib64 -lcudart -L${ROCM_ROOT}/lib -lamdhip64 -fopenmp
 DOQUINTUPLET = #-DFP16_Base
 PTCUTFLAG    =
 CUTVALUEFLAG = 

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,35 @@
-
 # Simple makefile
 
 EXES := bin/sdl_cpu bin/sdl_cuda
 
 SOURCES=$(wildcard code/core/*.cc)
-OBJECTS=$(SOURCES:.cc=.o)
 OBJECTS_CPU=$(SOURCES:.cc=_cpu.o)
 OBJECTS_CUDA=$(SOURCES:.cc=_cuda.o)
 OBJECTS_ROCM=$(SOURCES:.cc=_rocm.o)
-HEADERS=$(SOURCES:.cc=.h)
+OBJECTS=$(OBJECTS_CPU) $(OBJECTS_CUDA) $(OBJECTS_ROCM)
 
 CXX         = g++
-CXXFLAGS    = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual -lineinfo  -fopenmp -lgomp --default-stream per-thread
-LDFLAGS     = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual
-SOFLAGS     = -g -shared
-CXXFLAGS    = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual
-LDFLAGS     = -g -O2 $(SDLLIB) -L${TRACKLOOPERDIR}/SDL
-ROOTLIBS    = $(shell root-config --libs)
-ROOTCFLAGS  = $(foreach option, $(shell root-config --cflags), $(option))
-ALPAKAINCLUDE = -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include -std=c++17 -DALPAKA_DEBUG=0
-ALPAKA_CPU = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+CXXFLAGS    = -g -O2 -Wall -fPIC -Wshadow -Woverloaded-virtual -Wno-unused-function -fno-var-tracking -std=c++17
+INCLUDEFLAGS= -ISDL -I$(shell pwd) -Icode -Icode/core -I${ALPAKA_ROOT}/include -I/${BOOST_ROOT}/include $(shell rooutil-config --include) -I$(shell root-config --incdir)
+LDFLAGS     = -g -O2 $(SDLLIB) -L${TRACKLOOPERDIR}/SDL $(shell rooutil-config --libs) $(shell root-config --libs)
+LDFLAGS_CUDA= -L${CUDA_HOME}/lib64 -lcudart
+LDFLAGS_ROCM= -L${ROCM_ROOT}/lib -lamdhip64
+ALPAKAFLAGS = -DALPAKA_DEBUG=0
+CUDAINCLUDE = -I${CUDA_HOME}/include
+ROCMINCLUDE = -I${ROCM_ROOT}/include
+ALPAKA_CPU  = -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
 ALPAKA_CUDA = -DALPAKA_ACC_GPU_CUDA_ENABLED -DALPAKA_HOST_ONLY
 ALPAKA_ROCM = -DALPAKA_ACC_GPU_HIP_ENABLED -DALPAKA_HOST_ONLY -DALPAKA_DISABLE_VENDOR_RNG -D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__
-CFLAGS      = $(ROOTCFLAGS)  -Wall  -Wno-unused-function  -g  -O2  -fPIC  -fno-var-tracking -ISDL -I$(shell pwd) -Icode  -Icode/core -I${CUDA_HOME}/include -I${ROCM_ROOT}/include -fopenmp
-EXTRACFLAGS = $(shell rooutil-config) -g
-EXTRAFLAGS  = -fPIC -ITMultiDrawTreePlayer -Wunused-variable -lTMVA -lEG -lGenVector -lXMLIO -lMLP -lTreePlayer -L${CUDA_HOME}/lib64 -lcudart -L${ROCM_ROOT}/lib -lamdhip64 -fopenmp
-DOQUINTUPLET = #-DFP16_Base
+EXTRAFLAGS  = -ITMultiDrawTreePlayer -Wunused-variable -lTMVA -lEG -lGenVector -lXMLIO -lMLP -lTreePlayer -fopenmp
+DOQUINTUPLET =
 PTCUTFLAG    =
-CUTVALUEFLAG = 
+CUTVALUEFLAG =
 CUTVALUEFLAG_FLAGS = -DCUT_VALUE_DEBUG
 
 PRIMITIVEFLAG = 
 PRIMITIVEFLAG_FLAGS = -DPRIMITIVE_STUDY
 
 all: rooutil efficiency $(EXES)
-
 
 cutvalue: CUTVALUEFLAG = ${CUTVALUEFLAG_FLAGS}
 cutvalue: rooutil efficiency $(EXES)
@@ -46,25 +41,23 @@ cutvalue_primitive: CUTVALUEFLAG = ${CUTVALUEFLAG_FLAGS}
 cutvalue_primitive: PRIMITIVEFLAG = ${PRIMITIVEFLAG_FLAGS}
 cutvalue_primitive: rooutil efficiency $(EXES)
 
-bin/doAnalysis: bin/doAnalysis.o $(OBJECTS)
-	$(CXX) $(PTCUTFLAG) $(LDFLAGS) $^ $(ROOTLIBS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(EXTRAFLAGS) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_CPU) -o $@
 
 bin/sdl_cpu: SDLLIB=-lsdl_cpu
 bin/sdl_cpu: bin/sdl_cpu.o $(OBJECTS_CPU)
-	$(CXX) $(PTCUTFLAG) $(LDFLAGS) $^ $(ROOTLIBS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(EXTRAFLAGS) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_CPU) -o $@
+	$(CXX) $(LDFLAGS) $(EXTRAFLAGS) $(INCLUDEFLAGS) $(ALPAKAFLAGS) $^ $(ROOTLIBS) $(PTCUTFLAG) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKA_CPU) -o $@
 bin/sdl_cuda: SDLLIB=-lsdl_cuda
 bin/sdl_cuda: bin/sdl_cuda.o $(OBJECTS_CUDA)
-	$(CXX) $(PTCUTFLAG) $(LDFLAGS) $^ $(ROOTLIBS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(EXTRAFLAGS) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_CUDA) -o $@
+	$(CXX) $(LDFLAGS) $(EXTRAFLAGS) $(INCLUDEFLAGS) $(ALPAKAFLAGS) $^ $(ROOTLIBS) $(PTCUTFLAG) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKA_CUDA) $(LDFLAGS_CUDA) -o $@
 bin/sdl_rocm: SDLLIB=-lsdl_rocm
 bin/sdl_rocm: bin/sdl_rocm.o $(OBJECTS_ROCM)
-	$(CXX) $(PTCUTFLAG) $(LDFLAGS) $^ $(ROOTLIBS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(EXTRAFLAGS) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_ROCM) -o $@
+	$(CXX) $(LDFLAGS) $(EXTRAFLAGS) $(INCLUDEFLAGS) $(ALPAKAFLAGS) $^ $(ROOTLIBS) $(PTCUTFLAG) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKA_ROCM) $(LDFLAGS_ROCM) -o $@
 
 %_cpu.o: %.cc rooutil
-	$(CXX) $(PTCUTFLAG) $(CFLAGS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_CPU) $< -c -o $@
+	$(CXX) $(CXXFLAGS) $(EXTRAFLAGS) $(INCLUDEFLAGS) $(ALPAKAFLAGS) $(PTCUTFLAG) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKA_CPU) $< -c -o $@
 %_cuda.o: %.cc rooutil
-	$(CXX) $(PTCUTFLAG) $(CFLAGS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_CUDA) $< -c -o $@
+	$(CXX) $(CXXFLAGS) $(EXTRAFLAGS) $(INCLUDEFLAGS) $(ALPAKAFLAGS) $(PTCUTFLAG) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKA_CUDA) $(CUDAINCLUDE) $< -c -o $@
 %_rocm.o: %.cc rooutil
-	$(CXX) $(PTCUTFLAG) $(CFLAGS) $(EXTRACFLAGS) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKAINCLUDE) $(ALPAKA_ROCM) $< -c -o $@
+	$(CXX) $(CXXFLAGS) $(EXTRAFLAGS) $(INCLUDEFLAGS) $(ALPAKAFLAGS) $(PTCUTFLAG) $(CUTVALUEFLAG) $(PRIMITIVEFLAG) $(DOQUINTUPLET) $(ALPAKA_ROCM) $(ROCMINCLUDE) $< -c -o $@
 
 rooutil:
 	$(MAKE) -C code/rooutil/

--- a/bin/sdl_make_tracklooper
+++ b/bin/sdl_make_tracklooper
@@ -255,6 +255,10 @@ elif ([[ "$BACKENDOPT" == *"all"* ]] || [[ "$BACKENDOPT" == *"cuda"* ]]) && [ ! 
   echo "ERROR: bin/sdl_cuda failed to compile!" | tee -a ${LOG}
   echo "See ${LOG} file for more detail..." | tee -a ${LOG}
   exit 1
+elif ([[ "$BACKENDOPT" == *"all"* ]] || [[ "$BACKENDOPT" == *"rocm"* ]]) && [ ! -f bin/sdl_rocm ]; then
+  echo "ERROR: bin/sdl_rocm failed to compile!" | tee -a ${LOG}
+  echo "See ${LOG} file for more detail..." | tee -a ${LOG}
+  exit 1
 fi
 
 # Make a symlink with priority CUDA > CPU > ROCM


### PR DESCRIPTION
@slava77 found that in #381 there was an issue with the makefile causing `sdl_rocm` to fail to compile. I also found that `sdl_make_tracklooper` was not checking if this file was generated, which is probably why I missed this issue when working on #381.