### PR TITLE
T3 remove redundant new

### DIFF
--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -1670,7 +1670,6 @@ SDL::tripletsBuffer<alpaka::DevCpu>* SDL::Event<SDL::Acc>::getTriplets() {
     alpaka::memcpy(queue, tripletsInCPU->betaInCut_buf, tripletsBuffers->betaInCut_buf, nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->rtLo_buf, tripletsBuffers->rtLo_buf, nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->rtHi_buf, tripletsBuffers->rtHi_buf, nMemHost);
-    alpaka::memcpy(queue, tripletsInCPU->kZ_buf, tripletsBuffers->kZ_buf, nMemHost);
 #endif
     alpaka::memcpy(queue, tripletsInCPU->hitIndices_buf, tripletsBuffers->hitIndices_buf, 6 * nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->logicalLayers_buf, tripletsBuffers->logicalLayers_buf, 3 * nMemHost);

--- a/SDL/Event.cc
+++ b/SDL/Event.cc
@@ -1668,8 +1668,6 @@ SDL::tripletsBuffer<alpaka::DevCpu>* SDL::Event<SDL::Acc>::getTriplets() {
     alpaka::memcpy(queue, tripletsInCPU->zHiPointed_buf, tripletsBuffers->zHiPointed_buf, nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->sdlCut_buf, tripletsBuffers->sdlCut_buf, nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->betaInCut_buf, tripletsBuffers->betaInCut_buf, nMemHost);
-    alpaka::memcpy(queue, tripletsInCPU->betaOutCut_buf, tripletsBuffers->betaOutCut_buf, nMemHost);
-    alpaka::memcpy(queue, tripletsInCPU->deltaBetaCut_buf, tripletsBuffers->deltaBetaCut_buf, nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->rtLo_buf, tripletsBuffers->rtLo_buf, nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->rtHi_buf, tripletsBuffers->rtHi_buf, nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->kZ_buf, tripletsBuffers->kZ_buf, nMemHost);
@@ -1678,8 +1676,6 @@ SDL::tripletsBuffer<alpaka::DevCpu>* SDL::Event<SDL::Acc>::getTriplets() {
     alpaka::memcpy(queue, tripletsInCPU->logicalLayers_buf, tripletsBuffers->logicalLayers_buf, 3 * nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->segmentIndices_buf, tripletsBuffers->segmentIndices_buf, 2 * nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->betaIn_buf, tripletsBuffers->betaIn_buf, nMemHost);
-    alpaka::memcpy(queue, tripletsInCPU->betaOut_buf, tripletsBuffers->betaOut_buf, nMemHost);
-    alpaka::memcpy(queue, tripletsInCPU->pt_beta_buf, tripletsBuffers->pt_beta_buf, nMemHost);
     alpaka::memcpy(queue, tripletsInCPU->nTriplets_buf, tripletsBuffers->nTriplets_buf);
     alpaka::memcpy(queue, tripletsInCPU->totOccupancyTriplets_buf, tripletsBuffers->totOccupancyTriplets_buf);
     alpaka::wait(queue);

--- a/SDL/Event.h
+++ b/SDL/Event.h
@@ -179,9 +179,7 @@ namespace SDL {
     modulesBuffer<alpaka::DevCpu>* getModules(bool isFull = false);
 
     //read from file and init
-    static void initModules(QueueAcc& queue,
-                            const MapPLStoLayer& pLStoLayer,
-                            const char* moduleMetaDataFilePath);
+    static void initModules(QueueAcc& queue, const MapPLStoLayer& pLStoLayer, const char* moduleMetaDataFilePath);
   };
 
 }  // namespace SDL

--- a/SDL/PixelTriplet.h
+++ b/SDL/PixelTriplet.h
@@ -942,9 +942,9 @@ namespace SDL {
     float ys[3] = {mdsInGPU.anchorY[firstMDIndex], mdsInGPU.anchorY[secondMDIndex], mdsInGPU.anchorY[thirdMDIndex]};
 
     float g, f;
-    tripletRadius = tripletsInGPU.Circle_Radius[tripletIndex];
-    g = tripletsInGPU.Circle_CenterX[tripletIndex];
-    f = tripletsInGPU.Circle_CenterY[tripletIndex];
+    tripletRadius = tripletsInGPU.circleRadius[tripletIndex];
+    g = tripletsInGPU.circleCenterX[tripletIndex];
+    f = tripletsInGPU.circleCenterY[tripletIndex];
 
     pass = pass and passRadiusCriterion(acc,
                                         modulesInGPU,

--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -744,41 +744,6 @@ namespace SDL {
   };
 
   template <typename TAcc>
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE float computeRadiusFromThreeAnchorHits(
-      TAcc const& acc, float x1, float y1, float x2, float y2, float x3, float y3, float& g, float& f) {
-    float radius = 0.f;
-
-    //writing manual code for computing radius, which obviously sucks
-    //TODO:Use fancy inbuilt libraries like cuBLAS or cuSOLVE for this!
-    //(g,f) -> center
-    //first anchor hit - (x1,y1), second anchor hit - (x2,y2), third anchor hit - (x3, y3)
-
-    float denomInv = 1.0f / ((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3));
-
-    float xy1sqr = x1 * x1 + y1 * y1;
-
-    float xy2sqr = x2 * x2 + y2 * y2;
-
-    float xy3sqr = x3 * x3 + y3 * y3;
-
-    g = 0.5f * ((y3 - y2) * xy1sqr + (y1 - y3) * xy2sqr + (y2 - y1) * xy3sqr) * denomInv;
-
-    f = 0.5f * ((x2 - x3) * xy1sqr + (x3 - x1) * xy2sqr + (x1 - x2) * xy3sqr) * denomInv;
-
-    float c = ((x2 * y3 - x3 * y2) * xy1sqr + (x3 * y1 - x1 * y3) * xy2sqr + (x1 * y2 - x2 * y1) * xy3sqr) * denomInv;
-
-    if (((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3) == 0) || (g * g + f * f - c < 0)) {
-#ifdef Warnings
-      printf("three collinear points or FATAL! r^2 < 0!\n");
-#endif
-      radius = -1.f;
-    } else
-      radius = alpaka::math::sqrt(acc, g * g + f * f - c);
-
-    return radius;
-  };
-
-  template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void computeErrorInRadius(TAcc const& acc,
                                                            float* x1Vec,
                                                            float* y1Vec,
@@ -2732,9 +2697,11 @@ namespace SDL {
     computeErrorInRadius(acc, x3Vec, y3Vec, x1Vec, y1Vec, x2Vec, y2Vec, outerRadiusMin2S, outerRadiusMax2S);
 
     float g, f;
-    outerRadius = computeRadiusFromThreeAnchorHits(acc, x3, y3, x4, y4, x5, y5, g, f);
+    outerRadius = tripletsInGPU.Circle_Radius[outerTripletIndex];
     bridgeRadius = computeRadiusFromThreeAnchorHits(acc, x2, y2, x3, y3, x4, y4, g, f);
-    innerRadius = computeRadiusFromThreeAnchorHits(acc, x1, y1, x2, y2, x3, y3, g, f);
+    innerRadius = tripletsInGPU.Circle_Radius[innerTripletIndex];
+    g = tripletsInGPU.Circle_CenterX[innerTripletIndex];
+    f = tripletsInGPU.Circle_CenterY[innerTripletIndex];
 
 #ifdef USE_RZCHI2
     float inner_pt = 2 * k2Rinv1GeVf * innerRadius;

--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -2697,11 +2697,11 @@ namespace SDL {
     computeErrorInRadius(acc, x3Vec, y3Vec, x1Vec, y1Vec, x2Vec, y2Vec, outerRadiusMin2S, outerRadiusMax2S);
 
     float g, f;
-    outerRadius = tripletsInGPU.Circle_Radius[outerTripletIndex];
+    outerRadius = tripletsInGPU.circleRadius[outerTripletIndex];
     bridgeRadius = computeRadiusFromThreeAnchorHits(acc, x2, y2, x3, y3, x4, y4, g, f);
-    innerRadius = tripletsInGPU.Circle_Radius[innerTripletIndex];
-    g = tripletsInGPU.Circle_CenterX[innerTripletIndex];
-    f = tripletsInGPU.Circle_CenterY[innerTripletIndex];
+    innerRadius = tripletsInGPU.circleRadius[innerTripletIndex];
+    g = tripletsInGPU.circleCenterX[innerTripletIndex];
+    f = tripletsInGPU.circleCenterY[innerTripletIndex];
 
 #ifdef USE_RZCHI2
     float inner_pt = 2 * k2Rinv1GeVf * innerRadius;

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -195,9 +195,9 @@ namespace SDL {
     tripletsInGPU.lowerModuleIndices[tripletIndex * 3 + 2] = outerOuterLowerModuleIndex;
 
     tripletsInGPU.betaIn[tripletIndex] = __F2H(betaIn);
-    tripletsInGPU.circleRadius[tripletIndex] = __F2H(circleRadius);
-    tripletsInGPU.circleCenterX[tripletIndex] = __F2H(circleCenterX);
-    tripletsInGPU.circleCenterY[tripletIndex] = __F2H(circleCenterY);
+    tripletsInGPU.circleRadius[tripletIndex] = circleRadius;
+    tripletsInGPU.circleCenterX[tripletIndex] = circleCenterX;
+    tripletsInGPU.circleCenterY[tripletIndex] = circleCenterY;
     tripletsInGPU.logicalLayers[tripletIndex * 3] =
         modulesInGPU.layers[innerInnerLowerModuleIndex] + (modulesInGPU.subdets[innerInnerLowerModuleIndex] == 4) * 6;
     tripletsInGPU.logicalLayers[tripletIndex * 3 + 1] =

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -912,62 +912,6 @@ namespace SDL {
 
     //Cut #6: first beta cut
     pass = pass and (alpaka::math::abs(acc, betaInRHmin) < betaInCut);
-    if (not pass)
-      return pass;
-
-    float betaAv = 0.5f * (betaIn + betaOut);
-    pt_beta = dr * SDL::k2Rinv1GeVf / alpaka::math::sin(acc, betaAv);
-
-    float lIn = 5;
-    float lOut = 11;
-
-    float sdOut_dr = alpaka::math::sqrt(acc,
-                                        (mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex]) *
-                                                (mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex]) +
-                                            (mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]) *
-                                                (mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]));
-    float sdOut_d = mdsInGPU.anchorRt[fourthMDIndex] - mdsInGPU.anchorRt[thirdMDIndex];
-
-    runDeltaBetaIterationsT3(acc, betaIn, betaOut, betaAv, pt_beta, sdIn_dr, sdOut_dr, dr, lIn);
-
-    const float betaInMMSF = (alpaka::math::abs(acc, betaInRHmin + betaInRHmax) > 0)
-                                 ? (2.f * betaIn / alpaka::math::abs(acc, betaInRHmin + betaInRHmax))
-                                 : 0.;  //mean value of min,max is the old betaIn
-    const float betaOutMMSF = (alpaka::math::abs(acc, betaOutRHmin + betaOutRHmax) > 0)
-                                  ? (2.f * betaOut / alpaka::math::abs(acc, betaOutRHmin + betaOutRHmax))
-                                  : 0.;
-    betaInRHmin *= betaInMMSF;
-    betaInRHmax *= betaInMMSF;
-    betaOutRHmin *= betaOutMMSF;
-    betaOutRHmax *= betaOutMMSF;
-
-    const float dBetaMuls =
-        sdlThetaMulsF * 4.f /
-        alpaka::math::min(
-            acc, alpaka::math::abs(acc, pt_beta), SDL::pt_betaMax);  //need to confirm the range-out value of 7 GeV
-
-    const float alphaInAbsReg = alpaka::math::max(
-        acc,
-        alpaka::math::abs(acc, sdIn_alpha),
-        alpaka::math::asin(acc, alpaka::math::min(acc, rt_InLo * SDL::k2Rinv1GeVf / 3.0f, SDL::sinAlphaMax)));
-    const float alphaOutAbsReg = alpaka::math::max(
-        acc,
-        alpaka::math::abs(acc, sdOut_alpha),
-        alpaka::math::asin(acc, alpaka::math::min(acc, rt_OutLo * SDL::k2Rinv1GeVf / 3.0f, SDL::sinAlphaMax)));
-    const float dBetaInLum = lIn < 11 ? 0.0f : alpaka::math::abs(acc, alphaInAbsReg * SDL::deltaZLum / z_InLo);
-    const float dBetaOutLum = lOut < 11 ? 0.0f : alpaka::math::abs(acc, alphaOutAbsReg * SDL::deltaZLum / z_OutLo);
-    const float dBetaLum2 = (dBetaInLum + dBetaOutLum) * (dBetaInLum + dBetaOutLum);
-
-//    const float dBetaROut2 = dBetaROut * dBetaROut;
-    betaOutCut =
-        alpaka::math::asin(
-            acc,
-            alpaka::math::min(acc, dr * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax))  //FIXME: need faster version
-        + (0.02f / sdOut_d) + alpaka::math::sqrt(acc, dBetaLum2 + dBetaMuls * dBetaMuls);
-
-    //Cut #6: The real beta cut
-//    pass = pass and (alpaka::math::abs(acc, betaOut) < betaOutCut);
-
     return pass;
   };
 

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -492,19 +492,6 @@ namespace SDL {
     float rt_InOut = mdsInGPU.anchorRt[secondMDIndex];
 
     float sdIn_alpha = __H2F(segmentsInGPU.dPhiChanges[innerSegmentIndex]);
-    float sdIn_alpha_min = __H2F(segmentsInGPU.dPhiChangeMins[innerSegmentIndex]);
-    float sdIn_alpha_max = __H2F(segmentsInGPU.dPhiChangeMaxs[innerSegmentIndex]);
-
-    float sdOut_alphaOut = SDL::phi_mpi_pi(acc,
-                                           SDL::phi(acc,
-                                                    mdsInGPU.anchorX[thirdMDIndex] - mdsInGPU.anchorX[secondMDIndex],
-                                                    mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[secondMDIndex]) -
-                                               mdsInGPU.anchorPhi[thirdMDIndex]);
-
-    float sdOut_alphaOut_min = SDL::phi_mpi_pi(
-        acc, __H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMins[outerSegmentIndex]));
-    float sdOut_alphaOut_max = SDL::phi_mpi_pi(
-        acc, __H2F(segmentsInGPU.dPhiChangeMaxs[outerSegmentIndex]) - __H2F(segmentsInGPU.dPhiMaxs[outerSegmentIndex]));
 
     float tl_axis_x = mdsInGPU.anchorX[thirdMDIndex] - mdsInGPU.anchorX[firstMDIndex];
     float tl_axis_y = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
@@ -513,29 +500,8 @@ namespace SDL {
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    float betaOut =
-        -sdOut_alphaOut + SDL::phi_mpi_pi(acc, SDL::phi(acc, tl_axis_x, tl_axis_y) - mdsInGPU.anchorPhi[thirdMDIndex]);
-
-    float betaOutRHmin = betaOut;
-    float betaOutRHmax = betaOut;
-
-    bool isEC_secondLayer = (modulesInGPU.subdets[innerOuterLowerModuleIndex] == SDL::Endcap) and
-                            (modulesInGPU.moduleType[innerOuterLowerModuleIndex] == SDL::TwoS);
-
-    if (isEC_secondLayer) {
-      betaInRHmin = betaIn - sdIn_alpha_min + sdIn_alpha;
-      betaInRHmax = betaIn - sdIn_alpha_max + sdIn_alpha;
-    }
-
-    betaOutRHmin = betaOut - sdOut_alphaOut_min + sdOut_alphaOut;
-    betaOutRHmax = betaOut - sdOut_alphaOut_max + sdOut_alphaOut;
 
     float swapTemp;
-    if (alpaka::math::abs(acc, betaOutRHmin) > alpaka::math::abs(acc, betaOutRHmax)) {
-      swapTemp = betaOutRHmin;
-      betaOutRHmin = betaOutRHmax;
-      betaOutRHmax = swapTemp;
-    }
 
     if (alpaka::math::abs(acc, betaInRHmin) > alpaka::math::abs(acc, betaInRHmax)) {
       swapTemp = betaInRHmin;
@@ -654,15 +620,6 @@ namespace SDL {
     float rt_InLo = mdsInGPU.anchorRt[firstMDIndex];
     float rt_InOut = mdsInGPU.anchorRt[secondMDIndex];
     float sdIn_alpha = __H2F(segmentsInGPU.dPhiChanges[innerSegmentIndex]);
-    float sdOut_dPhiPos = SDL::phi_mpi_pi(acc, mdsInGPU.anchorPhi[thirdMDIndex] - mdsInGPU.anchorPhi[secondMDIndex]);
-
-    float sdOut_dPhiChange = __H2F(segmentsInGPU.dPhiChanges[outerSegmentIndex]);
-    float sdOut_dPhiChange_min = __H2F(segmentsInGPU.dPhiChangeMins[outerSegmentIndex]);
-    float sdOut_dPhiChange_max = __H2F(segmentsInGPU.dPhiChangeMaxs[outerSegmentIndex]);
-
-    float sdOut_alphaOutRHmin = SDL::phi_mpi_pi(acc, sdOut_dPhiChange_min - sdOut_dPhiPos);
-    float sdOut_alphaOutRHmax = SDL::phi_mpi_pi(acc, sdOut_dPhiChange_max - sdOut_dPhiPos);
-    float sdOut_alphaOut = SDL::phi_mpi_pi(acc, sdOut_dPhiChange - sdOut_dPhiPos);
 
     float tl_axis_x = mdsInGPU.anchorX[thirdMDIndex] - mdsInGPU.anchorX[firstMDIndex];
     float tl_axis_y = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];
@@ -674,18 +631,7 @@ namespace SDL {
     float betaInRHmin = betaIn + sdIn_alphaRHmin - sdIn_alpha;
     float betaInRHmax = betaIn + sdIn_alphaRHmax - sdIn_alpha;
 
-    float betaOut =
-        -sdOut_alphaOut + SDL::phi_mpi_pi(acc, SDL::phi(acc, tl_axis_x, tl_axis_y) - mdsInGPU.anchorPhi[thirdMDIndex]);
-
-    float betaOutRHmin = betaOut - sdOut_alphaOutRHmin + sdOut_alphaOut;
-    float betaOutRHmax = betaOut - sdOut_alphaOutRHmax + sdOut_alphaOut;
-
     float swapTemp;
-    if (alpaka::math::abs(acc, betaOutRHmin) > alpaka::math::abs(acc, betaOutRHmax)) {
-      swapTemp = betaOutRHmin;
-      betaOutRHmin = betaOutRHmax;
-      betaOutRHmax = swapTemp;
-    }
 
     if (alpaka::math::abs(acc, betaInRHmin) > alpaka::math::abs(acc, betaInRHmax)) {
       swapTemp = betaInRHmin;

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -377,7 +377,6 @@ namespace SDL {
     //beta computation
     float drt_tl_axis = alpaka::math::sqrt(acc, tl_axis_x * tl_axis_x + tl_axis_y * tl_axis_y);
 
-    float corrF = 1.f;
     //innerOuterAnchor - innerInnerAnchor
     const float rt_InSeg =
         alpaka::math::sqrt(acc,
@@ -388,7 +387,7 @@ namespace SDL {
     betaInCut = alpaka::math::asin(
                     acc,
                     alpaka::math::min(
-                        acc, (-rt_InSeg * corrF + drt_tl_axis) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
+                        acc, (-rt_InSeg + drt_tl_axis) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
                 (0.02f / drt_InSeg);
 
     //Cut #3: first beta cut

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -81,7 +81,7 @@ namespace SDL {
     Buf<TDev, unsigned int> nMemoryLocations_buf;
     Buf<TDev, uint8_t> logicalLayers_buf;
     Buf<TDev, unsigned int> hitIndices_buf;
-    Buf<TDev, float> betaIn_buf;
+    Buf<TDev, FPX> betaIn_buf;
     Buf<TDev, float> circleRadius_buf;
     Buf<TDev, float> circleCenterX_buf;
     Buf<TDev, float> circleCenterY_buf;

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -516,10 +516,9 @@ namespace SDL {
     float sdIn_d = rt_InOut - rt_InLo;
 
     float dr = alpaka::math::sqrt(acc, tl_axis_x * tl_axis_x + tl_axis_y * tl_axis_y);
-    const float corrF = 1.f;
     betaInCut =
         alpaka::math::asin(
-            acc, alpaka::math::min(acc, (-sdIn_dr * corrF + dr) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
+            acc, alpaka::math::min(acc, (-sdIn_dr + dr) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
         (0.02f / sdIn_d);
 
     //Cut #4: first beta cut

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -522,7 +522,7 @@ namespace SDL {
             acc, alpaka::math::min(acc, (-sdIn_dr * corrF + dr) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
         (0.02f / sdIn_d);
 
-    //Cut #6: first beta cut
+    //Cut #4: first beta cut
     pass = pass and (alpaka::math::abs(acc, betaInRHmin) < betaInCut);
     return pass;
   };

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -665,7 +665,8 @@ namespace SDL {
     float alpha_InLo = __H2F(segmentsInGPU.dPhiChanges[innerSegmentIndex]);
     float tl_axis_x = mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[firstMDIndex];
     float tl_axis_y = mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[firstMDIndex];
-    float betaInRHmin = alpha_InLo - SDL::phi_mpi_pi(acc, SDL::phi(acc, tl_axis_x, tl_axis_y) - mdsInGPU.anchorPhi[firstMDIndex]);
+    float betaInRHmin =
+        alpha_InLo - SDL::phi_mpi_pi(acc, SDL::phi(acc, tl_axis_x, tl_axis_y) - mdsInGPU.anchorPhi[firstMDIndex]);
 
     //beta computation
     float drt_tl_axis = alpaka::math::sqrt(acc, tl_axis_x * tl_axis_x + tl_axis_y * tl_axis_y);
@@ -878,7 +879,6 @@ namespace SDL {
     //Cut #6: first beta cut
     pass = pass and (alpaka::math::abs(acc, betaInRHmin) < betaInCut);
     return pass;
-
   };
 
   template <typename TAcc>

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -390,8 +390,7 @@ namespace SDL {
                         acc, (-rt_InSeg * corrF + drt_tl_axis) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
                 (0.02f / drt_InSeg);
 
-    //Cut #5: first beta cut
-    //-5
+    //Cut #3: first beta cut
     pass = pass and (alpaka::math::abs(acc, betaInRHmin) < betaInCut);
 
     return pass;

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -16,7 +16,7 @@ namespace SDL {
     unsigned int* nMemoryLocations;
     uint8_t* logicalLayers;
     unsigned int* hitIndices;
-    float* betaIn;
+    FPX* betaIn;
     float* circleRadius;
     float* circleCenterX;
     float* circleCenterY;

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -959,15 +959,7 @@ namespace SDL {
 
     float rt_InLo = mdsInGPU.anchorRt[firstMDIndex];
     float rt_InOut = mdsInGPU.anchorRt[secondMDIndex];
-    float rt_OutLo = mdsInGPU.anchorRt[thirdMDIndex];
-
-    float z_InLo = mdsInGPU.anchorZ[firstMDIndex];
-    float z_OutLo = mdsInGPU.anchorZ[thirdMDIndex];
-
-    float sdlThetaMulsF = 0.015f * alpaka::math::sqrt(acc, 0.1f + 0.2f * (rt_OutLo - rt_InLo) / 50.f);
-
     float sdIn_alpha = __H2F(segmentsInGPU.dPhiChanges[innerSegmentIndex]);
-    float sdOut_alpha = sdIn_alpha;  //weird
     float sdOut_dPhiPos = SDL::phi_mpi_pi(acc, mdsInGPU.anchorPhi[fourthMDIndex] - mdsInGPU.anchorPhi[thirdMDIndex]);
 
     float sdOut_dPhiChange = __H2F(segmentsInGPU.dPhiChanges[outerSegmentIndex]);
@@ -1022,79 +1014,8 @@ namespace SDL {
 
     //Cut #6: first beta cut
     pass = pass and (alpaka::math::abs(acc, betaInRHmin) < betaInCut);
-    if (not pass)
-      return pass;
-
-    float betaAv = 0.5f * (betaIn + betaOut);
-    pt_beta = dr * SDL::k2Rinv1GeVf / alpaka::math::sin(acc, betaAv);
-
-    int lIn = 11;   //endcap
-    int lOut = 13;  //endcap
-
-    float sdOut_dr = alpaka::math::sqrt(acc,
-                                        (mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex]) *
-                                                (mdsInGPU.anchorX[fourthMDIndex] - mdsInGPU.anchorX[thirdMDIndex]) +
-                                            (mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]) *
-                                                (mdsInGPU.anchorY[fourthMDIndex] - mdsInGPU.anchorY[thirdMDIndex]));
-    float sdOut_d = mdsInGPU.anchorRt[fourthMDIndex] - mdsInGPU.anchorRt[thirdMDIndex];
-
-    runDeltaBetaIterationsT3(acc, betaIn, betaOut, betaAv, pt_beta, sdIn_dr, sdOut_dr, dr, lIn);
-
-    const float betaInMMSF = (alpaka::math::abs(acc, betaInRHmin + betaInRHmax) > 0)
-                                 ? (2.f * betaIn / alpaka::math::abs(acc, betaInRHmin + betaInRHmax))
-                                 : 0.;  //mean value of min,max is the old betaIn
-    const float betaOutMMSF = (alpaka::math::abs(acc, betaOutRHmin + betaOutRHmax) > 0)
-                                  ? (2.f * betaOut / alpaka::math::abs(acc, betaOutRHmin + betaOutRHmax))
-                                  : 0.;
-    betaInRHmin *= betaInMMSF;
-    betaInRHmax *= betaInMMSF;
-    betaOutRHmin *= betaOutMMSF;
-    betaOutRHmax *= betaOutMMSF;
-
-    const float dBetaMuls =
-        sdlThetaMulsF * 4.f /
-        alpaka::math::min(
-            acc, alpaka::math::abs(acc, pt_beta), SDL::pt_betaMax);  //need to confirm the range-out value of 7 GeV
-
-    const float alphaInAbsReg = alpaka::math::max(
-        acc,
-        alpaka::math::abs(acc, sdIn_alpha),
-        alpaka::math::asin(acc, alpaka::math::min(acc, rt_InLo * SDL::k2Rinv1GeVf / 3.0f, SDL::sinAlphaMax)));
-    const float alphaOutAbsReg = alpaka::math::max(
-        acc,
-        alpaka::math::abs(acc, sdOut_alpha),
-        alpaka::math::asin(acc, alpaka::math::min(acc, rt_OutLo * SDL::k2Rinv1GeVf / 3.0f, SDL::sinAlphaMax)));
-    const float dBetaInLum = lIn < 11 ? 0.0f : alpaka::math::abs(acc, alphaInAbsReg * SDL::deltaZLum / z_InLo);
-    const float dBetaOutLum = lOut < 11 ? 0.0f : alpaka::math::abs(acc, alphaOutAbsReg * SDL::deltaZLum / z_OutLo);
-    const float dBetaLum2 = (dBetaInLum + dBetaOutLum) * (dBetaInLum + dBetaOutLum);
-
-    const float dBetaRIn2 = 0;  // TODO-RH
-    // const float dBetaROut2 = 0; // TODO-RH
-    float dBetaROut2 = 0;  //TODO-RH
-    betaOutCut =
-        alpaka::math::asin(
-            acc,
-            alpaka::math::min(acc, dr * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax))  //FIXME: need faster version
-        + (0.02f / sdOut_d) + alpaka::math::sqrt(acc, dBetaLum2 + dBetaMuls * dBetaMuls);
-
-    //Cut #6: The real beta cut
-    pass = pass and (alpaka::math::abs(acc, betaOut) < betaOutCut);
-    if (not pass)
-      return pass;
-
-    float dBetaRes = 0.02f / alpaka::math::min(acc, sdOut_d, sdIn_d);
-    float dBetaCut2 =
-        (dBetaRes * dBetaRes * 2.0f + dBetaMuls * dBetaMuls + dBetaLum2 + dBetaRIn2 + dBetaROut2 +
-         0.25f *
-             (alpaka::math::abs(acc, betaInRHmin - betaInRHmax) + alpaka::math::abs(acc, betaOutRHmin - betaOutRHmax)) *
-             (alpaka::math::abs(acc, betaInRHmin - betaInRHmax) + alpaka::math::abs(acc, betaOutRHmin - betaOutRHmax)));
-    float dBeta = betaIn - betaOut;
-    //Cut #7: Cut on dBeta
-    deltaBetaCut = alpaka::math::sqrt(acc, dBetaCut2);
-
-    pass = pass and (dBeta * dBeta <= dBetaCut2);
-
     return pass;
+
   };
 
   template <typename TAcc>

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -384,11 +384,10 @@ namespace SDL {
                                    (mdsInGPU.anchorX[secondMDIndex] - mdsInGPU.anchorX[firstMDIndex]) +
                                (mdsInGPU.anchorY[secondMDIndex] - mdsInGPU.anchorY[firstMDIndex]) *
                                    (mdsInGPU.anchorY[secondMDIndex] - mdsInGPU.anchorY[firstMDIndex]));
-    betaInCut = alpaka::math::asin(
-                    acc,
-                    alpaka::math::min(
-                        acc, (-rt_InSeg + drt_tl_axis) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
-                (0.02f / drt_InSeg);
+    betaInCut =
+        alpaka::math::asin(
+            acc, alpaka::math::min(acc, (-rt_InSeg + drt_tl_axis) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
+        (0.02f / drt_InSeg);
 
     //Cut #3: first beta cut
     pass = pass and (alpaka::math::abs(acc, betaInRHmin) < betaInCut);
@@ -516,10 +515,9 @@ namespace SDL {
     float sdIn_d = rt_InOut - rt_InLo;
 
     float dr = alpaka::math::sqrt(acc, tl_axis_x * tl_axis_x + tl_axis_y * tl_axis_y);
-    betaInCut =
-        alpaka::math::asin(
-            acc, alpaka::math::min(acc, (-sdIn_dr + dr) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
-        (0.02f / sdIn_d);
+    betaInCut = alpaka::math::asin(
+                    acc, alpaka::math::min(acc, (-sdIn_dr + dr) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
+                (0.02f / sdIn_d);
 
     //Cut #4: first beta cut
     pass = pass and (alpaka::math::abs(acc, betaInRHmin) < betaInCut);
@@ -644,11 +642,9 @@ namespace SDL {
     float sdIn_d = rt_InOut - rt_InLo;
 
     float dr = alpaka::math::sqrt(acc, tl_axis_x * tl_axis_x + tl_axis_y * tl_axis_y);
-    const float corrF = 1.f;
-    betaInCut =
-        alpaka::math::asin(
-            acc, alpaka::math::min(acc, (-sdIn_dr * corrF + dr) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
-        (0.02f / sdIn_d);
+    betaInCut = alpaka::math::asin(
+                    acc, alpaka::math::min(acc, (-sdIn_dr + dr) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
+                (0.02f / sdIn_d);
 
     //Cut #4: first beta cut
     pass = pass and (alpaka::math::abs(acc, betaInRHmin) < betaInCut);

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -367,7 +367,7 @@ namespace SDL {
     // Cut #2: Pointed Z (Inner segment two MD points to outer segment inner MD)
     pass = pass and ((zOut >= zLoPointed) && (zOut <= zHiPointed));
 
-    // First obtaining the raw betaIn and betaOut values without any correction and just purely based on the mini-doublet hit positions
+    // raw betaIn value without any correction, based on the mini-doublet hit positions
     float alpha_InLo = __H2F(segmentsInGPU.dPhiChanges[innerSegmentIndex]);
     float tl_axis_x = mdsInGPU.anchorX[thirdMDIndex] - mdsInGPU.anchorX[firstMDIndex];
     float tl_axis_y = mdsInGPU.anchorY[thirdMDIndex] - mdsInGPU.anchorY[firstMDIndex];

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -113,7 +113,7 @@ namespace SDL {
           nMemoryLocations_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
           logicalLayers_buf(allocBufWrapper<uint8_t>(devAccIn, maxTriplets * 3, queue)),
           hitIndices_buf(allocBufWrapper<unsigned int>(devAccIn, maxTriplets * 6, queue)),
-          betaIn_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
+          betaIn_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
           circleRadius_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           circleCenterX_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           circleCenterY_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -650,7 +650,7 @@ namespace SDL {
             acc, alpaka::math::min(acc, (-sdIn_dr * corrF + dr) * SDL::k2Rinv1GeVf / SDL::ptCut, SDL::sinAlphaMax)) +
         (0.02f / sdIn_d);
 
-    //Cut #6: first beta cut
+    //Cut #4: first beta cut
     pass = pass and (alpaka::math::abs(acc, betaInRHmin) < betaInCut);
     return pass;
   };

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -16,10 +16,10 @@ namespace SDL {
     unsigned int* nMemoryLocations;
     uint8_t* logicalLayers;
     unsigned int* hitIndices;
-    FPX* betaIn;
-    FPX* circleRadius;
-    FPX* circleCenterX;
-    FPX* circleCenterY;
+    float* betaIn;
+    float* circleRadius;
+    float* circleCenterX;
+    float* circleCenterY;
     bool* partOfPT5;
     bool* partOfT5;
     bool* partOfPT3;
@@ -81,10 +81,10 @@ namespace SDL {
     Buf<TDev, unsigned int> nMemoryLocations_buf;
     Buf<TDev, uint8_t> logicalLayers_buf;
     Buf<TDev, unsigned int> hitIndices_buf;
-    Buf<TDev, FPX> betaIn_buf;
-    Buf<TDev, FPX> circleRadius_buf;
-    Buf<TDev, FPX> circleCenterX_buf;
-    Buf<TDev, FPX> circleCenterY_buf;
+    Buf<TDev, float> betaIn_buf;
+    Buf<TDev, float> circleRadius_buf;
+    Buf<TDev, float> circleCenterX_buf;
+    Buf<TDev, float> circleCenterY_buf;
     Buf<TDev, bool> partOfPT5_buf;
     Buf<TDev, bool> partOfT5_buf;
     Buf<TDev, bool> partOfPT3_buf;
@@ -113,10 +113,10 @@ namespace SDL {
           nMemoryLocations_buf(allocBufWrapper<unsigned int>(devAccIn, 1, queue)),
           logicalLayers_buf(allocBufWrapper<uint8_t>(devAccIn, maxTriplets * 3, queue)),
           hitIndices_buf(allocBufWrapper<unsigned int>(devAccIn, maxTriplets * 6, queue)),
-          betaIn_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
-          circleRadius_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
-          circleCenterX_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
-          circleCenterY_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
+          betaIn_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
+          circleRadius_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
+          circleCenterX_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
+          circleCenterY_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           partOfPT5_buf(allocBufWrapper<bool>(devAccIn, maxTriplets, queue)),
           partOfT5_buf(allocBufWrapper<bool>(devAccIn, maxTriplets, queue)),
           partOfPT3_buf(allocBufWrapper<bool>(devAccIn, maxTriplets, queue))

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -169,7 +169,8 @@ namespace SDL {
                                                          float& zLoPointed,
                                                          float& zHiPointed,
                                                          float& sdlCut,
-                                                         float& betaInCut unsigned int& tripletIndex)
+                                                         float& betaInCut,
+                                                         unsigned int& tripletIndex)
 #else
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addTripletToMemory(struct SDL::modules& modulesInGPU,
                                                          struct SDL::miniDoublets& mdsInGPU,

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -873,8 +873,7 @@ namespace SDL {
                                                                    float& zLoPointed,
                                                                    float& zHiPointed,
                                                                    float& sdlCut,
-                                                                   float& betaInCut,
-                                                                   float& kZ) {
+                                                                   float& betaInCut) {
     bool pass = true;
 
     //this cut reduces the number of candidates by a factor of 4, i.e., 3 out of 4 warps can end right here!

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -16,13 +16,10 @@ namespace SDL {
     unsigned int* nMemoryLocations;
     uint8_t* logicalLayers;
     unsigned int* hitIndices;
-    //delta beta = betaIn - betaOut
     FPX* betaIn;
-    FPX* betaOut;
-    FPX* pt_beta;
-    FPX* Circle_Radius;
-    FPX* Circle_CenterX;
-    FPX* Circle_CenterY;
+    FPX* circleRadius;
+    FPX* circleCenterX;
+    FPX* circleCenterY;
     bool* partOfPT5;
     bool* partOfT5;
     bool* partOfPT3;
@@ -39,8 +36,6 @@ namespace SDL {
     float* zHiPointed;
     float* sdlCut;
     float* betaInCut;
-    float* betaOutCut;
-    float* deltaBetaCut;
     float* rtLo;
     float* rtHi;
     float* kZ;
@@ -55,11 +50,9 @@ namespace SDL {
       logicalLayers = alpaka::getPtrNative(tripletsbuf.logicalLayers_buf);
       hitIndices = alpaka::getPtrNative(tripletsbuf.hitIndices_buf);
       betaIn = alpaka::getPtrNative(tripletsbuf.betaIn_buf);
-      betaOut = alpaka::getPtrNative(tripletsbuf.betaOut_buf);
-      pt_beta = alpaka::getPtrNative(tripletsbuf.pt_beta_buf);
-      Circle_Radius = alpaka::getPtrNative(tripletsbuf.Circle_Radius_buf);
-      Circle_CenterX = alpaka::getPtrNative(tripletsbuf.Circle_CenterX_buf);
-      Circle_CenterY = alpaka::getPtrNative(tripletsbuf.Circle_CenterY_buf);
+      circleRadius = alpaka::getPtrNative(tripletsbuf.circleRadius_buf);
+      circleCenterX = alpaka::getPtrNative(tripletsbuf.circleCenterX_buf);
+      circleCenterY = alpaka::getPtrNative(tripletsbuf.circleCenterY_buf);
       partOfPT5 = alpaka::getPtrNative(tripletsbuf.partOfPT5_buf);
       partOfT5 = alpaka::getPtrNative(tripletsbuf.partOfT5_buf);
       partOfPT3 = alpaka::getPtrNative(tripletsbuf.partOfPT3_buf);
@@ -74,8 +67,6 @@ namespace SDL {
       zHiPointed = alpaka::getPtrNative(tripletsbuf.zHiPointed_buf);
       sdlCut = alpaka::getPtrNative(tripletsbuf.sdlCut_buf);
       betaInCut = alpaka::getPtrNative(tripletsbuf.betaInCut_buf);
-      betaOutCut = alpaka::getPtrNative(tripletsbuf.betaOutCut_buf);
-      deltaBetaCut = alpaka::getPtrNative(tripletsbuf.deltaBetaCut_buf);
       rtLo = alpaka::getPtrNative(tripletsbuf.rtLo_buf);
       rtHi = alpaka::getPtrNative(tripletsbuf.rtHi_buf);
       kZ = alpaka::getPtrNative(tripletsbuf.kZ_buf);
@@ -93,11 +84,9 @@ namespace SDL {
     Buf<TDev, uint8_t> logicalLayers_buf;
     Buf<TDev, unsigned int> hitIndices_buf;
     Buf<TDev, FPX> betaIn_buf;
-    Buf<TDev, FPX> betaOut_buf;
-    Buf<TDev, FPX> pt_beta_buf;
-    Buf<TDev, FPX> Circle_Radius_buf;
-    Buf<TDev, FPX> Circle_CenterX_buf;
-    Buf<TDev, FPX> Circle_CenterY_buf;
+    Buf<TDev, FPX> circleRadius_buf;
+    Buf<TDev, FPX> circleCenterX_buf;
+    Buf<TDev, FPX> circleCenterY_buf;
     Buf<TDev, bool> partOfPT5_buf;
     Buf<TDev, bool> partOfT5_buf;
     Buf<TDev, bool> partOfPT3_buf;
@@ -113,8 +102,6 @@ namespace SDL {
     Buf<TDev, float> zHiPointed_buf;
     Buf<TDev, float> sdlCut_buf;
     Buf<TDev, float> betaInCut_buf;
-    Buf<TDev, float> betaOutCut_buf;
-    Buf<TDev, float> deltaBetaCut_buf;
     Buf<TDev, float> rtLo_buf;
     Buf<TDev, float> rtHi_buf;
     Buf<TDev, float> kZ_buf;
@@ -130,11 +117,9 @@ namespace SDL {
           logicalLayers_buf(allocBufWrapper<uint8_t>(devAccIn, maxTriplets * 3, queue)),
           hitIndices_buf(allocBufWrapper<unsigned int>(devAccIn, maxTriplets * 6, queue)),
           betaIn_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
-          betaOut_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
-          pt_beta_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
-          Circle_Radius_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
-          Circle_CenterX_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
-          Circle_CenterY_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
+          circleRadius_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
+          circleCenterX_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
+          circleCenterY_buf(allocBufWrapper<FPX>(devAccIn, maxTriplets, queue)),
           partOfPT5_buf(allocBufWrapper<bool>(devAccIn, maxTriplets, queue)),
           partOfT5_buf(allocBufWrapper<bool>(devAccIn, maxTriplets, queue)),
           partOfPT3_buf(allocBufWrapper<bool>(devAccIn, maxTriplets, queue))
@@ -150,8 +135,6 @@ namespace SDL {
           zHiPointed_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           sdlCut_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           betaInCut_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
-          betaOutCut_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
-          deltaBetaCut_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           rtLo_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           rtHi_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           kZ_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue))
@@ -180,11 +163,9 @@ namespace SDL {
                                                          float& deltaPhiPos,
                                                          float& deltaPhi,
                                                          float& betaIn,
-                                                         float& betaOut,
-                                                         float& pt_beta,
-                                                         float& Circle_Radius,
-                                                         float& Circle_CenterX,
-                                                         float& Circle_CenterY,
+                                                         float& circleRadius,
+                                                         float& circleCenterX,
+                                                         float& circleCenterY,
                                                          float& zLo,
                                                          float& zHi,
                                                          float& rtLo,
@@ -193,8 +174,6 @@ namespace SDL {
                                                          float& zHiPointed,
                                                          float& sdlCut,
                                                          float& betaInCut,
-                                                         float& betaOutCut,
-                                                         float& deltaBetaCut,
                                                          float& kZ,
                                                          unsigned int& tripletIndex)
 #else
@@ -208,11 +187,9 @@ namespace SDL {
                                                          uint16_t& middleLowerModuleIndex,
                                                          uint16_t& outerOuterLowerModuleIndex,
                                                          float& betaIn,
-                                                         float& betaOut,
-                                                         float& pt_beta,
-                                                         float& Circle_Radius,
-                                                         float& Circle_CenterX,
-                                                         float& Circle_CenterY,
+                                                         float& circleRadius,
+                                                         float& circleCenterX,
+                                                         float& circleCenterY,
                                                          unsigned int& tripletIndex)
 #endif
   {
@@ -223,11 +200,9 @@ namespace SDL {
     tripletsInGPU.lowerModuleIndices[tripletIndex * 3 + 2] = outerOuterLowerModuleIndex;
 
     tripletsInGPU.betaIn[tripletIndex] = __F2H(betaIn);
-    tripletsInGPU.betaOut[tripletIndex] = __F2H(betaOut);
-    tripletsInGPU.pt_beta[tripletIndex] = __F2H(pt_beta);
-    tripletsInGPU.Circle_Radius[tripletIndex] = __F2H(Circle_Radius);
-    tripletsInGPU.Circle_CenterX[tripletIndex] = __F2H(Circle_CenterX);
-    tripletsInGPU.Circle_CenterY[tripletIndex] = __F2H(Circle_CenterY);
+    tripletsInGPU.circleRadius[tripletIndex] = __F2H(circleRadius);
+    tripletsInGPU.circleCenterX[tripletIndex] = __F2H(circleCenterX);
+    tripletsInGPU.circleCenterY[tripletIndex] = __F2H(circleCenterY);
     tripletsInGPU.logicalLayers[tripletIndex * 3] =
         modulesInGPU.layers[innerInnerLowerModuleIndex] + (modulesInGPU.subdets[innerInnerLowerModuleIndex] == 4) * 6;
     tripletsInGPU.logicalLayers[tripletIndex * 3 + 1] =
@@ -258,8 +233,6 @@ namespace SDL {
     tripletsInGPU.zHiPointed[tripletIndex] = zHiPointed;
     tripletsInGPU.sdlCut[tripletIndex] = sdlCut;
     tripletsInGPU.betaInCut[tripletIndex] = betaInCut;
-    tripletsInGPU.betaOutCut[tripletIndex] = betaOutCut;
-    tripletsInGPU.deltaBetaCut[tripletIndex] = deltaBetaCut;
     tripletsInGPU.kZ[tripletIndex] = kZ;
 #endif
   };
@@ -658,104 +631,6 @@ namespace SDL {
   };
 
   template <typename TAcc>
-  ALPAKA_FN_ACC ALPAKA_FN_INLINE void runDeltaBetaIterationsT3(TAcc const& acc,
-                                                               float& betaIn,
-                                                               float& betaOut,
-                                                               float& betaAv,
-                                                               float& pt_beta,
-                                                               float sdIn_dr,
-                                                               float sdOut_dr,
-                                                               float dr,
-                                                               float lIn) {
-    if (lIn == 0) {
-      betaOut += copysign(
-          alpaka::math::asin(
-              acc,
-              alpaka::math::min(acc, sdOut_dr * SDL::k2Rinv1GeVf / alpaka::math::abs(acc, pt_beta), SDL::sinAlphaMax)),
-          betaOut);
-      return;
-    }
-
-    if (betaIn * betaOut > 0.f and
-        (alpaka::math::abs(acc, pt_beta) < 4.f * SDL::pt_betaMax or
-         (lIn >= 11 and alpaka::math::abs(acc, pt_beta) <
-                            8.f * SDL::pt_betaMax)))  //and the pt_beta is well-defined; less strict for endcap-endcap
-    {
-      const float betaInUpd =
-          betaIn +
-          SDL::copysignf(alpaka::math::asin(
-                             acc,
-                             alpaka::math::min(
-                                 acc, sdIn_dr * SDL::k2Rinv1GeVf / alpaka::math::abs(acc, pt_beta), SDL::sinAlphaMax)),
-                         betaIn);  //FIXME: need a faster version
-      const float betaOutUpd =
-          betaOut +
-          SDL::copysignf(alpaka::math::asin(
-                             acc,
-                             alpaka::math::min(
-                                 acc, sdOut_dr * SDL::k2Rinv1GeVf / alpaka::math::abs(acc, pt_beta), SDL::sinAlphaMax)),
-                         betaOut);  //FIXME: need a faster version
-      betaAv = 0.5f * (betaInUpd + betaOutUpd);
-
-      //1st update
-      //pt_beta = dr * k2Rinv1GeVf / alpaka::math::sin(acc, betaAv); //get a better pt estimate
-      const float pt_beta_inv =
-          1.f / alpaka::math::abs(acc, dr * k2Rinv1GeVf / alpaka::math::sin(acc, betaAv));  //get a better pt estimate
-
-      betaIn += SDL::copysignf(
-          alpaka::math::asin(acc, alpaka::math::min(acc, sdIn_dr * SDL::k2Rinv1GeVf * pt_beta_inv, SDL::sinAlphaMax)),
-          betaIn);  //FIXME: need a faster version
-      betaOut += SDL::copysignf(
-          alpaka::math::asin(acc, alpaka::math::min(acc, sdOut_dr * SDL::k2Rinv1GeVf * pt_beta_inv, SDL::sinAlphaMax)),
-          betaOut);  //FIXME: need a faster version
-      //update the av and pt
-      betaAv = 0.5f * (betaIn + betaOut);
-      //2nd update
-      pt_beta = dr * SDL::k2Rinv1GeVf / alpaka::math::sin(acc, betaAv);  //get a better pt estimate
-    } else if (lIn < 11 && alpaka::math::abs(acc, betaOut) < 0.2f * alpaka::math::abs(acc, betaIn) &&
-               alpaka::math::abs(acc, pt_beta) < 12.f * SDL::pt_betaMax)  //use betaIn sign as ref
-    {
-      const float pt_betaIn = dr * k2Rinv1GeVf / alpaka::math::sin(acc, betaIn);
-
-      const float betaInUpd =
-          betaIn + SDL::copysignf(
-                       alpaka::math::asin(
-                           acc,
-                           alpaka::math::min(
-                               acc, sdIn_dr * SDL::k2Rinv1GeVf / alpaka::math::abs(acc, pt_betaIn), SDL::sinAlphaMax)),
-                       betaIn);  //FIXME: need a faster version
-      const float betaOutUpd =
-          betaOut +
-          SDL::copysignf(
-              alpaka::math::asin(
-                  acc,
-                  alpaka::math::min(
-                      acc, sdOut_dr * SDL::k2Rinv1GeVf / alpaka::math::abs(acc, pt_betaIn), SDL::sinAlphaMax)),
-              betaIn);  //FIXME: need a faster version
-      betaAv = (alpaka::math::abs(acc, betaOut) > 0.2f * alpaka::math::abs(acc, betaIn))
-                   ? (0.5f * (betaInUpd + betaOutUpd))
-                   : betaInUpd;
-
-      //1st update
-      pt_beta = dr * SDL::k2Rinv1GeVf / alpaka::math::sin(acc, betaAv);  //get a better pt estimate
-      betaIn += SDL::copysignf(
-          alpaka::math::asin(
-              acc,
-              alpaka::math::min(acc, sdIn_dr * SDL::k2Rinv1GeVf / alpaka::math::abs(acc, pt_beta), SDL::sinAlphaMax)),
-          betaIn);  //FIXME: need a faster version
-      betaOut += SDL::copysignf(
-          alpaka::math::asin(
-              acc,
-              alpaka::math::min(acc, sdOut_dr * SDL::k2Rinv1GeVf / alpaka::math::abs(acc, pt_beta), SDL::sinAlphaMax)),
-          betaIn);  //FIXME: need a faster version
-      //update the av and pt
-      betaAv = 0.5f * (betaIn + betaOut);
-      //2nd update
-      pt_beta = dr * SDL::k2Rinv1GeVf / alpaka::math::sin(acc, betaAv);  //get a better pt estimate
-    }
-  };
-
-  template <typename TAcc>
   ALPAKA_FN_ACC ALPAKA_FN_INLINE bool runTripletDefaultAlgoBBBB(TAcc const& acc,
                                                                 struct SDL::modules& modulesInGPU,
                                                                 struct SDL::miniDoublets& mdsInGPU,
@@ -775,16 +650,12 @@ namespace SDL {
                                                                 float& deltaPhiPos,
                                                                 float& dPhi,
                                                                 float& betaIn,
-                                                                float& betaOut,
-                                                                float& pt_beta,
                                                                 float& zLo,
                                                                 float& zHi,
                                                                 float& zLoPointed,
                                                                 float& zHiPointed,
                                                                 float& sdlCut,
-                                                                float& betaInCut,
-                                                                float& betaOutCut,
-                                                                float& deltaBetaCut) {
+                                                                float& betaInCut) {
     bool pass = true;
     float rt_InLo = mdsInGPU.anchorRt[firstMDIndex];
     float rt_InOut = mdsInGPU.anchorRt[secondMDIndex];
@@ -839,15 +710,11 @@ namespace SDL {
                                                                 float& deltaPhiPos,
                                                                 float& dPhi,
                                                                 float& betaIn,
-                                                                float& betaOut,
-                                                                float& pt_beta,
                                                                 float& zLo,
                                                                 float& rtLo,
                                                                 float& rtHi,
                                                                 float& sdlCut,
                                                                 float& betaInCut,
-                                                                float& betaOutCut,
-                                                                float& deltaBetaCut,
                                                                 float& kZ) {
     bool pass = true;
 
@@ -876,7 +743,7 @@ namespace SDL {
 
     float betaInRHmin = betaIn;
     float betaInRHmax = betaIn;
-    betaOut =
+    float betaOut =
         -sdOut_alphaOut + SDL::phi_mpi_pi(acc, SDL::phi(acc, tl_axis_x, tl_axis_y) - mdsInGPU.anchorPhi[fourthMDIndex]);
 
     float betaOutRHmin = betaOut;
@@ -945,15 +812,11 @@ namespace SDL {
                                                                 float& deltaPhiPos,
                                                                 float& dPhi,
                                                                 float& betaIn,
-                                                                float& betaOut,
-                                                                float& pt_beta,
                                                                 float& zLo,
                                                                 float& rtLo,
                                                                 float& rtHi,
                                                                 float& sdlCut,
                                                                 float& betaInCut,
-                                                                float& betaOutCut,
-                                                                float& deltaBetaCut,
                                                                 float& kZ) {
     bool pass = true;
 
@@ -980,7 +843,7 @@ namespace SDL {
     float betaInRHmin = betaIn + sdIn_alphaRHmin - sdIn_alpha;
     float betaInRHmax = betaIn + sdIn_alphaRHmax - sdIn_alpha;
 
-    betaOut =
+    float betaOut =
         -sdOut_alphaOut + SDL::phi_mpi_pi(acc, SDL::phi(acc, tl_axis_x, tl_axis_y) - mdsInGPU.anchorPhi[fourthMDIndex]);
 
     float betaOutRHmin = betaOut - sdOut_alphaOutRHmin + sdOut_alphaOut;
@@ -1073,8 +936,6 @@ namespace SDL {
                                                             float& deltaPhiPos,
                                                             float& deltaPhi,
                                                             float& betaIn,
-                                                            float& betaOut,
-                                                            float& pt_beta,
                                                             float& zLo,
                                                             float& zHi,
                                                             float& rtLo,
@@ -1083,8 +944,6 @@ namespace SDL {
                                                             float& zHiPointed,
                                                             float& sdlCut,
                                                             float& betaInCut,
-                                                            float& betaOutCut,
-                                                            float& deltaBetaCut,
                                                             float& kZ) {
     bool pass = false;
 
@@ -1123,16 +982,12 @@ namespace SDL {
                                        deltaPhiPos,
                                        deltaPhi,
                                        betaIn,
-                                       betaOut,
-                                       pt_beta,
                                        zLo,
                                        zHi,
                                        zLoPointed,
                                        zHiPointed,
                                        sdlCut,
-                                       betaInCut,
-                                       betaOutCut,
-                                       deltaBetaCut);
+                                       betaInCut);
     }
 
     else if (innerInnerLowerModuleSubdet == SDL::Barrel and innerOuterLowerModuleSubdet == SDL::Barrel and
@@ -1156,16 +1011,12 @@ namespace SDL {
                                        deltaPhiPos,
                                        deltaPhi,
                                        betaIn,
-                                       betaOut,
-                                       pt_beta,
                                        zLo,
                                        zHi,
                                        zLoPointed,
                                        zHiPointed,
                                        sdlCut,
-                                       betaInCut,
-                                       betaOutCut,
-                                       deltaBetaCut);
+                                       betaInCut);
 
     }
 
@@ -1190,15 +1041,11 @@ namespace SDL {
                                        deltaPhiPos,
                                        deltaPhi,
                                        betaIn,
-                                       betaOut,
-                                       pt_beta,
                                        zLo,
                                        rtLo,
                                        rtHi,
                                        sdlCut,
                                        betaInCut,
-                                       betaOutCut,
-                                       deltaBetaCut,
                                        kZ);
 
     }
@@ -1224,15 +1071,11 @@ namespace SDL {
                                        deltaPhiPos,
                                        deltaPhi,
                                        betaIn,
-                                       betaOut,
-                                       pt_beta,
                                        zLo,
                                        rtLo,
                                        rtHi,
                                        sdlCut,
                                        betaInCut,
-                                       betaOutCut,
-                                       deltaBetaCut,
                                        kZ);
     }
 
@@ -1254,11 +1097,9 @@ namespace SDL {
                                                                    float& deltaPhiPos,
                                                                    float& deltaPhi,
                                                                    float& betaIn,
-                                                                   float& betaOut,
-                                                                   float& pt_beta,
-                                                                   float& Circle_Radius,
-                                                                   float& Circle_CenterX,
-                                                                   float& Circle_CenterY,
+                                                                   float& circleRadius,
+                                                                   float& circleCenterX,
+                                                                   float& circleCenterY,
                                                                    float& zLo,
                                                                    float& zHi,
                                                                    float& rtLo,
@@ -1267,8 +1108,6 @@ namespace SDL {
                                                                    float& zHiPointed,
                                                                    float& sdlCut,
                                                                    float& betaInCut,
-                                                                   float& betaOutCut,
-                                                                   float& deltaBetaCut,
                                                                    float& kZ) {
     bool pass = true;
 
@@ -1325,8 +1164,6 @@ namespace SDL {
                                            deltaPhiPos,
                                            deltaPhi,
                                            betaIn,
-                                           betaOut,
-                                           pt_beta,
                                            zLo,
                                            zHi,
                                            rtLo,
@@ -1335,8 +1172,6 @@ namespace SDL {
                                            zHiPointed,
                                            sdlCut,
                                            betaInCut,
-                                           betaOutCut,
-                                           deltaBetaCut,
                                            kZ));
 
     float x1 = mdsInGPU.anchorX[firstMDIndex];
@@ -1346,8 +1181,7 @@ namespace SDL {
     float y2 = mdsInGPU.anchorY[secondMDIndex];
     float y3 = mdsInGPU.anchorY[thirdMDIndex];
 
-    Circle_Radius = computeRadiusFromThreeAnchorHits(acc, x1, y1, x2, y2, x3, y3, Circle_CenterX, Circle_CenterY);
-    pt_beta = Circle_Radius * SDL::k2Rinv1GeVf * 2;
+    circleRadius = computeRadiusFromThreeAnchorHits(acc, x1, y1, x2, y2, x3, y3, circleCenterX, circleCenterY);
     return pass;
   };
 
@@ -1391,8 +1225,8 @@ namespace SDL {
 
             uint16_t outerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[outerSegmentIndex];
 
-            float zOut, rtOut, deltaPhiPos, deltaPhi, betaIn, betaOut, pt_beta, Circle_Radius, Circle_CenterX, Circle_CenterY;
-            float zLo, zHi, rtLo, rtHi, zLoPointed, zHiPointed, sdlCut, betaInCut, betaOutCut, deltaBetaCut, kZ;
+            float zOut, rtOut, deltaPhiPos, deltaPhi, betaIn, circleRadius, circleCenterX, circleCenterY;
+            float zLo, zHi, rtLo, rtHi, zLoPointed, zHiPointed, sdlCut, betaInCut, kZ;
 
             bool success = runTripletConstraintsAndAlgo(acc,
                                                         modulesInGPU,
@@ -1408,11 +1242,9 @@ namespace SDL {
                                                         deltaPhiPos,
                                                         deltaPhi,
                                                         betaIn,
-                                                        betaOut,
-                                                        pt_beta,
-                                                        Circle_Radius,
-                                                        Circle_CenterX,
-                                                        Circle_CenterY,
+                                                        circleRadius,
+                                                        circleCenterX,
+                                                        circleCenterY,
                                                         zLo,
                                                         zHi,
                                                         rtLo,
@@ -1421,8 +1253,6 @@ namespace SDL {
                                                         zHiPointed,
                                                         sdlCut,
                                                         betaInCut,
-                                                        betaOutCut,
-                                                        deltaBetaCut,
                                                         kZ);
 
             if (success) {
@@ -1453,11 +1283,9 @@ namespace SDL {
                                    deltaPhiPos,
                                    deltaPhi,
                                    betaIn,
-                                   betaOut,
-                                   pt_beta,
-                                   Circle_Radius,
-                                   Circle_CenterX,
-                                   Circle_CenterY,
+                                   circleRadius,
+                                   circleCenterX,
+                                   circleCenterY,
                                    zLo,
                                    zHi,
                                    rtLo,
@@ -1466,8 +1294,6 @@ namespace SDL {
                                    zHiPointed,
                                    sdlCut,
                                    betaInCut,
-                                   betaOutCut,
-                                   deltaBetaCut,
                                    kZ,
                                    tripletIndex);
 #else
@@ -1481,11 +1307,9 @@ namespace SDL {
                                    middleLowerModuleIndex,
                                    outerOuterLowerModuleIndex,
                                    betaIn,
-                                   betaOut,
-                                   pt_beta,
-                                   Circle_Radius,
-                                   Circle_CenterX,
-                                   Circle_CenterY,
+                                   circleRadius,
+                                   circleCenterX,
+                                   circleCenterY,
                                    tripletIndex);
 #endif
               }

--- a/SDL/Triplet.h
+++ b/SDL/Triplet.h
@@ -38,7 +38,6 @@ namespace SDL {
     float* betaInCut;
     float* rtLo;
     float* rtHi;
-    float* kZ;
 #endif
     template <typename TBuff>
     void setData(TBuff& tripletsbuf) {
@@ -69,7 +68,6 @@ namespace SDL {
       betaInCut = alpaka::getPtrNative(tripletsbuf.betaInCut_buf);
       rtLo = alpaka::getPtrNative(tripletsbuf.rtLo_buf);
       rtHi = alpaka::getPtrNative(tripletsbuf.rtHi_buf);
-      kZ = alpaka::getPtrNative(tripletsbuf.kZ_buf);
 #endif
     }
   };
@@ -104,7 +102,6 @@ namespace SDL {
     Buf<TDev, float> betaInCut_buf;
     Buf<TDev, float> rtLo_buf;
     Buf<TDev, float> rtHi_buf;
-    Buf<TDev, float> kZ_buf;
 #endif
 
     template <typename TQueue, typename TDevAcc>
@@ -136,8 +133,7 @@ namespace SDL {
           sdlCut_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           betaInCut_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
           rtLo_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
-          rtHi_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue)),
-          kZ_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue))
+          rtHi_buf(allocBufWrapper<float>(devAccIn, maxTriplets, queue))
 #endif
     {
       alpaka::memset(queue, nTriplets_buf, 0u);
@@ -173,9 +169,7 @@ namespace SDL {
                                                          float& zLoPointed,
                                                          float& zHiPointed,
                                                          float& sdlCut,
-                                                         float& betaInCut,
-                                                         float& kZ,
-                                                         unsigned int& tripletIndex)
+                                                         float& betaInCut unsigned int& tripletIndex)
 #else
   ALPAKA_FN_ACC ALPAKA_FN_INLINE void addTripletToMemory(struct SDL::modules& modulesInGPU,
                                                          struct SDL::miniDoublets& mdsInGPU,
@@ -233,7 +227,6 @@ namespace SDL {
     tripletsInGPU.zHiPointed[tripletIndex] = zHiPointed;
     tripletsInGPU.sdlCut[tripletIndex] = sdlCut;
     tripletsInGPU.betaInCut[tripletIndex] = betaInCut;
-    tripletsInGPU.kZ[tripletIndex] = kZ;
 #endif
   };
 
@@ -976,7 +969,7 @@ namespace SDL {
             uint16_t outerOuterLowerModuleIndex = segmentsInGPU.outerLowerModuleIndices[outerSegmentIndex];
 
             float zOut, rtOut, deltaPhiPos, deltaPhi, betaIn, circleRadius, circleCenterX, circleCenterY;
-            float zLo, zHi, rtLo, rtHi, zLoPointed, zHiPointed, sdlCut, betaInCut, kZ;
+            float zLo, zHi, rtLo, rtHi, zLoPointed, zHiPointed, sdlCut, betaInCut;
 
             bool success = runTripletConstraintsAndAlgo(acc,
                                                         modulesInGPU,
@@ -1002,8 +995,7 @@ namespace SDL {
                                                         zLoPointed,
                                                         zHiPointed,
                                                         sdlCut,
-                                                        betaInCut,
-                                                        kZ);
+                                                        betaInCut);
 
             if (success) {
               unsigned int totOccupancyTriplets = alpaka::atomicOp<alpaka::AtomicAdd>(
@@ -1044,7 +1036,6 @@ namespace SDL {
                                    zHiPointed,
                                    sdlCut,
                                    betaInCut,
-                                   kZ,
                                    tripletIndex);
 #else
                 addTripletToMemory(modulesInGPU,

--- a/code/core/write_sdl_ntuple.cc
+++ b/code/core/write_sdl_ntuple.cc
@@ -995,33 +995,6 @@ std::tuple<float, float, float, vector<unsigned int>, vector<unsigned int>> pars
 }
 
 //________________________________________________________________________________________________________________________________
-float computeRadiusFromThreeAnchorHits(float x1, float y1, float x2, float y2, float x3, float y3, float& g, float& f)
-{
-   float radius = 0;
-   if ((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3) == 0)
-    {
-        return -1; // WTF man three collinear points!
-    }
-
-    float denom = ((y1 - y3) * (x2 - x3) - (x1 - x3) * (y2 - y3));
-
-    g = 0.5 * ((y3 - y2) * (x1 * x1 + y1 * y1) + (y1 - y3) * (x2 * x2 + y2 * y2) + (y2 - y1) * (x3 * x3 + y3 * y3)) / denom;
-
-    f = 0.5 * ((x2 - x3) * (x1 * x1 + y1 * y1) + (x3 - x1) * (x2 * x2 + y2 * y2) + (x1 - x2) * (x3 * x3 + y3 * y3)) / denom;
-
-    float c = ((x2 * y3 - x3 * y2) * (x1 * x1 + y1 * y1) + (x3 * y1 - x1 * y3) * (x2 * x2 + y2 * y2) + (x1 * y2 - x2 * y1) * (x3 * x3 + y3 * y3)) / denom;
-
-    if (g * g + f * f - c < 0)
-    {
-        std::cout << "FATAL! r^2 < 0!" << std::endl;
-        return -1;
-    }
-
-    radius = sqrtf(g * g + f * f - c);
-    return radius;
-}
-
-//________________________________________________________________________________________________________________________________
 void printHitMultiplicities(SDL::Event<SDL::Acc>* event)
 {
     SDL::modulesBuffer<alpaka::DevCpu>& modulesInGPU = (*event->getModules());


### PR DESCRIPTION
In the T3 kernels, we have some functions called runTripletDefaultAlgoBBBB, and also the BBEE and EEEE regions. Those cuts are duplicating with the passPointingConstraintBBB ... functions. On the other hand, introducing beta iteration cuts to triplet objects are not physically meaningful. In this PR, we still keep the first beta cut as geometric requirement and move to passPointingConstraint function, but remove all the beta iteration functions.

Another improvement is that the triplet radius is calculated and saved for each of the T3s. In this case, we don't need to calculate the radius of triplet multiple times when building T5, pT3 and pT5s. This will also bring timing improvement.
Slides describing the influence of this PR is summarized here. 
https://indico.cern.ch/event/1407246/contributions/5914814/attachments/2846057/4976175/check%20the%20T3%20cuts%20EEEE%202.pdf

