### PR TITLE
Fix small issues with arm64

### DIFF
--- a/SDL/Kernels.h
+++ b/SDL/Kernels.h
@@ -418,7 +418,7 @@ namespace SDL {
           if (secondpass && (!segmentsInGPU.isQuad[jx] || (segmentsInGPU.isDup[jx] & 1)))
             continue;
 
-          char quad_diff = segmentsInGPU.isQuad[ix] - segmentsInGPU.isQuad[jx];
+          int8_t quad_diff = segmentsInGPU.isQuad[ix] - segmentsInGPU.isQuad[jx];
           float score_diff = segmentsInGPU.score[ix] - segmentsInGPU.score[jx];
           // Always keep quads over trips. If they are the same, we want the object with better score
           int idxToRemove;

--- a/code/rooutil/Makefile.arch
+++ b/code/rooutil/Makefile.arch
@@ -389,6 +389,15 @@ LDFLAGS       = -O
 SOFLAGS       = -shared
 endif
 
+ifeq ($(ARCH),linuxarm64)
+# ARM Linux with egcs
+CXX           = g++
+CXXFLAGS      = -O -Wall -fPIC -Wshadow -Woverloaded-virtual
+LD            = g++
+LDFLAGS       = -O
+SOFLAGS       = -shared
+endif
+
 ifeq ($(ARCH),mklinux)
 # MkLinux with libc5
 CXX           = g++

--- a/setup.sh
+++ b/setup.sh
@@ -6,8 +6,11 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/code/rooutil/thisrooutil.sh
 
+ARCH=$(uname -m)
 if [[ $(hostname) == *lnx4555* ]]; then
   export SCRAM_ARCH=el9_amd64_gcc12
+elif [[ $ARCH == "aarch64" || $ARCH == "arm64" ]]; then
+  export SCRAM_ARCH=el9_aarch64_gcc12
 else
   export SCRAM_ARCH=el8_amd64_gcc12
 fi


### PR DESCRIPTION
This PR solves a few small issues when working on an arm64 machine. First, it closes #398 by changing `char` to `int8_t`, as explained in that issue. Apart from that, it fixes the `rooutil` makefile to accept arm64 and changes the `setup.sh` script so that it uses the right scram arch.

This could be potentially useful since CMSSW is built for multiple architectures, including arm64. Also, I find it useful since I can now run both standalone and CMSSW workflows on my laptop so it is easier to work on it.

The only caveat is that ROCm doesn't work with arm64, but that's not a big deal.

<details>
<summary>In case it's useful for someone else, I'll leave some rough guidelines for how to get it to work on an Apple silicon Mac.</summary>
<ol>
<li>Install CVMFS following <a href=https://cvmfs.readthedocs.io/en/stable/cpt-quickstart.html#setting-up-the-software> these instructions</a>.</li>
<li>Install Docker.</li>
<li>Download the EL9 Docker image with <code>docker pull cmssw/el9:aarch64</code>.</li>
<li>Start a Docker container with <code>docker run --rm -it -v /cvmfs:/cvmfs -v $PWD:/home -v [any other data paths you need] cmssw/el9:aarch64</code>.</li>
<li>For CMSSW you'll need to set up a simple siteconfig. You can do it like this:
<pre><code>git clone https://github.com/cms-sw/siteconf.git
sed -i '/&ltprefer ipfamily="0"\/&gt/,/&ltbackupproxy url="http:\/\/cmsbproxy\.fnal\.gov:3128"\/&gt/d' siteconf/local/JobConfig/site-local-config.xml
export SITECONFIG_PATH=$PWD/siteconf/local
</code></pre>
</li>
</ol>
</details>