### PR TITLE
Bug fix for applying pT5 r-z chi2

### DIFF
--- a/SDL/PixelTriplet.h
+++ b/SDL/PixelTriplet.h
@@ -2559,7 +2559,12 @@ namespace SDL {
 
     rzChiSquared = computePT5RZChiSquared(acc, modulesInGPU, lowerModuleIndices, rtPix, zPix, rts, zs);
 
-    if (/*pixelRadius*/ 0 < 5.0f * kR1GeVf) {  // FIXME: pixelRadius is not defined yet
+    //get the appropriate radii and centers
+    centerX = segmentsInGPU.circleCenterX[pixelSegmentArrayIndex];
+    centerY = segmentsInGPU.circleCenterY[pixelSegmentArrayIndex];
+    pixelRadius = segmentsInGPU.circleRadius[pixelSegmentArrayIndex];
+
+    if (pixelRadius < 5.0f * kR1GeVf) {  // FIXME: pixelRadius is not defined yet
       pass = pass and passPT5RZChiSquaredCuts(modulesInGPU,
                                               lowerModuleIndex1,
                                               lowerModuleIndex2,
@@ -2582,11 +2587,6 @@ namespace SDL {
                    mdsInGPU.anchorY[thirdMDIndex],
                    mdsInGPU.anchorY[fourthMDIndex],
                    mdsInGPU.anchorY[fifthMDIndex]};
-
-    //get the appropriate radii and centers
-    centerX = segmentsInGPU.circleCenterX[pixelSegmentArrayIndex];
-    centerY = segmentsInGPU.circleCenterY[pixelSegmentArrayIndex];
-    pixelRadius = segmentsInGPU.circleRadius[pixelSegmentArrayIndex];
 
     float T5CenterX = quintupletsInGPU.regressionG[quintupletIndex];
     float T5CenterY = quintupletsInGPU.regressionF[quintupletIndex];

--- a/SDL/PixelTriplet.h
+++ b/SDL/PixelTriplet.h
@@ -2557,14 +2557,15 @@ namespace SDL {
                     mdsInGPU.anchorRt[fourthMDIndex],
                     mdsInGPU.anchorRt[fifthMDIndex]};
 
-    rzChiSquared = computePT5RZChiSquared(acc, modulesInGPU, lowerModuleIndices, rtPix, zPix, rts, zs);
+    rzChiSquared = 0;
 
     //get the appropriate radii and centers
     centerX = segmentsInGPU.circleCenterX[pixelSegmentArrayIndex];
     centerY = segmentsInGPU.circleCenterY[pixelSegmentArrayIndex];
     pixelRadius = segmentsInGPU.circleRadius[pixelSegmentArrayIndex];
 
-    if (pixelRadius < 5.0f * kR1GeVf) {  // FIXME: pixelRadius is not defined yet
+    if (pixelRadius < 5.0f * kR1GeVf) {  //only apply r-z chi2 cuts for <5GeV tracks
+      rzChiSquared = computePT5RZChiSquared(acc, modulesInGPU, lowerModuleIndices, rtPix, zPix, rts, zs);
       pass = pass and passPT5RZChiSquaredCuts(modulesInGPU,
                                               lowerModuleIndex1,
                                               lowerModuleIndex2,


### PR DESCRIPTION
We would like to apply r-z chi2 only for pT5 < 5GeV in the algorithm. However, the original check in the code is problematic: it uses the pixelRadius < 5*kR1GeVf, but the pixelRadius is not defined yet. Bug fix and the efficiency is improved by not applying r-z cut on high pt pT5 tracks.