### PR TITLE
Dynamic Allocation Tests

### DIFF
--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -3131,15 +3131,13 @@ namespace SDL {
       alpaka::syncBlockThreads(acc);
 
       // Initialize variables outside of the for loop.
-      int occupancy, category_number, eta_number;
+      int occupancy = 0;
 
       for (int i = globalThreadIdx[2]; i < *modulesInGPU.nLowerModules; i += gridThreadExtent[2]) {
         // Condition for a quintuple to exist for a module
         // TCs don't exist for layers 5 and 6 barrel, and layers 2,3,4,5 endcap
-        short module_rings = modulesInGPU.rings[i];
         short module_layers = modulesInGPU.layers[i];
         short module_subdets = modulesInGPU.subdets[i];
-        float module_eta = alpaka::math::abs(acc, modulesInGPU.eta[i]);
 
         if (tripletsInGPU.nTriplets[i] == 0)
           continue;
@@ -3150,52 +3148,7 @@ namespace SDL {
 
         int nEligibleT5Modules = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nEligibleT5Modulesx, 1);
 
-        if (module_layers <= 3 && module_subdets == 5)
-          category_number = 0;
-        else if (module_layers >= 4 && module_subdets == 5)
-          category_number = 1;
-        else if (module_layers <= 2 && module_subdets == 4 && module_rings >= 11)
-          category_number = 2;
-        else if (module_layers >= 3 && module_subdets == 4 && module_rings >= 8)
-          category_number = 2;
-        else if (module_layers <= 2 && module_subdets == 4 && module_rings <= 10)
-          category_number = 3;
-        else if (module_layers >= 3 && module_subdets == 4 && module_rings <= 7)
-          category_number = 3;
-        else
-          category_number = -1;
-
-        if (module_eta < 0.75)
-          eta_number = 0;
-        else if (module_eta > 0.75 && module_eta < 1.5)
-          eta_number = 1;
-        else if (module_eta > 1.5 && module_eta < 2.25)
-          eta_number = 2;
-        else if (module_eta > 2.25 && module_eta < 3)
-          eta_number = 3;
-        else
-          eta_number = -1;
-
-        if (category_number == 0 && eta_number == 0)
-          occupancy = 336;
-        else if (category_number == 0 && eta_number == 1)
-          occupancy = 414;
-        else if (category_number == 0 && eta_number == 2)
-          occupancy = 231;
-        else if (category_number == 0 && eta_number == 3)
-          occupancy = 146;
-        else if (category_number == 3 && eta_number == 1)
-          occupancy = 0;
-        else if (category_number == 3 && eta_number == 2)
-          occupancy = 191;
-        else if (category_number == 3 && eta_number == 3)
-          occupancy = 106;
-        else {
-          occupancy = 0;
-#ifdef Warnings
-          printf("Unhandled case in createEligibleModulesListForQuintupletsGPU! Module index = %i\n", i);
-#endif
-        }
+        occupancy = 2 * tripletsInGPU.nTriplets[i];
 
         int nTotQ = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalQuintupletsx, occupancy);
         rangesInGPU.quintupletModuleIndices[i] = nTotQ;

--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -3056,7 +3056,9 @@ namespace SDL {
                   alpaka::atomicOp<alpaka::AtomicAdd>(acc, &quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1u);
               if (totOccupancyQuintuplets >= rangesInGPU.quintupletModuleOccupancy[lowerModule1]) {
 #ifdef Warnings
-                printf("Quintuplet excess alert! Module index = %d, Occupancy limit = %d\n", lowerModule1, rangesInGPU.quintupletModuleOccupancy[lowerModule1]);
+                printf("Quintuplet excess alert! Module index = %d, Occupancy limit = %d\n",
+                       lowerModule1,
+                       rangesInGPU.quintupletModuleOccupancy[lowerModule1]);
 #endif
               } else {
                 int quintupletModuleIndex =

--- a/SDL/Quintuplet.h
+++ b/SDL/Quintuplet.h
@@ -3056,7 +3056,7 @@ namespace SDL {
                   alpaka::atomicOp<alpaka::AtomicAdd>(acc, &quintupletsInGPU.totOccupancyQuintuplets[lowerModule1], 1u);
               if (totOccupancyQuintuplets >= rangesInGPU.quintupletModuleOccupancy[lowerModule1]) {
 #ifdef Warnings
-                printf("Quintuplet excess alert! Module index = %d\n", lowerModule1);
+                printf("Quintuplet excess alert! Module index = %d, Occupancy limit = %d\n", lowerModule1, rangesInGPU.quintupletModuleOccupancy[lowerModule1]);
 #endif
               } else {
                 int quintupletModuleIndex =
@@ -3148,7 +3148,7 @@ namespace SDL {
 
         int nEligibleT5Modules = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nEligibleT5Modulesx, 1);
 
-        occupancy = 2 * tripletsInGPU.nTriplets[i];
+        occupancy = 2 * tripletsInGPU.nTriplets[i] + 30;
 
         int nTotQ = alpaka::atomicOp<alpaka::AtomicAdd>(acc, &nTotalQuintupletsx, occupancy);
         rangesInGPU.quintupletModuleIndices[i] = nTotQ;


### PR DESCRIPTION
I see a 5x-10x reduction (from 500k to 50k-100k per event) in the nTotalQuintuplets variable from the changes below from @slava77's suggestion. Using this PR for tests. Obviously no timing difference with the cache enabled, but I do see improvement when it is turned off:

Timing with dynamic allocation (this PR)
<img width="1409" alt="Screenshot 2024-05-24 at 4 57 39 PM" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/8277f75d-ee0d-4963-af60-28bf2368d705">

Master Timing
<img width="1409" alt="Screenshot 2024-05-24 at 4 53 25 PM" src="https://github.com/SegmentLinking/TrackLooper/assets/25272611/befa652f-b54b-45bb-bde1-52e8172ce2a8">
